### PR TITLE
Handle omitted data-property attribute

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,9 @@ Next, let's add the example CSS choices. Think of a few different ways that `bor
 </section>
 ```
 
-This will give us three different choices. Note that each choice gets its own ID: `example_one`, `example_two`, `example_three` and so on. You can choose which option will be shown at first by setting the `initial-choice` attribute to `true` (only one choice should have this).
+The first thing to note is that the `section` element has a `data-property` attribute whose value is the name of the property, `border-radius` in this case. The editor uses this to test whether the user's browser supports the property. If it doesn't, then an interactive example won't work, and we just display the CSS options without their output. If you know that the example property has good cross-browser support, you can omit this attribute (for example, the `border-radius` example could certainly omit it).
+
+Next, we have three `div` elements, one for each example CSS choice. Note that each choice gets its own ID: `example_one`, `example_two`, `example_three` and so on. You can choose which option will be shown at first by setting the `initial-choice` attribute to `true` (only one choice should have this).
 
 Now we've finished writing the HTML for the example. The final version of `border-radius.html` should look like this:
 

--- a/js/editor-libs/mce-utils.js
+++ b/js/editor-libs/mce-utils.js
@@ -41,13 +41,13 @@ module.exports = {
     isPropertySupported: function(dataset) {
         'use strict';
 
-        /* If there is no dataset, there is nothing to
-           test so, simply return true */
-        if (dataset === undefined) {
+        var property = dataset['property'];
+        /* If there are no 'property' attributes,
+           there is nothing to test, so return true. */
+        if (property === undefined) {
             return true;
         }
 
-        var property = dataset['property'];
         var tmpElem = document.createElement('div');
 
         return tmpElem.style[property] !== undefined;


### PR DESCRIPTION
The current`isPropertySupported` code checks whether the given `dataset` is undefined, and skips the check if it is.

But actually if no `data-` attributes are given, then `dataset` will be an empty map, which will end up making the function return `false`.

This change should instead make the code check whether `dataset` contains a `property` property, and return `true` if it doesn't - so omitting `data-property` means all browsers support it.

I've also updated CONTRIBUTING.md to talk a bit about this attribute.