### PR TITLE
JS RegExp examples (with caveats)

### DIFF
--- a/live-examples/js-examples/regexp-constructor.html
+++ b/live-examples/js-examples/regexp-constructor.html
@@ -1,0 +1,14 @@
+<pre>
+<code id="static-js">var re1 = /\w+/;
+var re2 = new RegExp('\\w+');
+
+console.log(re1);
+// expected output: /\w+/
+
+console.log(re2);
+// expected output: /\w+/
+
+console.log(re1 === re2);
+// expected output: false
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-getregexp-@@species.html
+++ b/live-examples/js-examples/regexp-getregexp-@@species.html
@@ -1,0 +1,14 @@
+<pre>
+<code id="static-js">class MyRegExp extends RegExp {
+  // Overwrite MyRegExp species to the parent RegExp constructor
+  static get [Symbol.species]() {
+    return RegExp;
+  }
+}
+
+var regex1 = new MyRegExp('foo','g');
+
+console.log(regex1.test('football'));
+// expected output: true
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-lastindex.html
+++ b/live-examples/js-examples/regexp-lastindex.html
@@ -1,0 +1,15 @@
+<pre>
+<code id="static-js">var regex1 = new RegExp( "foo", "g" );
+var str1 = 'table football, foosball';
+
+regex1.test(str1);
+
+console.log(regex1.lastIndex);
+// expected output: 9
+
+regex1.test(str1);
+
+console.log(regex1.lastIndex);
+// expected output: 19
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-prototype-@@match.html
+++ b/live-examples/js-examples/regexp-prototype-@@match.html
@@ -1,0 +1,15 @@
+<pre>
+<code id="static-js">class RegExp1 extends RegExp {
+  [Symbol.match](str) {
+    var result = RegExp.prototype[Symbol.match].call(this, str);
+    if (result) {
+      return 'VALID';
+    }
+    return 'INVALID';
+  }
+}
+
+console.log('2012-07-02'.match(new RegExp1('([0-9]+)-([0-9]+)-([0-9]+)')));
+// expected output: "VALID"
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-prototype-@@replace.html
+++ b/live-examples/js-examples/regexp-prototype-@@replace.html
@@ -1,0 +1,11 @@
+<pre>
+<code id="static-js">class RegExp1 extends RegExp {
+  [Symbol.replace](str) {
+    return RegExp.prototype[Symbol.replace].call(this, str, '#!@?');
+  }
+}
+
+console.log('football'.replace(new RegExp1('foo')));
+// expected output: "#!@?tball"
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-prototype-@@search.html
+++ b/live-examples/js-examples/regexp-prototype-@@search.html
@@ -1,0 +1,15 @@
+<pre>
+<code id="static-js">class RegExp1 extends RegExp {
+  constructor(str) {
+    super(str)
+    this.pattern = str;
+  }
+  [Symbol.search](str) {
+    return str.indexOf(this.pattern);
+  }
+}
+
+console.log('table football'.search(new RegExp1('foo')));
+// expected output: 6
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-prototype-@@split.html
+++ b/live-examples/js-examples/regexp-prototype-@@split.html
@@ -1,0 +1,15 @@
+<pre>
+<code id="static-js">class RegExp1 extends RegExp {
+  [Symbol.split](str, limit) {
+    var result = RegExp.prototype[Symbol.split].call(this, str, limit);
+    return result.map(x => "(" + x + ")");
+  }
+}
+
+console.log('2016-01-02'.split(new RegExp1('-')));
+// expected output: ["(2016)", "(01)", "(02)"]
+
+console.log('2016-01-02'.split(new RegExp('-')));
+// expected output: ["2016", "01", "02"]
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-prototype-exec.html
+++ b/live-examples/js-examples/regexp-prototype-exec.html
@@ -1,0 +1,12 @@
+<pre>
+<code id="static-js">var regex1 = RegExp('foo*','g');
+var str1 = 'table football, foosball';
+var array1;
+
+while ((array1 = regex1.exec(str1)) !== null) {
+  console.log(`Found ${array1[0]}. Next starts at ${regex1.lastIndex}.`);
+  // expected output: "Found foo. Next starts at 9."
+  // expected output: "Found foo. Next starts at 19."
+}
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-prototype-flags.html
+++ b/live-examples/js-examples/regexp-prototype-flags.html
@@ -1,0 +1,10 @@
+<pre>
+<code id="static-js">// outputs RegExp flags in alphabetical order
+
+console.log(/foo/ig.flags);
+// expected output: "gi"
+
+console.log(/bar/myu.flags);
+// expected output: "muy"
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-prototype-global.html
+++ b/live-examples/js-examples/regexp-prototype-global.html
@@ -1,0 +1,12 @@
+<pre>
+<code id="static-js">var regex1 = new RegExp('foo', 'g');
+
+console.log(regex1.global);
+// expected output: true
+
+var regex2 = new RegExp('bar', 'i');
+
+console.log(regex2.global);
+// expected output: false
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-prototype-ignorecase.html
+++ b/live-examples/js-examples/regexp-prototype-ignorecase.html
@@ -1,0 +1,14 @@
+<pre>
+<code id="static-js">var regex1 = new RegExp('foo');
+var regex2 = new RegExp('foo', 'i');
+
+console.log(regex1.test('Football'));
+// expected output: false
+
+console.log(regex2.ignoreCase);
+// expected output: true
+
+console.log(regex2.test('Football'));
+// expected output: true
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-prototype-multiline.html
+++ b/live-examples/js-examples/regexp-prototype-multiline.html
@@ -1,0 +1,17 @@
+<pre>
+<code id="static-js">var regex1 = new RegExp('^football');
+var regex2 = new RegExp('^football', 'm');
+
+console.log(regex1.multiline);
+// expected output: false
+
+console.log(regex2.multiline);
+// expected output: true
+
+console.log(regex1.test('rugby\nfootball'));
+// expected output: false
+
+console.log(regex2.test('rugby\nfootball'));
+// expected output: true
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-prototype-source.html
+++ b/live-examples/js-examples/regexp-prototype-source.html
@@ -2,7 +2,7 @@
 <code id="static-js">var regex1 = /fooBar/ig;
 
 console.log(regex1.source);
-// expected output: "foobar"
+// expected output: "fooBar"
 
 console.log(new RegExp().source);
 // expected output: "(?:)"

--- a/live-examples/js-examples/regexp-prototype-source.html
+++ b/live-examples/js-examples/regexp-prototype-source.html
@@ -1,0 +1,14 @@
+<pre>
+<code id="static-js">var regex1 = /fooBar/ig;
+
+console.log(regex1.source);
+// expected output: "foobar"
+
+console.log(new RegExp().source);
+// expected output: "(?:)"
+
+console.log(new RegExp('\n').source === '\\n');
+// expected output: true (starting with ES5)
+// (due to escaping)
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-prototype-sticky.html
+++ b/live-examples/js-examples/regexp-prototype-sticky.html
@@ -1,0 +1,16 @@
+<pre>
+<code id="static-js">var str1 = 'table football';
+var regex1 = new RegExp('foo','y');
+
+regex1.lastIndex = 6;
+
+console.log(regex1.sticky);
+// expected output: true
+
+console.log(regex1.test(str1));
+// expected output: true
+
+console.log(regex1.test(str1));
+// expected output: false
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-prototype-test.html
+++ b/live-examples/js-examples/regexp-prototype-test.html
@@ -1,0 +1,18 @@
+<pre>
+<code id="static-js">var regex1 = RegExp('foo*');
+var regex2 = RegExp('foo*','g');
+var str1 = 'table football';
+
+console.log(regex1.test(str1));
+// expected output: true
+
+console.log(regex1.test(str1));
+// expected output: true
+
+console.log(regex2.test(str1));
+// expected output: true
+
+console.log(regex2.test(str1));
+// expected output: false
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-prototype-tostring.html
+++ b/live-examples/js-examples/regexp-prototype-tostring.html
@@ -1,6 +1,6 @@
 <pre>
 <code id="static-js">console.log(new RegExp('a+b+c'));
-// expected output: a+b+c
+// expected output: /a+b+c/
 
 console.log(new RegExp('a+b+c').toString());
 // expected output: "/a+b+c/"
@@ -9,7 +9,7 @@ console.log(new RegExp('bar', 'g').toString());
 // expected output: "/bar/g"
 
 console.log(new RegExp('\n', 'g').toString());
-// expected output: "/\n/g"
+// expected output (if your browser supports escaping): "/\n/g" 
 
 console.log(new RegExp('\\n', 'g').toString());
 // expected output: "/\n/g"

--- a/live-examples/js-examples/regexp-prototype-tostring.html
+++ b/live-examples/js-examples/regexp-prototype-tostring.html
@@ -1,0 +1,17 @@
+<pre>
+<code id="static-js">console.log(new RegExp('a+b+c'));
+// expected output: a+b+c
+
+console.log(new RegExp('a+b+c').toString());
+// expected output: "/a+b+c/"
+
+console.log(new RegExp('bar', 'g').toString());
+// expected output: "/bar/g"
+
+console.log(new RegExp('\n', 'g').toString());
+// expected output: "/\n/g"
+
+console.log(new RegExp('\\n', 'g').toString());
+// expected output: "/\n/g"
+</code>
+</pre>

--- a/live-examples/js-examples/regexp-prototype-unicode.html
+++ b/live-examples/js-examples/regexp-prototype-unicode.html
@@ -1,0 +1,17 @@
+<pre>
+<code id="static-js">var regex1 = new RegExp('\u{61}');
+var regex2 = new RegExp('\u{61}', 'u');
+
+console.log(regex1.unicode);
+// expected output: false
+
+console.log(regex2.unicode);
+// expected output: true
+
+console.log(regex1.source);
+// expected output: "a"
+
+console.log(regex2.source);
+// expected output: "a"
+</code>
+</pre>

--- a/site.json
+++ b/site.json
@@ -1609,6 +1609,125 @@
             "title": "JavaScript Demo: Promise.then()",
             "type": "js"
         },
+        "regexpConstructor": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-constructor.html",
+            "fileName": "regexp-constructor.html",
+            "title": "JavaScript Demo: RegExp Constructor",
+            "type": "js"
+        },
+        "regexpGetRegExp@@Species": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-getregexp-@@species.html",
+            "fileName": "regexp-getregexp-@@species.html",
+            "title": "JavaScript Demo: RegExp.getRegExp[@@species]",
+            "type": "js"
+        },
+        "regexpLastIndex": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-lastindex.html",
+            "fileName": "regexp-lastindex.html",
+            "title": "JavaScript Demo: RegExp.lastIndex",
+            "type": "js"
+        },
+        "regexpPrototype@@Match": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-prototype-@@match.html",
+            "fileName": "regexp-prototype-@@match.html",
+            "title": "JavaScript Demo: RegExp.prototype[@@match]",
+            "type": "js"
+        },
+        "regexpPrototype@@Replace": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-prototype-@@replace.html",
+            "fileName": "regexp-prototype-@@replace.html",
+            "title": "JavaScript Demo: RegExp.prototype[@@replace]",
+            "type": "js"
+        },
+        "regexpPrototype@@Search": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-prototype-@@search.html",
+            "fileName": "regexp-prototype-@@search.html",
+            "title": "JavaScript Demo: RegExp.prototype[@@search]",
+            "type": "js"
+        },
+        "regexpPrototype@@Split": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-prototype-@@split.html",
+            "fileName": "regexp-prototype-@@split.html",
+            "title": "JavaScript Demo: RegExp.prototype[@@split]",
+            "type": "js"
+        },
+        "regexpPrototypeExec": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-prototype-exec.html",
+            "fileName": "regexp-prototype-exec.html",
+            "title": "JavaScript Demo: RegExp.prototype.exec()",
+            "type": "js"
+        },
+        "regexpPrototypeFlags": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-prototype-flags.html",
+            "fileName": "regexp-prototype-flags.html",
+            "title": "JavaScript Demo: RegExp.prototype.flags",
+            "type": "js"
+        },
+        "regexpPrototypeGlobal": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-prototype-global.html",
+            "fileName": "regexp-prototype-global.html",
+            "title": "JavaScript Demo: RegExp.prototype.global",
+            "type": "js"
+        },
+        "regexpPrototypeIgnoreCase": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-prototype-ignorecase.html",
+            "fileName": "regexp-prototype-ignorecase.html",
+            "title": "JavaScript Demo: RegExp.prototype.ignoreCase",
+            "type": "js"
+        },
+        "regexpPrototypeMultiLine": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-prototype-multiline.html",
+            "fileName": "regexp-prototype-multiline.html",
+            "title": "JavaScript Demo: RegExp.prototype.multiline",
+            "type": "js"
+        },
+        "regexpPrototypeSource": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-prototype-source.html",
+            "fileName": "regexp-prototype-source.html",
+            "title": "JavaScript Demo: RegExp.prototype.source",
+            "type": "js"
+        },
+        "regexpPrototypeSticky": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-prototype-sticky.html",
+            "fileName": "regexp-prototype-sticky.html",
+            "title": "JavaScript Demo: RegExp.prototype.sticky",
+            "type": "js"
+        },
+        "regexpPrototypeTest": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-prototype-test.html",
+            "fileName": "regexp-prototype-test.html",
+            "title": "JavaScript Demo: RegExp.prototype.test",
+            "type": "js"
+        },
+        "regexpPrototypeToString": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-prototype-tostring.html",
+            "fileName": "regexp-prototype-tostring.html",
+            "title": "JavaScript Demo: RegExp.prototype.toString()",
+            "type": "js"
+        },
+        "regexpPrototypeUnicode": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/regexp-prototype-unicode.html",
+            "fileName": "regexp-prototype-unicode.html",
+            "title": "JavaScript Demo: RegExp.prototype.unicode",
+            "type": "js"
+        },
         "setPrototype@@Iterator": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/set-prototype-@@iterator.html",


### PR DESCRIPTION
I don't necessarily think we should merge this, but I put it out there for discussion.

The issues are:

1. `regexp-prototype-source.html` - specifically:

```
console.log(new RegExp('\n').source === '\\n');
// expected output: true
```

Which I believe should return `true` (source : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/source)

It returns `true` in Firefox and Safari but `false` in Chrome and Opera .

2. `regexp-prototype-tostring.html` - (possibly related to 1.) specifically:

```
console.log(new RegExp('\n', 'g').toString());
// expected output: "/\n/g"
```

This produces the expected output in Firefox and Safari but in Chrome and Opera produces:

```
"/
/g"
```