### PR TITLE
Update font-weight example

### DIFF
--- a/live-examples/css-examples/css/font-weight.css
+++ b/live-examples/css-examples/css/font-weight.css
@@ -1,0 +1,3 @@
+#output section {
+    font-size: 1.2em;
+}

--- a/live-examples/css-examples/font-weight.html
+++ b/live-examples/css-examples/font-weight.html
@@ -1,5 +1,5 @@
-<section id="example-choice-list" class="example-choice-list" data-property="fontWeight">
-<div class="example-choice">
+<section id="example-choice-list" class="example-choice-list" data-property="font-family">
+<div class="example-choice" initial-choice="true">
 <pre><code id="example_one" class="language-css">font-weight: normal;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -7,22 +7,36 @@
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">font-weight: 200;</code></pre>
+<pre><code id="example_two" class="language-css">font-weight: bold;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">font-weight: bold;</code></pre>
+<pre><code id="example_three" class="language-css">font-weight: lighter;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">font-weight: 900;</code></pre>
+<pre><code id="example_four" class="language-css">font-weight: bolder;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_five" class="language-css">font-weight: 100;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_six" class="language-css">font-weight: 900;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -30,6 +44,6 @@
 
 <div id="output" class="output hidden">
     <section id="default-example">
-        <span id="example-element" class="transition-all">Choose an examples to change the font weight.</span>
+        <p id="example-element">London. Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather. As much mud in the streets as if the waters had but newly retired from the face of the earth, and it would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine lizard up Holborn Hill.</p>
     </section>
 </div>

--- a/site.json
+++ b/site.json
@@ -3199,7 +3199,7 @@
         "fontWeight": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":
-                "../../live-examples/css-examples/css/fonts-base.css",
+                "../../live-examples/css-examples/css/font-weight.css",
             "exampleCode": "live-examples/css-examples/font-weight.html",
             "fileName": "font-weight.html",
             "title": "CSS Demo: Font Weight",


### PR DESCRIPTION
Added some more options, changed the text to be in line with the other `font` examples. I'm happy to use a different text, if you don't like this one :).

I wonder if we should use common CSS for related examples. I saw there was some work to support this already.
