### PR TITLE
Improvements to the position example

### DIFF
--- a/live-examples/css-examples/css/position.css
+++ b/live-examples/css-examples/css/position.css
@@ -9,9 +9,9 @@
 
 .box {
     display: inline-block;
-    height: 80px;
-    width: 80px;
-    margin: 0 10px;
+    height: 65px;
+    width: 65px;
+    margin: 10px;
     background-color: rgba(0, 0, 255, 0.2);
     border: 3px solid blue;
 }
@@ -23,12 +23,7 @@
 
 #example-element-placeholder {
     position: absolute;
-    top: 0;
-    left: 100px;
+    left: 85px;
     background-color: transparent;
     border: 3px dotted red;
-}
-
-#example-element-container p:first-of-type {
-    margin-top: 80px;
 }

--- a/live-examples/css-examples/position.html
+++ b/live-examples/css-examples/position.html
@@ -9,7 +9,7 @@
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">position: relative;
-top: 80px; left: 80px;</code></pre>
+top: 65px; left: 65px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
@@ -25,7 +25,7 @@ top: 40px; left: 40px;</code></pre>
 
 <div id="choice-sticky" class="example-choice">
 <pre><code id="example_four" class="language-css">position: sticky;
-top: 0;</code></pre>
+top: 20px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
@@ -35,8 +35,9 @@ top: 0;</code></pre>
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
       <div id="example-element-container">
+<p>In this demo you can control the <code>position</code> property for the yellow box.</p>
         <div class="box"></div><div class="box" id="example-element-placeholder"></div><div class="box transition-all" id="example-element"></div><div class="box"></div>
-<p>To see the effect of <code>position: sticky</code>, select the <code>position: sticky</code> option and scroll this container.</p>
+<p>To see the effect of <code>sticky</code> positioning, select the <code>position: sticky</code> option and scroll this container.</p>
 <p>The element will scroll along with its container, until it is at the top of the container (or reaches the offset specified in <code>top</code>), and will then stop scrolling, so it stays visible.</p>
 <p>The rest of this text is only supplied to make sure the container overflows, so as to enable you to scroll it and see the effect.</p>
 <hr/>


### PR DESCRIPTION
I was looking at these, and decided the boxes ought to be smaller to make it less likely that they wrap. It still kind of works when they wrap, but it's better if they don't IMO.

But then I also realised that the "sticky" example wasn't very good, because the boxes are already at the top, so the sticky box doesn't scroll at all, so it's just like fixed. So I added a bit of text above, so you can more easily see it working.