### PR TITLE
Adding a CSS interactive example for word-break property

### DIFF
--- a/live-examples/css-examples/css/word-break.css
+++ b/live-examples/css-examples/css/word-break.css
@@ -1,5 +1,5 @@
 #example-element {
- width:10em;
- text-align: start;
- border: solid 1px darkgray;
+    width:10em;
+    text-align: start;
+    border: solid 1px darkgray;
 }

--- a/live-examples/css-examples/css/word-break.css
+++ b/live-examples/css-examples/css/word-break.css
@@ -1,5 +1,6 @@
 #example-element {
-    width:10em;
+    width: 80%;
+    padding: 20px;
     text-align: start;
     border: solid 1px darkgray;
 }

--- a/live-examples/css-examples/css/word-break.css
+++ b/live-examples/css-examples/css/word-break.css
@@ -1,0 +1,5 @@
+#example-element {
+ width:10em;
+ text-align: start;
+ border: solid 1px darkgray;
+}

--- a/live-examples/css-examples/word-break.html
+++ b/live-examples/css-examples/word-break.html
@@ -1,27 +1,23 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-radius">
-
     <div class="example-choice" initial-choice="true">
         <pre><code id="example_one" class="language-css">word-break: normal;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
-    <div class="example-choice" initial-choice="true">
+    <div class="example-choice">
         <pre><code id="example_two" class="language-css">word-break: break-all;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
-    <div class="example-choice" initial-choice="true">
+    <div class="example-choice">
         <pre><code id="example_three" class="language-css">word-break: keep-all;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
-
-
 </section>
-
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
       <div id="example-element" class="transition-all">Honorificabilitudinitatibus

--- a/live-examples/css-examples/word-break.html
+++ b/live-examples/css-examples/word-break.html
@@ -20,7 +20,7 @@
 </section>
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
-      <div id="example-element" class="transition-all">Honorificabilitudinitatibus
+      <div id="example-element" class="transition-all">Honorificabilitudinitatibus califragilisticexpialidocious Pneumonoultramicroscopicsilicovolcanoconiosis
         次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉
       </div>
     </section>

--- a/live-examples/css-examples/word-break.html
+++ b/live-examples/css-examples/word-break.html
@@ -1,0 +1,31 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="border-radius">
+
+    <div class="example-choice" initial-choice="true">
+        <pre><code id="example_one" class="language-css">word-break: normal;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice" initial-choice="true">
+        <pre><code id="example_two" class="language-css">word-break: break-all;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice" initial-choice="true">
+        <pre><code id="example_three" class="language-css">word-break: keep-all;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+      <div id="example-element" class="transition-all">Honorificabilitudinitatibus
+        次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉
+      </div>
+    </section>
+</div>

--- a/live-examples/css-examples/word-break.html
+++ b/live-examples/css-examples/word-break.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="border-radius">
+<section id="example-choice-list" class="example-choice-list large" data-property="word-break">
     <div class="example-choice" initial-choice="true">
         <pre><code id="example_one" class="language-css">word-break: normal;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">

--- a/site.json
+++ b/site.json
@@ -3257,6 +3257,15 @@
             "title": "CSS Demo: Transform",
             "type": "css"
         },
+        "word-break": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/css/word-break.css",
+            "exampleCode": "live-examples/css-examples/word-break.html",
+            "fileName": "word-break.html",
+            "title": "CSS Demo: Word Break",
+            "type": "css"
+        },
         "zIndex": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc": "../../live-examples/css-examples/css/z-index.css",


### PR DESCRIPTION
Proposing a simple example for the [word-break](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break) CSS property