### PR TITLE
Add text-shadow example

### DIFF
--- a/live-examples/css-examples/css/text-shadow.css
+++ b/live-examples/css-examples/css/text-shadow.css
@@ -1,0 +1,4 @@
+p {
+    color: #352995;
+    font: 1.5em Georgia, serif;
+}

--- a/live-examples/css-examples/text-shadow.html
+++ b/live-examples/css-examples/text-shadow.html
@@ -1,0 +1,49 @@
+<section id="example-choice-list" class="example-choice-list" data-property="textShadow">
+<div class="example-choice">
+<pre><code id="example_one" class="language-css">text-shadow: 1px 1px 2px pink;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice" initial-choice="true">
+<pre><code id="example_two" class="language-css">text-shadow: #FC0 1px 0 10px;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_three" class="language-css">text-shadow: 5px 5px #558ABB;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_four" class="language-css">text-shadow: red 2px 5px;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_five" class="language-css">text-shadow: 5px 10px;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_six" class="language-css">text-shadow: 1px 1px 2px red, 0 0 1em blue, 0 0 0.2em blue;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <p id="example-element">Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy...</p>
+    </section>
+</div>

--- a/site.json
+++ b/site.json
@@ -3259,6 +3259,15 @@
             "title": "CSS Demo: Text Overflow",
             "type": "css"
         },
+        "textShadow": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/css/text-shadow.css",
+            "exampleCode": "live-examples/css-examples/text-shadow.html",
+            "fileName": "text-shadow.html",
+            "title": "CSS Demo: Text Shadow",
+            "type": "css"
+        },
         "transform": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "exampleCode": "live-examples/css-examples/transform.html",


### PR DESCRIPTION
The examples are taken more or less directly from the original page: https://developer.mozilla.org/en-US/docs/Web/CSS/text-shadow.