### PR TITLE
Adding an interactive example for the opacity CSS property

### DIFF
--- a/live-examples/css-examples/css/opacity.css
+++ b/live-examples/css-examples/css/opacity.css
@@ -1,8 +1,4 @@
-#example-element-container {
-    border: 2px solid;
-    border-image: linear-gradient(90deg, white, turquoise) 1;
-}
-
 #example-element {
     background-color: turquoise;
+    padding: 1em;
 }

--- a/live-examples/css-examples/css/opacity.css
+++ b/live-examples/css-examples/css/opacity.css
@@ -1,0 +1,8 @@
+#example-element-container {
+    border: 2px solid;
+    border-image: linear-gradient(90deg, white, turquoise) 1;
+}
+
+#example-element {
+    background-color: turquoise;
+}

--- a/live-examples/css-examples/opacity.html
+++ b/live-examples/css-examples/opacity.html
@@ -1,6 +1,6 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="border-radius">
+<section id="example-choice-list" class="example-choice-list large" data-property="opacity">
 
-    <div class="example-choice" initial-choice="true">
+    <div class="example-choice">
         <pre><code id="example_one" class="language-css">opacity: 0;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
             <span class="visually-hidden">Copy to Clipboard</span>
@@ -12,7 +12,7 @@
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
-    <div class="example-choice" initial-choice="true">
+    <div class="example-choice">
         <pre><code id="example_three" class="language-css">opacity: 1;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
             <span class="visually-hidden">Copy to Clipboard</span>
@@ -24,9 +24,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
-      <div id="example-element-container">
-        <div id="example-element" class="transition-all">This is a text we might not see depending on the opacity.
-        </div>
-      </div>
+        <div id="example-element" class="transition-all">This is an element we might not see depending on the opacity.</div>
     </section>
 </div>

--- a/live-examples/css-examples/opacity.html
+++ b/live-examples/css-examples/opacity.html
@@ -1,0 +1,32 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="border-radius">
+
+    <div class="example-choice" initial-choice="true">
+        <pre><code id="example_one" class="language-css">opacity: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice" initial-choice="true">
+        <pre><code id="example_two" class="language-css">opacity: 0.33;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice" initial-choice="true">
+        <pre><code id="example_three" class="language-css">opacity: 1;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+      <div id="example-element-container">
+        <div id="example-element" class="transition-all">This is a text we might not see depending on the opacity.
+        </div>
+      </div>
+    </section>
+</div>

--- a/site.json
+++ b/site.json
@@ -3214,6 +3214,15 @@
             "title": "CSS Demo: Object Fit",
             "type": "css"
         },
+        "opacity": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/css/opacity.css",
+            "exampleCode": "live-examples/css-examples/opacity.html",
+            "fileName": "opacity.html",
+            "title": "CSS Demo: Opacity",
+            "type": "css"
+        },
         "position": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":


### PR DESCRIPTION
Adding an interactive example for the [opacity](https://developer.mozilla.org/en-US/docs/Web/CSS/opacity) CSS property