### PR TITLE
deploy to S3 via jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,34 @@
+#!groovy
+
+def buildSite() {
+    stage ('build') {
+      try {
+        sh 'bin/build.sh'
+      } catch(err) {
+        sh "bin/irc-notify.sh --stage 'build " + env.BRANCH_NAME + "' --status 'failed'"
+        throw err
+      }
+    }
+}
+
+def syncS3(String bucket) {
+    stage ('s3 sync') {
+        try {
+          sh "cd docs && aws s3 sync . s3://" + bucket +" --acl public-read --delete --profile mdninteractive"
+        } catch(err) {
+          sh "bin/irc-notify.sh --stage 's3 sync " + env.BRANCH_NAME + "' --status 'failed'"
+          throw err
+        }
+        sh "bin/irc-notify.sh --stage 's3 sync " + env.BRANCH_NAME + "' --status 'shipped'"
+    }
+}
+
+node {
+    stage ('Prepare') {
+      checkout scm
+    }
+    if ( env.BRANCH_NAME == 'prod' ) {
+      buildSite()
+      syncS3('mdninteractive')
+    }
+}

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ npm install
 
 This will ensure that you have all the required development modules installed to build and test your contributions. You are now set-up, and ready to contribute. Thank you o/\o
 
+### Publishing to production (`interactive-examples.mdn.mozilla.net`)
+
+1. Push to the `prod` branch on GitHub, e.g. `git push origin master:prod` (this will push your local `master` branch to the remote `prod` branch)
+
 ### General
 
 There are two types of live examples we currently support. Those are JavaScript and Cascasing Style Sheets. The process of contributing either is essentially the same but, there are slight differences you need to be aware of.

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -x
+cd "$(dirname ${BASH_SOURCE[0]})"/..
+echo "Starting build"
+docker run -v "$PWD":/mdn -w /mdn node:latest bash -c "/usr/local/bin/npm install && /usr/local/bin/npm run build"
+echo "Build finished"

--- a/bin/irc-notify.sh
+++ b/bin/irc-notify.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -eo pipefail
+
+# Required environment variables if using --stage:
+# BRANCH_NAME, BUILD_NUMBER
+
+# defaults and constants
+NICK="examplesbot"
+CHANNEL="#mdndev"
+SERVER="irc.mozilla.org:6697"
+BLUE_BUILD_URL="https://ci.us-west.moz.works/blue/organizations/jenkins/mdn_interactive_examples"
+BLUE_BUILD_URL="${BLUE_BUILD_URL}/detail/${BRANCH_NAME/\//%2f}/${BUILD_NUMBER}/pipeline"
+# colors and styles: values from the following links
+# http://www.mirc.com/colors.html
+# http://stackoverflow.com/a/13382032
+RED=$'\x034'
+YELLOW=$'\x038'
+GREEN=$'\x039'
+BLUE=$'\x0311'
+BOLD=$'\x02'
+NORMAL=$'\x0F'
+
+# parse cli args
+while [[ $# -gt 1 ]]; do
+    key="$1"
+    case $key in
+        --stage)
+            STAGE="$2"
+            shift # past argument
+            ;;
+        --status)
+            STATUS="$2"
+            shift # past argument
+            ;;
+        -m|--message)
+            MESSAGE="$2"
+            shift # past argument
+            ;;
+        --irc_nick)
+            NICK="$2"
+            shift # past argument
+            ;;
+        --irc_server)
+            SERVER="$2"
+            shift # past argument
+            ;;
+        --irc_channel)
+            CHANNEL="$2"
+            shift # past argument
+            ;;
+    esac
+    shift # past argument or value
+done
+
+if [[ -n "$STATUS" ]]; then
+    STATUS=$(echo "$STATUS" | tr '[:lower:]' '[:upper:]')
+    case "$STATUS" in
+      'SUCCESS')
+        STATUS_COLOR="🎉 ${BOLD}${GREEN}"
+        ;;
+      'SHIPPED')
+        STATUS_COLOR="🚢 ${BOLD}${GREEN}"
+        ;;
+      'WARNING')
+        STATUS_COLOR="⚠️ ${BOLD}${YELLOW}"
+        ;;
+      'FAILURE')
+        STATUS_COLOR="🚨 ${BOLD}${RED}"
+        ;;
+      *)
+        STATUS_COLOR="✨ $BLUE"
+        ;;
+    esac
+    STATUS="${STATUS_COLOR}${STATUS}${NORMAL}: "
+fi
+
+if [[ -n "$STAGE" ]]; then
+    MESSAGE="${STATUS}${STAGE}:"
+    MESSAGE="$MESSAGE Branch ${BOLD}${BRANCH_NAME}${NORMAL} build #${BUILD_NUMBER}: ${BLUE_BUILD_URL}"
+elif [[ -n "$MESSAGE" ]]; then
+    MESSAGE="${STATUS}${MESSAGE}"
+else
+    echo "Missing required arguments"
+    echo
+    echo "Usage: irc-notify.sh [--stage STAGE]|[-m MESSAGE]"
+    echo "Optional args: --status, --irc_nick, --irc_server, --irc_channel"
+    exit 1
+fi
+
+if [[ -n "$BUILD_NUMBER" ]]; then
+    NICK="${NICK}-${BUILD_NUMBER}"
+fi
+
+(
+  echo "NICK ${NICK}"
+  echo "USER ${NICK} 8 * : ${NICK}"
+  sleep 5
+  echo "JOIN ${CHANNEL}"
+  echo "NOTICE ${CHANNEL} :${MESSAGE}"
+  echo "QUIT"
+) | openssl s_client -connect "$SERVER" > /dev/null 2>&1


### PR DESCRIPTION
This PR allows deployment to S3 by pushing to the prod branch (see README changes for more info). There is a new Jenkins multi-branch pipeline titled `mdn_interactive_examples. This uses the `node:latest` [docker image](https://hub.docker.com/_/node/) to build, as we'd prefer not to install additional commands on the Jenkins server. The node image version number can be tweaked if desired. 

While we're waiting on the  [DNS entry](https://bugzilla.mozilla.org/show_bug.cgi?id=1385423) for the official site (which will be [interactive-examples.mdn.mozilla.net](interactive-examples.mdn.mozilla.net)), examples can be viewed in a subdirectory of [https://interactive-examples.mdn.moz.works/](https://interactive-examples.mdn.moz.works/). There doesn't currently appear to be an index.html page.



https://github.com/mozmeao/infra/issues/362