### PR TITLE
Date - JS Interactive Examples

### DIFF
--- a/live-examples/js-examples/date-constructor.html
+++ b/live-examples/js-examples/date-constructor.html
@@ -1,0 +1,14 @@
+<pre>
+<code id="static-js">var date1 = new Date('December 17, 1995 03:24:00');
+// Sun Dec 17 1995 03:24:00 GMT...
+
+var date2 = new Date('1995-12-17T03:24:00');
+// Sun Dec 17 1995 03:24:00 GMT...
+
+console.log(date1 === date2);
+// expected output: false;
+
+console.log(date1 - date2);
+// expected output: 0
+</code>
+</pre>

--- a/live-examples/js-examples/date-getdate.html
+++ b/live-examples/js-examples/date-getdate.html
@@ -1,8 +1,8 @@
 <pre>
 <code id="static-js">var birthday = new Date('August 19, 1975 23:15:30');
-var day = birthday.getDate();
+var date1 = birthday.getDate();
 
-console.log(day);
+console.log(date1);
 // expected output: 19
 </code>
 </pre>

--- a/live-examples/js-examples/date-getdate.html
+++ b/live-examples/js-examples/date-getdate.html
@@ -1,0 +1,8 @@
+<pre>
+<code id="static-js">var birthday = new Date('August 19, 1975 23:15:30');
+var day = birthday.getDate();
+
+console.log(day);
+// expected output: 19
+</code>
+</pre>

--- a/live-examples/js-examples/date-getday.html
+++ b/live-examples/js-examples/date-getday.html
@@ -1,0 +1,9 @@
+<pre>
+<code id="static-js">var birthday = new Date('Tue, August 19, 1975 23:15:30');
+var day = birthday.getDay();
+// Sunday - Saturday : 0 - 6
+
+console.log(day);
+// expected output: 2
+</code>
+</pre>

--- a/live-examples/js-examples/date-getday.html
+++ b/live-examples/js-examples/date-getday.html
@@ -1,9 +1,9 @@
 <pre>
-<code id="static-js">var birthday = new Date('Tue, August 19, 1975 23:15:30');
-var day = birthday.getDay();
+<code id="static-js">var birthday = new Date('August 19, 1975 23:15:30');
+var day1 = birthday.getDay();
 // Sunday - Saturday : 0 - 6
 
-console.log(day);
+console.log(day1);
 // expected output: 2
 </code>
 </pre>

--- a/live-examples/js-examples/date-getfullyear.html
+++ b/live-examples/js-examples/date-getfullyear.html
@@ -1,0 +1,7 @@
+<pre>
+<code id="static-js">var moonLanding = new Date('July 20, 69 00:20:18');
+
+console.log(moonLanding.getFullYear());
+// expected output: 1969
+</code>
+</pre>

--- a/live-examples/js-examples/date-gethours.html
+++ b/live-examples/js-examples/date-gethours.html
@@ -1,0 +1,7 @@
+<pre>
+<code id="static-js">var birthday = new Date('March 13, 08 04:20');
+
+console.log(birthday.getHours());
+// expected output: 4
+</code>
+</pre>

--- a/live-examples/js-examples/date-getmilliseconds.html
+++ b/live-examples/js-examples/date-getmilliseconds.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var moonLanding = new Date('July 20, 69 00:20:18.123');
+<code id="static-js">var moonLanding = new Date('July 20, 69 00:20:18');
+moonLanding.setMilliseconds(123);
 
 console.log(moonLanding.getMilliseconds());
 // expected output: 123

--- a/live-examples/js-examples/date-getmilliseconds.html
+++ b/live-examples/js-examples/date-getmilliseconds.html
@@ -1,0 +1,7 @@
+<pre>
+<code id="static-js">var moonLanding = new Date('July 20, 69 00:20:18.123');
+
+console.log(moonLanding.getMilliseconds());
+// expected output: 123
+</code>
+</pre>

--- a/live-examples/js-examples/date-getminutes.html
+++ b/live-examples/js-examples/date-getminutes.html
@@ -1,0 +1,7 @@
+<pre>
+<code id="static-js">var birthday = new Date('March 13, 08 04:20');
+
+console.log(birthday.getMinutes());
+// expected output: 20
+</code>
+</pre>

--- a/live-examples/js-examples/date-getmonth.html
+++ b/live-examples/js-examples/date-getmonth.html
@@ -1,0 +1,7 @@
+<pre>
+<code id="static-js">var moonLanding = new Date('July 20, 69 00:20:18');
+
+console.log(moonLanding.getMonth()); // (January gives 0)
+// expected output: 6
+</code>
+</pre>

--- a/live-examples/js-examples/date-getseconds.html
+++ b/live-examples/js-examples/date-getseconds.html
@@ -1,0 +1,7 @@
+<pre>
+<code id="static-js">var moonLanding = new Date('July 20, 69 00:20:18');
+
+console.log(moonLanding.getSeconds());
+// expected output: 18
+</code>
+</pre>

--- a/live-examples/js-examples/date-gettime.html
+++ b/live-examples/js-examples/date-gettime.html
@@ -1,0 +1,8 @@
+<pre>
+<code id="static-js">var moonLanding = new Date('July 20, 69 00:20:18');
+
+// milliseconds since Jan 1, 1970, 00:00:00.000
+console.log(moonLanding.getTime());
+// expected output: -14261982000
+</code>
+</pre>

--- a/live-examples/js-examples/date-gettime.html
+++ b/live-examples/js-examples/date-gettime.html
@@ -1,8 +1,8 @@
 <pre>
-<code id="static-js">var moonLanding = new Date('July 20, 69 00:20:18');
+<code id="static-js">var moonLanding = new Date('July 20, 69 00:20:18 GMT+00:00');
 
-// milliseconds since Jan 1, 1970, 00:00:00.000
+// milliseconds since Jan 1, 1970, 00:00:00.000 GMT
 console.log(moonLanding.getTime());
-// expected output: -14261982000
+// expected output: -14254782000
 </code>
 </pre>

--- a/live-examples/js-examples/date-gettimezoneoffset.html
+++ b/live-examples/js-examples/date-gettimezoneoffset.html
@@ -1,0 +1,12 @@
+<pre>
+<code id="static-js">var date1 = new Date('Tue, August 19, 1975 23:15:30 GMT+07:00');
+var date2 = new Date('Tue, August 19, 1975 23:15:30 GMT-02:00');
+
+console.log(date1.getTimezoneOffset());
+// expected output: your local timezone offset in minutes
+// (eg -120). NOT the timezone offset of the date object.
+
+console.log(date1.getTimezoneOffset === date2.getTimezoneOffset);
+// expected output: true
+</code>
+</pre>

--- a/live-examples/js-examples/date-gettimezoneoffset.html
+++ b/live-examples/js-examples/date-gettimezoneoffset.html
@@ -1,12 +1,12 @@
 <pre>
-<code id="static-js">var date1 = new Date('Tue, August 19, 1975 23:15:30 GMT+07:00');
-var date2 = new Date('Tue, August 19, 1975 23:15:30 GMT-02:00');
+<code id="static-js">var date1 = new Date('August 19, 1975 23:15:30 GMT+07:00');
+var date2 = new Date('August 19, 1975 23:15:30 GMT-02:00');
 
 console.log(date1.getTimezoneOffset());
 // expected output: your local timezone offset in minutes
 // (eg -120). NOT the timezone offset of the date object.
 
-console.log(date1.getTimezoneOffset === date2.getTimezoneOffset);
+console.log(date1.getTimezoneOffset() === date2.getTimezoneOffset());
 // expected output: true
 </code>
 </pre>

--- a/live-examples/js-examples/date-getutcdate.html
+++ b/live-examples/js-examples/date-getutcdate.html
@@ -1,0 +1,11 @@
+<pre>
+<code id="static-js">var date1 = new Date('Tue, August 19, 1975 23:15:30 GMT+11:00');
+var date2 = new Date('Tue, August 19, 1975 23:15:30 GMT-11:00');
+
+console.log(date1.getUTCDate());
+// expected output: 19
+
+console.log(date2.getUTCDate());
+// expected output: 20
+</code>
+</pre>

--- a/live-examples/js-examples/date-getutcdate.html
+++ b/live-examples/js-examples/date-getutcdate.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">var date1 = new Date('Tue, August 19, 1975 23:15:30 GMT+11:00');
-var date2 = new Date('Tue, August 19, 1975 23:15:30 GMT-11:00');
+<code id="static-js">var date1 = new Date('August 19, 1975 23:15:30 GMT+11:00');
+var date2 = new Date('August 19, 1975 23:15:30 GMT-11:00');
 
 console.log(date1.getUTCDate());
 // expected output: 19

--- a/live-examples/js-examples/date-getutcday.html
+++ b/live-examples/js-examples/date-getutcday.html
@@ -1,0 +1,13 @@
+<pre>
+<code id="static-js">var date1 = new Date('Tue, August 19, 1975 23:15:30 GMT+11:00');
+var date2 = new Date('Tue, August 19, 1975 23:15:30 GMT-11:00');
+
+// Tuesday
+console.log(date1.getUTCDay());
+// expected output: 2
+
+// Wednesday
+console.log(date2.getUTCDay());
+// expected output: 3
+</code>
+</pre>

--- a/live-examples/js-examples/date-getutcday.html
+++ b/live-examples/js-examples/date-getutcday.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">var date1 = new Date('Tue, August 19, 1975 23:15:30 GMT+11:00');
-var date2 = new Date('Tue, August 19, 1975 23:15:30 GMT-11:00');
+<code id="static-js">var date1 = new Date('August 19, 1975 23:15:30 GMT+11:00');
+var date2 = new Date('August 19, 1975 23:15:30 GMT-11:00');
 
 // Tuesday
 console.log(date1.getUTCDay());

--- a/live-examples/js-examples/date-getutcfullyear.html
+++ b/live-examples/js-examples/date-getutcfullyear.html
@@ -1,0 +1,11 @@
+<pre>
+<code id="static-js">var date1 = new Date('December 31, 1975, 23:15:30 GMT+11:00');
+var date2 = new Date('December 31, 1975, 23:15:30 GMT-11:00');
+
+console.log(date1.getUTCFullYear());
+// expected output: 1975
+
+console.log(date2.getUTCFullYear());
+// expected output: 1976
+</code>
+</pre>

--- a/live-examples/js-examples/date-getutchours.html
+++ b/live-examples/js-examples/date-getutchours.html
@@ -1,0 +1,11 @@
+<pre>
+<code id="static-js">var date1 = new Date('December 31, 1975, 23:15:30 GMT+11:00');
+var date2 = new Date('December 31, 1975, 23:15:30 GMT-11:00');
+
+console.log(date1.getUTCHours());
+// expected output: 12
+
+console.log(date2.getUTCHours());
+// expected output: 10
+</code>
+</pre>

--- a/live-examples/js-examples/date-getutcmonth.html
+++ b/live-examples/js-examples/date-getutcmonth.html
@@ -1,0 +1,13 @@
+<pre>
+<code id="static-js">var date1 = new Date('December 31, 1975, 23:15:30.123 GMT+11:00');
+var date2 = new Date('December 31, 1975, 23:15:30.123 GMT-11:00');
+
+// December
+console.log(date1.getUTCMonth());
+// expected output: 11
+
+// January
+console.log(date2.getUTCMonth());
+// expected output: 0
+</code>
+</pre>

--- a/live-examples/js-examples/date-getutcmonth.html
+++ b/live-examples/js-examples/date-getutcmonth.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">var date1 = new Date('December 31, 1975, 23:15:30.123 GMT+11:00');
-var date2 = new Date('December 31, 1975, 23:15:30.123 GMT-11:00');
+<code id="static-js">var date1 = new Date('December 31, 1975, 23:15:30 GMT+11:00');
+var date2 = new Date('December 31, 1975, 23:15:30 GMT-11:00');
 
 // December
 console.log(date1.getUTCMonth());

--- a/live-examples/js-examples/date-now.html
+++ b/live-examples/js-examples/date-now.html
@@ -1,0 +1,15 @@
+<pre>
+<code id="static-js">// this example takes 2 seconds to run
+var start = Date.now();
+
+console.log("starting timer...");
+// expected output: starting timer...
+
+setTimeout(function() {
+  var millis = Date.now() - start;
+
+  console.log("seconds elapsed = " + Math.floor(millis/1000));
+  // expected output : seconds elapsed = 2
+}, 2000);
+</code>
+</pre>

--- a/live-examples/js-examples/date-parse.html
+++ b/live-examples/js-examples/date-parse.html
@@ -1,9 +1,11 @@
 <pre>
-<code id="static-js">var unixTimeZero = Date.parse('Thu, 01 Jan 1970 00:00:00 GMT');
+<code id="static-js">var unixTimeZero = Date.parse('01 Jan 1970 00:00:00 GMT');
 var javaScriptRelease = Date.parse('04 Dec 1995 00:12:00 GMT');
-var millisElapsed = javaScriptRelease - unixTimeZero;
 
-console.log(millisElapsed);
-//expected output: 818035920000
+console.log(unixTimeZero);
+// expected output: 0
+
+console.log(javaScriptRelease);
+// expected output: 818035920000
 </code>
 </pre>

--- a/live-examples/js-examples/date-parse.html
+++ b/live-examples/js-examples/date-parse.html
@@ -1,0 +1,9 @@
+<pre>
+<code id="static-js">var unixTimeZero = Date.parse('Thu, 01 Jan 1970 00:00:00 GMT');
+var javaScriptRelease = Date.parse('04 Dec 1995 00:12:00 GMT');
+var millisElapsed = javaScriptRelease - unixTimeZero;
+
+console.log(millisElapsed);
+//expected output: 818035920000
+</code>
+</pre>

--- a/live-examples/js-examples/date-setdate.html
+++ b/live-examples/js-examples/date-setdate.html
@@ -1,0 +1,15 @@
+<pre>
+<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+
+event.setDate(24);
+
+console.log(event.getDate());
+// expected output: 24
+
+event.setDate(32);
+// Only 31 days in August!
+
+console.log(event.getDate());
+// expected output: 1
+</code>
+</pre>

--- a/live-examples/js-examples/date-setdate.html
+++ b/live-examples/js-examples/date-setdate.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+<code id="static-js">var event = new Date('August 19, 1975 23:15:30');
 
 event.setDate(24);
 

--- a/live-examples/js-examples/date-setfullyear.html
+++ b/live-examples/js-examples/date-setfullyear.html
@@ -1,0 +1,14 @@
+<pre>
+<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+
+event.setFullYear(1969);
+
+console.log(event.getFullYear());
+// expected output: 1969
+
+event.setFullYear(0);
+
+console.log(event.getFullYear());
+// expected output: 0
+</code>
+</pre>

--- a/live-examples/js-examples/date-setfullyear.html
+++ b/live-examples/js-examples/date-setfullyear.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+<code id="static-js">var event = new Date('August 19, 1975 23:15:30');
 
 event.setFullYear(1969);
 

--- a/live-examples/js-examples/date-sethours.html
+++ b/live-examples/js-examples/date-sethours.html
@@ -1,0 +1,14 @@
+<pre>
+<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+event.setHours(20);
+
+console.log(event);
+// expected output: Tue Aug 19 1975 20:15:30 GMT+0200 (CEST)
+// (note: your timezone may vary)
+
+event.setHours(20,21,22);
+
+console.log(event);
+// expected output: Tue Aug 19 1975 20:21:22 GMT+0200 (CEST)
+</code>
+</pre>

--- a/live-examples/js-examples/date-sethours.html
+++ b/live-examples/js-examples/date-sethours.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+<code id="static-js">var event = new Date('August 19, 1975 23:15:30');
 event.setHours(20);
 
 console.log(event);

--- a/live-examples/js-examples/date-setmilliseconds.html
+++ b/live-examples/js-examples/date-setmilliseconds.html
@@ -1,0 +1,12 @@
+<pre>
+<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30.123');
+
+console.log(event.getMilliseconds());
+// expected output: 123
+
+event.setMilliseconds(456);
+
+console.log(event.getMilliseconds());
+// expected output: 456
+</code>
+</pre>

--- a/live-examples/js-examples/date-setmilliseconds.html
+++ b/live-examples/js-examples/date-setmilliseconds.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30.123');
+<code id="static-js">var event = new Date('August 19, 1975 23:15:30.123');
 
 console.log(event.getMilliseconds());
 // expected output: 123

--- a/live-examples/js-examples/date-setmilliseconds.html
+++ b/live-examples/js-examples/date-setmilliseconds.html
@@ -1,8 +1,8 @@
 <pre>
-<code id="static-js">var event = new Date('August 19, 1975 23:15:30.123');
+<code id="static-js">var event = new Date('August 19, 1975 23:15:30');
 
 console.log(event.getMilliseconds());
-// expected output: 123
+// expected output: 0
 
 event.setMilliseconds(456);
 

--- a/live-examples/js-examples/date-setminutes.html
+++ b/live-examples/js-examples/date-setminutes.html
@@ -1,0 +1,13 @@
+<pre>
+<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+
+event.setMinutes(45);
+
+console.log(event.getMinutes());
+// expected output: 45
+
+console.log(event);
+// expected output: Tue Aug 19 1975 23:45:30 GMT+0200 (CEST)
+// (note: your timezone may vary)
+</code>
+</pre>

--- a/live-examples/js-examples/date-setminutes.html
+++ b/live-examples/js-examples/date-setminutes.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+<code id="static-js">var event = new Date('August 19, 1975 23:15:30');
 
 event.setMinutes(45);
 

--- a/live-examples/js-examples/date-setmonth.html
+++ b/live-examples/js-examples/date-setmonth.html
@@ -1,0 +1,13 @@
+<pre>
+<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+
+event.setMonth(3);
+
+console.log(event.getMonth());
+// expected output: 3
+
+console.log(event);
+// Sat Apr 19 1975 23:15:30 GMT+0100 (CET)
+// (note: your timezone may vary)
+</code>
+</pre>

--- a/live-examples/js-examples/date-setmonth.html
+++ b/live-examples/js-examples/date-setmonth.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+<code id="static-js">var event = new Date('August 19, 1975 23:15:30');
 
 event.setMonth(3);
 

--- a/live-examples/js-examples/date-setseconds.html
+++ b/live-examples/js-examples/date-setseconds.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+<code id="static-js">var event = new Date('August 19, 1975 23:15:30');
 
 event.setSeconds(42);
 

--- a/live-examples/js-examples/date-setseconds.html
+++ b/live-examples/js-examples/date-setseconds.html
@@ -1,0 +1,13 @@
+<pre>
+<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+
+event.setSeconds(42);
+
+console.log(event.getSeconds());
+// expected output: 42
+
+console.log(event);
+// Sat Apr 19 1975 23:15:42 GMT+0100 (CET)
+// (note: your timezone may vary)
+</code>
+</pre>

--- a/live-examples/js-examples/date-settime.html
+++ b/live-examples/js-examples/date-settime.html
@@ -1,0 +1,13 @@
+<pre>
+<code id="static-js">var event1 = new Date('July 1, 1999');
+var event2 = new Date();
+event2.setTime(event1.getTime());
+
+console.log(event1);
+// expected output: Thu Jul 01 1999 00:00:00 GMT+0200 (CEST)
+
+console.log(event2);
+// expected output: Thu Jul 01 1999 00:00:00 GMT+0200 (CEST)
+// (note: your timezone may vary)
+</code>
+</pre>

--- a/live-examples/js-examples/date-setutcdate.html
+++ b/live-examples/js-examples/date-setutcdate.html
@@ -1,0 +1,12 @@
+<pre>
+<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30 GMT-3:00');
+
+console.log(event.getUTCDate());
+// expected output: 20
+
+event.setUTCDate(19);
+
+console.log(event.getUTCDate());
+// expected output: 19
+</code>
+</pre>

--- a/live-examples/js-examples/date-setutcdate.html
+++ b/live-examples/js-examples/date-setutcdate.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30 GMT-3:00');
+<code id="static-js">var event = new Date('August 19, 1975 23:15:30 GMT-3:00');
 
 console.log(event.getUTCDate());
 // expected output: 20

--- a/live-examples/js-examples/date-setutcfullyear.html
+++ b/live-examples/js-examples/date-setutcfullyear.html
@@ -1,0 +1,15 @@
+<pre>
+<code id="static-js">var event = new Date('December 31, 1975 23:15:30 GMT-3:00');
+
+console.log(event.getUTCFullYear());
+// expected output: 1976
+
+console.log(event.toUTCString());
+// expected output: Thu, 01 Jan 1976 02:15:30 GMT
+
+event.setUTCFullYear(1975);
+
+console.log(event.toUTCString());
+// expected output: Wed, 01 Jan 1975 02:15:30 GMT
+</code>
+</pre>

--- a/live-examples/js-examples/date-setutchours.html
+++ b/live-examples/js-examples/date-setutchours.html
@@ -1,0 +1,15 @@
+<pre>
+<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30 GMT-3:00');
+
+console.log(event.toUTCString());
+// expected output: Wed, 20 Aug 1975 02:15:30 GMT
+
+console.log(event.getUTCHours());
+// expected output: 2
+
+event.setUTCHours(23);
+
+console.log(event.toUTCString());
+// expected output: Wed, 20 Aug 1975 23:15:30 GMT
+</code>
+</pre>

--- a/live-examples/js-examples/date-setutchours.html
+++ b/live-examples/js-examples/date-setutchours.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30 GMT-3:00');
+<code id="static-js">var event = new Date('August 19, 1975 23:15:30 GMT-3:00');
 
 console.log(event.toUTCString());
 // expected output: Wed, 20 Aug 1975 02:15:30 GMT

--- a/live-examples/js-examples/date-setutcmonth.html
+++ b/live-examples/js-examples/date-setutcmonth.html
@@ -1,0 +1,15 @@
+<pre>
+<code id="static-js">var event = new Date('December 31, 1975 23:15:30 GMT-3:00');
+
+console.log(event.toUTCString());
+// Thu, 01 Jan 1976 02:15:30 GMT
+
+console.log(event.getUTCMonth());
+// expected output: 0
+
+event.setUTCMonth(11);
+
+console.log(event.toUTCString());
+// expected output: Wed, 01 Dec 1976 02:15:30 GMT
+</code>
+</pre>

--- a/live-examples/js-examples/date-todatestring.html
+++ b/live-examples/js-examples/date-todatestring.html
@@ -1,0 +1,11 @@
+<pre>
+<code id="static-js">var event = new Date(1993, 6, 28, 14, 39, 7);
+
+console.log(event.toString());
+// expected output: Wed Jul 28 1993 14:39:07 GMT+0200 (CEST)
+// (note: your timezone may vary)
+
+console.log(event.toDateString());
+// expected output: Wed Jul 28 1993
+</code>
+</pre>

--- a/live-examples/js-examples/date-toisostring.html
+++ b/live-examples/js-examples/date-toisostring.html
@@ -1,0 +1,10 @@
+<pre>
+<code id="static-js">var event = new Date('05 October 2011 14:48 UTC');
+console.log(event.toString());
+// expected output: Wed Oct 05 2011 16:48:00 GMT+0200 (CEST)
+// (note: your timezone may vary)
+
+console.log(event.toISOString());
+// expected output: 2011-10-05T14:48:00.000Z
+</code>
+</pre>

--- a/live-examples/js-examples/date-tojson.html
+++ b/live-examples/js-examples/date-tojson.html
@@ -1,0 +1,12 @@
+<pre>
+<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30 UTC');
+
+var jsonDate = event.toJSON();
+
+console.log(jsonDate);
+// expected output: 1975-08-19T23:15:30.000Z
+
+console.log(new Date(jsonDate).toUTCString());
+// expected output: Tue, 19 Aug 1975 23:15:30 GMT
+</code>
+</pre>

--- a/live-examples/js-examples/date-tojson.html
+++ b/live-examples/js-examples/date-tojson.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30 UTC');
+<code id="static-js">var event = new Date('August 19, 1975 23:15:30 UTC');
 
 var jsonDate = event.toJSON();
 

--- a/live-examples/js-examples/date-tolocaledatestring.html
+++ b/live-examples/js-examples/date-tolocaledatestring.html
@@ -1,0 +1,15 @@
+<pre>
+<code id="static-js">var event = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
+
+var options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+
+console.log(event.toLocaleDateString('de-DE', options));
+// expected output: Donnerstag, 20. Dezember 2012
+
+console.log(event.toLocaleDateString('ar-EG', options));
+// expected output: الخميس، ٢٠ ديسمبر، ٢٠١٢
+
+console.log(event.toLocaleDateString('ko-KR', options));
+// expected output: 2012년 12월 20일 목요일
+</code>
+</pre>

--- a/live-examples/js-examples/date-tolocalestring.html
+++ b/live-examples/js-examples/date-tolocalestring.html
@@ -1,0 +1,12 @@
+<pre>
+<code id="static-js">var event = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
+
+// British English uses day-month-year order and 24-hour time without AM/PM
+console.log(event.toLocaleString('en-GB', { timeZone: 'UTC' }));
+// expected output: 20/12/2012, 03:00:00
+
+// Korean uses year-month-day order and 12-hour time with AM/PM
+console.log(event.toLocaleString('ko-KR', { timeZone: 'UTC' }));
+// expected output: 2012. 12. 20. 오전 3:00:00
+</code>
+</pre>

--- a/live-examples/js-examples/date-tolocaletimestring.html
+++ b/live-examples/js-examples/date-tolocaletimestring.html
@@ -1,0 +1,15 @@
+<pre>
+<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+
+console.log(event.toLocaleTimeString('en-US'));
+// expected output: 11:15:30 PM
+
+console.log(event.toLocaleTimeString('it-IT'));
+// expected output: 23:15:30
+
+console.log(event.toLocaleTimeString('ar-EG'));
+// expected output: ١١:١٥:٣٠ م
+
+// NOTE: THERE SEEMS TO BE SOME INCONSISTENCY BETWEEN BROWSERS HERE!
+</code>
+</pre>

--- a/live-examples/js-examples/date-tolocaletimestring.html
+++ b/live-examples/js-examples/date-tolocaletimestring.html
@@ -1,15 +1,13 @@
 <pre>
-<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+<code id="static-js">var event = new Date('August 19, 1975 23:15:30 GMT+00:00');
 
 console.log(event.toLocaleTimeString('en-US'));
-// expected output: 11:15:30 PM
+// expected output: 1:15:30 AM
 
 console.log(event.toLocaleTimeString('it-IT'));
-// expected output: 23:15:30
+// expected output: 01:15:30
 
 console.log(event.toLocaleTimeString('ar-EG'));
-// expected output: ١١:١٥:٣٠ م
-
-// NOTE: THERE SEEMS TO BE SOME INCONSISTENCY BETWEEN BROWSERS HERE!
+// expected output: ١٢:١٥:٣٠ ص
 </code>
 </pre>

--- a/live-examples/js-examples/date-tolocaletimestring.html
+++ b/live-examples/js-examples/date-tolocaletimestring.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var event = new Date('August 19, 1975 23:15:30 GMT+00:00');
+<code id="static-js">// Depending on timezone, your results will vary
+var event = new Date('August 19, 1975 23:15:30 GMT+00:00');
 
 console.log(event.toLocaleTimeString('en-US'));
 // expected output: 1:15:30 AM

--- a/live-examples/js-examples/date-tostring.html
+++ b/live-examples/js-examples/date-tostring.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+<code id="static-js">var event = new Date('August 19, 1975 23:15:30');
 
 console.log(event.toString());
 // expected output: Tue Aug 19 1975 23:15:30 GMT+0200 (CEST)

--- a/live-examples/js-examples/date-tostring.html
+++ b/live-examples/js-examples/date-tostring.html
@@ -1,0 +1,8 @@
+<pre>
+<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+
+console.log(event.toString());
+// expected output: Tue Aug 19 1975 23:15:30 GMT+0200 (CEST)
+// (note: your timezone may vary)
+</code>
+</pre>

--- a/live-examples/js-examples/date-totimestring.html
+++ b/live-examples/js-examples/date-totimestring.html
@@ -1,0 +1,8 @@
+<pre>
+<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+
+console.log(event.toTimeString());
+// expected output: 23:15:30 GMT+0200 (CEST)
+// (note: your timezone may vary)
+</code>
+</pre>

--- a/live-examples/js-examples/date-totimestring.html
+++ b/live-examples/js-examples/date-totimestring.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var event = new Date('Tue, August 19, 1975 23:15:30');
+<code id="static-js">var event = new Date('August 19, 1975 23:15:30');
 
 console.log(event.toTimeString());
 // expected output: 23:15:30 GMT+0200 (CEST)

--- a/live-examples/js-examples/date-toutcstring.html
+++ b/live-examples/js-examples/date-toutcstring.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">var event = new Date('Wed, 14 Jun 2017 00:00:00 PDT');
-  
+<code id="static-js">var event = new Date('14 Jun 2017 00:00:00 PDT');
+
 console.log(event.toUTCString());
 // expected output: Wed, 14 Jun 2017 07:00:00 GMT
 </code>

--- a/live-examples/js-examples/date-toutcstring.html
+++ b/live-examples/js-examples/date-toutcstring.html
@@ -1,0 +1,7 @@
+<pre>
+<code id="static-js">var event = new Date('Wed, 14 Jun 2017 00:00:00 PDT');
+  
+console.log(event.toUTCString());
+// expected output: Wed, 14 Jun 2017 07:00:00 GMT
+</code>
+</pre>

--- a/live-examples/js-examples/date-utc.html
+++ b/live-examples/js-examples/date-utc.html
@@ -1,0 +1,11 @@
+<pre>
+<code id="static-js">var utcDate1 = new Date(Date.UTC(96, 1, 2, 3, 4, 5));
+var utcDate2 = new Date(Date.UTC(0, 0, 0, 0, 0, 0));
+
+console.log(utcDate1.toUTCString());
+// expected output: Fri, 02 Feb 1996 03:04:05 GMT
+
+console.log(utcDate2.toUTCString());
+// expected output: Sun, 31 Dec 1899 00:00:00 GMT
+</code>
+</pre>

--- a/live-examples/js-examples/date-valueof.html
+++ b/live-examples/js-examples/date-valueof.html
@@ -1,11 +1,12 @@
 <pre>
-<code id="static-js">var utcDate1 = new Date(Date.UTC(96, 1, 2, 3, 4, 5));
-var utcDate2 = new Date(Date.UTC(0, 0, 0, 0, 0, 0));
+<code id="static-js">var date1 = new Date(Date.UTC(96, 1, 2, 3, 4, 5));
 
-console.log(utcDate1.toUTCString());
-// expected output: Fri, 02 Feb 1996 03:04:05 GMT
+console.log(date1.valueOf());
+// expected output: 823230245000
 
-console.log(utcDate2.toUTCString());
-// expected output: Sun, 31 Dec 1899 00:00:00 GMT
+var date2 = new Date('02 Feb 1996 03:04:05 GMT');
+
+console.log(date1.valueOf());
+// expected output: 823230245000
 </code>
 </pre>

--- a/live-examples/js-examples/date-valueof.html
+++ b/live-examples/js-examples/date-valueof.html
@@ -1,0 +1,11 @@
+<pre>
+<code id="static-js">var utcDate1 = new Date(Date.UTC(96, 1, 2, 3, 4, 5));
+var utcDate2 = new Date(Date.UTC(0, 0, 0, 0, 0, 0));
+
+console.log(utcDate1.toUTCString());
+// expected output: Fri, 02 Feb 1996 03:04:05 GMT
+
+console.log(utcDate2.toUTCString());
+// expected output: Sun, 31 Dec 1899 00:00:00 GMT
+</code>
+</pre>

--- a/site.json
+++ b/site.json
@@ -615,56 +615,56 @@
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/date-setutchours.html",
             "fileName": "date-setutchours.html",
-            "title": "JavaScript Demo: Date.setUTCHours())",
+            "title": "JavaScript Demo: Date.setUTCHours()",
             "type": "js"
         },
         "dateSetUTCMonth": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/date-setutcmonth.html",
             "fileName": "date-setutcmonth.html",
-            "title": "JavaScript Demo: Date.setUTCMonth())",
+            "title": "JavaScript Demo: Date.setUTCMonth()",
             "type": "js"
         },
         "dateToDateString": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/date-todatestring.html",
             "fileName": "date-todatestring.html",
-            "title": "JavaScript Demo: Date.toDateString())",
+            "title": "JavaScript Demo: Date.toDateString()",
             "type": "js"
         },
         "dateToISOString": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/date-toisostring.html",
             "fileName": "date-toisostring.html",
-            "title": "JavaScript Demo: Date.toISOString())",
+            "title": "JavaScript Demo: Date.toISOString()",
             "type": "js"
         },
         "dateToJSON": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/date-tojson.html",
             "fileName": "date-tojson.html",
-            "title": "JavaScript Demo: Date.toJSON())",
+            "title": "JavaScript Demo: Date.toJSON()",
             "type": "js"
         },
         "dateToLocaleDateString": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/date-tolocaledatestring.html",
             "fileName": "date-tolocaledatestring.html",
-            "title": "JavaScript Demo: Date.toLocaleDateString())",
+            "title": "JavaScript Demo: Date.toLocaleDateString()",
             "type": "js"
         },
         "dateToLocaleString": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/date-tolocalestring.html",
             "fileName": "date-tolocalestring.html",
-            "title": "JavaScript Demo: Date.toLocaleString())",
+            "title": "JavaScript Demo: Date.toLocaleString()",
             "type": "js"
         },
         "dateToLocaleTimeString": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/date-tolocaletimestring.html",
             "fileName": "date-tolocaletimestring.html",
-            "title": "JavaScript Demo: Date.toLocaleTimeString())",
+            "title": "JavaScript Demo: Date.toLocaleTimeString()",
             "type": "js"
         },
         "dateToString": {

--- a/site.json
+++ b/site.json
@@ -205,6 +205,76 @@
             "title": "JavaScript Demo: ArrayBuffer.slice()",
             "type": "js"
         },
+        "atomicsAdd": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/atomics-add.html",
+            "fileName": "atomics-add.html",
+            "title": "JavaScript Demo: Atomics.add()",
+            "type": "js"
+        },
+        "atomicsAnd": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/atomics-and.html",
+            "fileName": "atomics-and.html",
+            "title": "JavaScript Demo: Atomics.and()",
+            "type": "js"
+        },
+        "atomicsCompareExchange": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/atomics-compareexchange.html",
+            "fileName": "atomics-compareexchange.html",
+            "title": "JavaScript Demo: Atomics.compareExchange()",
+            "type": "js"
+        },
+        "atomicsExchange": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/atomics-exchange.html",
+            "fileName": "atomics-exchange.html",
+            "title": "JavaScript Demo: Atomics.exchange()",
+            "type": "js"
+        },
+        "atomicsIsLockFree": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/atomics-islockfree.html",
+            "fileName": "atomics-islockfree.html",
+            "title": "JavaScript Demo: Atomics.isLockFree()",
+            "type": "js"
+        },
+        "atomicsLoad": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/atomics-load.html",
+            "fileName": "atomics-load.html",
+            "title": "JavaScript Demo: Atomics.load()",
+            "type": "js"
+        },
+        "atomicsOr": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/atomics-or.html",
+            "fileName": "atomics-or.html",
+            "title": "JavaScript Demo: Atomics.or()",
+            "type": "js"
+        },
+        "atomicsStore": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/atomics-store.html",
+            "fileName": "atomics-store.html",
+            "title": "JavaScript Demo: Atomics.store()",
+            "type": "js"
+        },
+        "atomicsSub": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/atomics-sub.html",
+            "fileName": "atomics-sub.html",
+            "title": "JavaScript Demo: Atomics.sub()",
+            "type": "js"
+        },
+        "atomicsXor": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/atomics-xor.html",
+            "fileName": "atomics-xor.html",
+            "title": "JavaScript Demo: Atomics.xor()",
+            "type": "js"
+        },
         "dataviewBuffer": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/dataview-buffer.html",
@@ -345,6 +415,293 @@
             "title": "JavaScript Demo: DataView.setUint32()",
             "type": "js"
         },
+        "dateConstructor": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-constructor.html",
+            "fileName": "date-constructor.html",
+            "title": "JavaScript Demo: Date Constructor",
+            "type": "js"
+        },
+        "dateGetDate": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-getdate.html",
+            "fileName": "date-getdate.html",
+            "title": "JavaScript Demo: Date.getDate()",
+            "type": "js"
+        },
+        "dateGetDay": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-getday.html",
+            "fileName": "date-getday.html",
+            "title": "JavaScript Demo: Date.getDay()",
+            "type": "js"
+        },
+        "dateGetFullYear": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-getfullyear.html",
+            "fileName": "date-getfullyear.html",
+            "title": "JavaScript Demo: Date.getFullYear()",
+            "type": "js"
+        },
+        "dateGetHours": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-gethours.html",
+            "fileName": "date-gethours.html",
+            "title": "JavaScript Demo: Date.getHours()",
+            "type": "js"
+        },
+        "dateGetMilliseconds": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-getmilliseconds.html",
+            "fileName": "date-getmilliseconds.html",
+            "title": "JavaScript Demo: Date.getMilliseconds()",
+            "type": "js"
+        },
+        "dateGetMinutes": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-getminutes.html",
+            "fileName": "date-getminutes.html",
+            "title": "JavaScript Demo: Date.getMinutes()",
+            "type": "js"
+        },
+        "dateGetMonth": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-getmonth.html",
+            "fileName": "date-getmonth.html",
+            "title": "JavaScript Demo: Date.getMonth()",
+            "type": "js"
+        },
+        "dateGetSeconds": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-getseconds.html",
+            "fileName": "date-getseconds.html",
+            "title": "JavaScript Demo: Date.getSeconds()",
+            "type": "js"
+        },
+        "dateGetTime": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-gettime.html",
+            "fileName": "date-gettime.html",
+            "title": "JavaScript Demo: Date.getTime()",
+            "type": "js"
+        },
+        "dateGetTimezoneOffset": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-gettimezoneoffset.html",
+            "fileName": "date-gettimezoneoffset.html",
+            "title": "JavaScript Demo: Date.getTimezoneOffset()",
+            "type": "js"
+        },
+        "dateGetUTCDate": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-getutcdate.html",
+            "fileName": "date-getutcdate.html",
+            "title": "JavaScript Demo: Date.getUTCDate()",
+            "type": "js"
+        },
+        "dateGetUTCDay": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-getutcday.html",
+            "fileName": "date-getutcday.html",
+            "title": "JavaScript Demo: Date.getUTCDay()",
+            "type": "js"
+        },
+        "dateGetUTCFullYear": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-getutcfullyear.html",
+            "fileName": "date-getutcfullyear.html",
+            "title": "JavaScript Demo: Date.getUTCFullYear()",
+            "type": "js"
+        },
+        "dateGetUTCHours": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-getutchours.html",
+            "fileName": "date-getutchours.html",
+            "title": "JavaScript Demo: Date.getUTCHours()",
+            "type": "js"
+        },
+        "dateGetUTCMonth": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-getutcmonth.html",
+            "fileName": "date-getutcmonth.html",
+            "title": "JavaScript Demo: Date.getUTCMonth()",
+            "type": "js"
+        },
+        "dateNow": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-now.html",
+            "fileName": "date-now.html",
+            "title": "JavaScript Demo: Date.now()",
+            "type": "js"
+        },
+        "dateParse": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-parse.html",
+            "fileName": "date-parse.html",
+            "title": "JavaScript Demo: Date.parse()",
+            "type": "js"
+        },
+        "dateSetDate": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-setdate.html",
+            "fileName": "date-setdate.html",
+            "title": "JavaScript Demo: Date.setDate()",
+            "type": "js"
+        },
+        "dateSetFullYear": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-setfullyear.html",
+            "fileName": "date-setfullyear.html",
+            "title": "JavaScript Demo: Date.setFullYear()",
+            "type": "js"
+        },
+        "dateSetHours": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-sethours.html",
+            "fileName": "date-sethours.html",
+            "title": "JavaScript Demo: Date.setHours()",
+            "type": "js"
+        },
+        "dateSetMilliseconds": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-setmilliseconds.html",
+            "fileName": "date-setmilliseconds.html",
+            "title": "JavaScript Demo: Date.setMilliseconds()",
+            "type": "js"
+        },
+        "dateSetMinutes": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-setminutes.html",
+            "fileName": "date-setminutes.html",
+            "title": "JavaScript Demo: Date.setMinutes()",
+            "type": "js"
+        },
+        "dateSetMonth": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-setmonth.html",
+            "fileName": "date-setmonth.html",
+            "title": "JavaScript Demo: Date.setMonth()",
+            "type": "js"
+        },
+        "dateSetSeconds": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-setseconds.html",
+            "fileName": "date-setseconds.html",
+            "title": "JavaScript Demo: Date.setSeconds()",
+            "type": "js"
+        },
+        "dateSetTime": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-settime.html",
+            "fileName": "date-settime.html",
+            "title": "JavaScript Demo: Date.setTime()",
+            "type": "js"
+        },
+        "dateSetUTCDate": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-setutcdate.html",
+            "fileName": "date-setutcdate.html",
+            "title": "JavaScript Demo: Date.setUTCDate()",
+            "type": "js"
+        },
+        "dateSetUTCFullYear": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-setutcfullyear.html",
+            "fileName": "date-setutcfullyear.html",
+            "title": "JavaScript Demo: Date.setUTCFullYear()",
+            "type": "js"
+        },
+        "dateSetUTCHours": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-setutchours.html",
+            "fileName": "date-setutchours.html",
+            "title": "JavaScript Demo: Date.setUTCHours())",
+            "type": "js"
+        },
+        "dateSetUTCMonth": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-setutcmonth.html",
+            "fileName": "date-setutcmonth.html",
+            "title": "JavaScript Demo: Date.setUTCMonth())",
+            "type": "js"
+        },
+        "dateToDateString": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-todatestring.html",
+            "fileName": "date-todatestring.html",
+            "title": "JavaScript Demo: Date.toDateString())",
+            "type": "js"
+        },
+        "dateToISOString": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-toisostring.html",
+            "fileName": "date-toisostring.html",
+            "title": "JavaScript Demo: Date.toISOString())",
+            "type": "js"
+        },
+        "dateToJSON": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-tojson.html",
+            "fileName": "date-tojson.html",
+            "title": "JavaScript Demo: Date.toJSON())",
+            "type": "js"
+        },
+        "dateToLocaleDateString": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-tolocaledatestring.html",
+            "fileName": "date-tolocaledatestring.html",
+            "title": "JavaScript Demo: Date.toLocaleDateString())",
+            "type": "js"
+        },
+        "dateToLocaleString": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-tolocalestring.html",
+            "fileName": "date-tolocalestring.html",
+            "title": "JavaScript Demo: Date.toLocaleString())",
+            "type": "js"
+        },
+        "dateToLocaleTimeString": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-tolocaletimestring.html",
+            "fileName": "date-tolocaletimestring.html",
+            "title": "JavaScript Demo: Date.toLocaleTimeString())",
+            "type": "js"
+        },
+        "dateToString": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-tostring.html",
+            "fileName": "date-tostring.html",
+            "title": "JavaScript Demo: Date.toString())",
+            "type": "js"
+        },
+        "dateToTimeString": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-totimestring.html",
+            "fileName": "date-totimestring.html",
+            "title": "JavaScript Demo: Date.toTimeString())",
+            "type": "js"
+        },
+        "dateToUTCString": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-toutcstring.html",
+            "fileName": "date-toutcstring.html",
+            "title": "JavaScript Demo: Date.toUTCString())",
+            "type": "js"
+        },
+        "dateUTC": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-utc.html",
+            "fileName": "date-utc.html",
+            "title": "JavaScript Demo: Date.UTC())",
+            "type": "js"
+        },
+        "dateValueOf": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/date-valueof.html",
+            "fileName": "date-valueof.html",
+            "title": "JavaScript Demo: Date.valueOf())",
+            "type": "js"
+        },
         "promiseAll": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/promise-all.html",
@@ -392,76 +749,6 @@
             "exampleCode": "live-examples/js-examples/promise-then.html",
             "fileName": "promise-then.html",
             "title": "JavaScript Demo: Promise.then()",
-            "type": "js"
-        },
-        "atomicsAdd": {
-            "baseTmpl": "tmpl/live-js-tmpl.html",
-            "exampleCode": "live-examples/js-examples/atomics-add.html",
-            "fileName": "atomics-add.html",
-            "title": "JavaScript Demo: Atomics.add()",
-            "type": "js"
-        },
-        "atomicsAnd": {
-            "baseTmpl": "tmpl/live-js-tmpl.html",
-            "exampleCode": "live-examples/js-examples/atomics-and.html",
-            "fileName": "atomics-and.html",
-            "title": "JavaScript Demo: Atomics.and()",
-            "type": "js"
-        },
-        "atomicsCompareExchange": {
-            "baseTmpl": "tmpl/live-js-tmpl.html",
-            "exampleCode": "live-examples/js-examples/atomics-compareexchange.html",
-            "fileName": "atomics-compareexchange.html",
-            "title": "JavaScript Demo: Atomics.compareExchange()",
-            "type": "js"
-        },
-        "atomicsExchange": {
-            "baseTmpl": "tmpl/live-js-tmpl.html",
-            "exampleCode": "live-examples/js-examples/atomics-exchange.html",
-            "fileName": "atomics-exchange.html",
-            "title": "JavaScript Demo: Atomics.exchange()",
-            "type": "js"
-        },
-        "atomicsIsLockFree": {
-            "baseTmpl": "tmpl/live-js-tmpl.html",
-            "exampleCode": "live-examples/js-examples/atomics-islockfree.html",
-            "fileName": "atomics-islockfree.html",
-            "title": "JavaScript Demo: Atomics.isLockFree()",
-            "type": "js"
-        },
-        "atomicsLoad": {
-            "baseTmpl": "tmpl/live-js-tmpl.html",
-            "exampleCode": "live-examples/js-examples/atomics-load.html",
-            "fileName": "atomics-load.html",
-            "title": "JavaScript Demo: Atomics.load()",
-            "type": "js"
-        },
-        "atomicsOr": {
-            "baseTmpl": "tmpl/live-js-tmpl.html",
-            "exampleCode": "live-examples/js-examples/atomics-or.html",
-            "fileName": "atomics-or.html",
-            "title": "JavaScript Demo: Atomics.or()",
-            "type": "js"
-        },
-        "atomicsStore": {
-            "baseTmpl": "tmpl/live-js-tmpl.html",
-            "exampleCode": "live-examples/js-examples/atomics-store.html",
-            "fileName": "atomics-store.html",
-            "title": "JavaScript Demo: Atomics.store()",
-            "type": "js"
-        },
-        "atomicsSub": {
-            "baseTmpl": "tmpl/live-js-tmpl.html",
-            "exampleCode": "live-examples/js-examples/atomics-sub.html",
-            "fileName": "atomics-sub.html",
-            "title": "JavaScript Demo: Atomics.sub()",
-            "type": "js"
-        },
-        "atomicsXor": {
-            "baseTmpl": "tmpl/live-js-tmpl.html",
-            "exampleCode": "live-examples/js-examples/atomics-xor.html",
-            "fileName": "atomics-xor.html",
-            "title": "JavaScript Demo: Atomics.xor()",
             "type": "js"
         },
         "sharedarraybufferByteLength": {


### PR DESCRIPTION
Note that there is a browser inconsistency for Date.toLocaleTimeString (try Chrome, Safari and Firefox). We can of course remove that example.

Apologies for the merge conflict, let me know if this a problem.

