### PR TITLE
console.log support for arrays of arrays and arrays of strings

### DIFF
--- a/js/editor-libs/console.js
+++ b/js/editor-libs/console.js
@@ -29,7 +29,7 @@
         var output = '';
         for (var i = 0; i < input.length; i++) {
             if (typeof(input[i]) === "string") {
-                output += "'" + input[i] + "'";
+                output += '"' + input[i] + '"';
             } else if (Array.isArray(input[i])) {
                 output += '[';
                 output += formatArray(input[i]);
@@ -56,7 +56,7 @@
      */
      function formatOutput(input) {
          if (typeof(input) === "string") {
-             return "'" + input + "'";
+             return '"' + input + '"';
          } else if (Array.isArray(input)) {
            // check the contents of the array
            return '[' + formatArray(input) + ']';
@@ -64,7 +64,7 @@
              return input;
          }
      }
-    
+
     /**
      * Writes the provided content to the editor’s output area
      * @param {String} content - The content to write to output

--- a/js/editor-libs/console.js
+++ b/js/editor-libs/console.js
@@ -17,22 +17,54 @@
     };
 
     /**
-     * Formats output to indicate its type:
-     * - quotes around strings
+     * Formats arrays:
+     * - quotes around strings in arrays
      * - square brackets around arrays
+     * - adds commas appropraitely (with spacing)
+     * designed to be used recursively
      * @param {any} input - The output to log.
      * @returns Formatted output as a string.
      */
-    function formatOutput(input) {
-        if (typeof(input) === "string") {
-            return '"' + input + '"';
-        } else if (Array.isArray(input)) {
-          return '[' + input + ']';
-        } else {
-            return input;
+    function formatArray(input) {
+        var output = '';
+        for (var i = 0; i < input.length; i++) {
+            if (typeof(input[i]) === "string") {
+                output += "'" + input[i] + "'";
+            } else if (Array.isArray(input[i])) {
+                output += '[';
+                output += formatArray(input[i]);
+                output += ']';
+            } else {
+              output += input[i];
+            }
+
+            if (i < (input.length - 1)) {
+              output += ', ';
+            }
         }
+        return output;
     }
 
+    /**
+     * Formats output to indicate its type:
+     * - quotes around strings
+     * - square brackets around arrays
+     * (also copes with arrays of arrays)
+     * does NOT detect Int32Array etc
+     * @param {any} input - The output to log.
+     * @returns Formatted output as a string.
+     */
+     function formatOutput(input) {
+         if (typeof(input) === "string") {
+             return "'" + input + "'";
+         } else if (Array.isArray(input)) {
+           // check the contents of the array
+           return '[' + formatArray(input) + ']';
+         } else {
+             return input;
+         }
+     }
+    
     /**
      * Writes the provided content to the editor’s output area
      * @param {String} content - The content to write to output

--- a/js/editor-libs/console.js
+++ b/js/editor-libs/console.js
@@ -20,14 +20,14 @@
      * Formats arrays:
      * - quotes around strings in arrays
      * - square brackets around arrays
-     * - adds commas appropraitely (with spacing)
+     * - adds commas appropriately (with spacing)
      * designed to be used recursively
      * @param {any} input - The output to log.
      * @returns Formatted output as a string.
      */
     function formatArray(input) {
         var output = '';
-        for (var i = 0; i < input.length; i++) {
+        for (var i = 0, l = input.length; i < l; i++) {
             if (typeof(input[i]) === "string") {
                 output += '"' + input[i] + '"';
             } else if (Array.isArray(input[i])) {
@@ -35,11 +35,11 @@
                 output += formatArray(input[i]);
                 output += ']';
             } else {
-              output += input[i];
+                output += input[i];
             }
 
             if (i < (input.length - 1)) {
-              output += ', ';
+                output += ', ';
             }
         }
         return output;
@@ -58,8 +58,8 @@
          if (typeof(input) === "string") {
              return '"' + input + '"';
          } else if (Array.isArray(input)) {
-           // check the contents of the array
-           return '[' + formatArray(input) + ']';
+             // check the contents of the array
+             return '[' + formatArray(input) + ']';
          } else {
              return input;
          }


### PR DESCRIPTION
This is a tentative pull request for the enhancement of the console log types.

Building on the work by @wbamberg this change should add support for arrays of arrays and arrays of strings. As this method takes advantage of recursion it *should* work to any level of 'nesting'.

Note: we still don't have support for `Int32Array` et al as `Array.isArray()` returns `false` in those cases. Not sure what the best way to test for these cases are, but would be nice to, especially for the `SharedBufferArray` examples.

PS I added a space after commas and made it single quotes around strings, which I think is inline with our preference and browser console output.



