### PR TITLE
Format logged objects to indicate their type

### DIFF
--- a/js/editor-libs/console.js
+++ b/js/editor-libs/console.js
@@ -17,6 +17,24 @@
     };
 
     /**
+    * Formats output to indicate its type:
+    * - quotes around strings
+    * - square brackets around arrays
+    * @param {any} input - The output to log.
+    */
+    function indicateType(input) {
+        switch (typeof(input)) {
+            case "string":
+                input = `"${input}"`;
+            case "object":
+                if (Array.isArray(input)) {
+                    input = `[${input}]`;
+                }
+        }
+        return input;
+    }
+
+    /**
      * Writes the provided content to the editor’s output area
      * @param {String} content - The content to write to output
      */
@@ -34,7 +52,7 @@
 
     // eslint-disable-next-line no-console
     console.log = function(loggedItem) {
-        writeOutput(loggedItem);
+        writeOutput(indicateType(loggedItem));
         // do not swallow console.log
         originalConsoleLogger.apply(console, arguments);
     };

--- a/js/editor-libs/console.js
+++ b/js/editor-libs/console.js
@@ -23,15 +23,13 @@
     * @param {any} input - The output to log.
     */
     function indicateType(input) {
-        switch (typeof(input)) {
-            case "string":
-                input = `"${input}"`;
-            case "object":
-                if (Array.isArray(input)) {
-                    input = `[${input}]`;
-                }
+        if (typeof(input) === "string") {
+            return `"${input}"`;
+        } else if (Array.isArray(input)) {
+            return `[${input}]`;
+        } else {
+            return input;
         }
-        return input;
     }
 
     /**

--- a/js/editor-libs/console.js
+++ b/js/editor-libs/console.js
@@ -17,16 +17,17 @@
     };
 
     /**
-    * Formats output to indicate its type:
-    * - quotes around strings
-    * - square brackets around arrays
-    * @param {any} input - The output to log.
-    */
-    function indicateType(input) {
+     * Formats output to indicate its type:
+     * - quotes around strings
+     * - square brackets around arrays
+     * @param {any} input - The output to log.
+     * @returns Formatted output as a string.
+     */
+    function formatOutput(input) {
         if (typeof(input) === "string") {
-            return `"${input}"`;
+            return '"' + input + '"';
         } else if (Array.isArray(input)) {
-            return `[${input}]`;
+          return '[' + input + ']';
         } else {
             return input;
         }
@@ -50,7 +51,7 @@
 
     // eslint-disable-next-line no-console
     console.log = function(loggedItem) {
-        writeOutput(indicateType(loggedItem));
+        writeOutput(formatOutput(loggedItem));
         // do not swallow console.log
         originalConsoleLogger.apply(console, arguments);
     };


### PR DESCRIPTION
Here's a simple attempt to format logged objects to indicate their type:

* wrap strings in quotes
* wrap arrays in square brackets
