### PR TITLE
UI Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ npm start
 
 Point your browser to:
 
-[localhost:8080/docs/pages/css/border-radius.html](http://localhost:8000/docs/pages/css/border-radius.html)
+[localhost:8080/pages/css/border-radius.html](http://localhost:8000/pages/css/border-radius.html)
 
 Once satisfied with the example, [submit your pull request](https://help.github.com/articles/creating-a-pull-request/).
 
@@ -251,7 +251,7 @@ npm start
 
 Point your browser to:
 
-[localhost:8080/docs/pages/js/array-from.html](http://localhost:8000/docs/pages/js/array-from.html)
+[localhost:8080/pages/js/array-from.html](http://localhost:8000/pages/js/array-from.html)
 
 Once satisfied with the example, [submit your pull request](https://help.github.com/articles/creating-a-pull-request/).
 

--- a/css/editable-css.css
+++ b/css/editable-css.css
@@ -6,6 +6,7 @@ body {
     padding: 0;
     margin: 0;
     font-family: sans-serif;
+    border: 1em solid #eaeff2;
 }
 
 header h4 {
@@ -20,7 +21,6 @@ pre[class*='language-'] {
 
 .editor-wrapper {
     background-color: #eaeff2;
-    border: 10px solid #eaeff2;
     width: 100%;
     max-height: 500px;
     overflow: hidden;

--- a/css/editable-css.css
+++ b/css/editable-css.css
@@ -121,6 +121,13 @@ pre[class*='language-'] {
     position: absolute;
     top: .75em;
     right: 1em;
+    background-color: #fff;
+    color: #4c4c4c;
+    padding: 3px 5px 2px;
+    border: 2px solid #9b9b9b;
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
 }
 
 .example-choice.selected > .reset {

--- a/css/editable-js.css
+++ b/css/editable-js.css
@@ -7,6 +7,7 @@ body {
     padding: 0;
     margin: 0;
     font-family: sans-serif;
+    border: 1em solid #eaeff2;
 }
 
 #editor,

--- a/css/editable-js.css
+++ b/css/editable-js.css
@@ -44,19 +44,32 @@ body {
 }
 
 .output {
+    position: relative;
     display: inline-block;
     background-color: #fff;
     margin: 0;
-    padding: .8em 1em 1em;
-    border: 1px solid #e0e0e0;
-    border-left: 0;
-    border-radius: 6px;
-    border-top-left-radius: 0;
+    border: 0;
+    box-shadow: 2px 2px 5px -2px rgba(0, 0, 0, .1);
     width: 92%;
     height: 80px;
     font-family: courier;
     word-break: break-word;
     overflow-y: auto;
+    vertical-align: middle;
+}
+
+.output:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    border: 40px solid transparent; /* half of height of .output */
+    border-left: 20px solid #eaeff2;
+    border-right: 0;
+}
+
+.output code {
+    padding: .8em 1em .8em 35px;
 }
 
 .button {
@@ -101,11 +114,11 @@ body {
 @supports (display: flex) {
     .output-container {
         display: flex;
+        align-items: center;
     }
 
-    .output-container button {
-        margin-right: 20px;
-        flex: 0 75px;
+    .run {
+        margin-right: 10px;
     }
 
     .output {

--- a/css/editable-js.css
+++ b/css/editable-js.css
@@ -55,7 +55,7 @@ body {
     height: 80px;
     font-family: courier;
     word-break: break-word;
-    overflow-y: scroll;
+    overflow-y: auto;
 }
 
 .button {

--- a/css/editable-js.css
+++ b/css/editable-js.css
@@ -61,33 +61,23 @@ body {
 .button {
     display: inline-block;
     background-color: #fff;
-    color: #29627e;
+    color: #4c4c4c;
     margin: 0;
-    padding: .8em 1em 1em;
-    border: 1px solid #3f87a6;
-    font-size: .9em;
-    width: 7%;
-    height: 40px;
+    padding: 3px 5px 2px;
+    border: 2px solid #9b9b9b;
+    font-size: 14px;
+    line-height: 1;
     cursor: pointer;
 }
 
 .reset {
-    background-color: #29627e;
-    color: #fff;
-    padding: .5em;
-    width: 12%;
-    font-size: 1em;
     animation: fadein 1s;
 }
 
-.run:hover,
-.run:focus {
+.run {
     background-color: #29627e;
+    border-color: transparent;
     color: #fff;
-}
-
-.run:active {
-    margin-top: 1px;
 }
 
 .fade-in {

--- a/tmpl/live-js-tmpl.html
+++ b/tmpl/live-js-tmpl.html
@@ -17,7 +17,7 @@
           </div>
 
           <div class="output-container">
-              <button id="execute" class="button" type="button">Run</button>
+              <button id="execute" class="button run" type="button">Run &rsaquo;</button>
               <div id="output" class="output"><code></code></div>
           </div>
       </section>


### PR DESCRIPTION
It seemed faster to just make some changes than dictate them to @schalkneethling like a remote operated CSS drone.

Summary of changes:
- Update compiled example location on localhost
  - Update the localhost URLs for viewing built files
 - Unify button styles
  - Tried to mimic redesign style buttons, but a bit smaller
  - Make CSS reset buttons match JS one
- Hide scroll bar when content not overflowing JS output area
- Standardize example border between JS and CSS
- Tweaks to JS output area
  - Make the run button the same size as other buttons
  - Add a `›` to the Run button
  - Add arrow cutout to output area
  - Add a box-shadow to output area

Fixes #108.

I'd been putting off installing and running locally because things things don't usually go well for me. I shouldn't have put it off. It was super easy to install, run, and make changes too. I had one small problem which I was able to solve myself because the server was well configured. Well done @schalkneethling  🎩 