### PR TITLE
Fixed mistake in array-reduce comment

### DIFF
--- a/live-examples/js-examples/array-reduce.html
+++ b/live-examples/js-examples/array-reduce.html
@@ -6,7 +6,7 @@ const reducer = (accumulator, currentValue) => accumulator + currentValue;
 console.log(array1.reduce(reducer));
 // expected output: 10
 
-// 5 + 2 + 3 + 4
+// 5 + 1 + 2 + 3 + 4
 console.log(array1.reduce(reducer, 5));
 // expected output: 15
 </code>


### PR DESCRIPTION
The first element of the array was missing in the comment of the array reduce example.