### PR TITLE
Fix case in Object example titles

### DIFF
--- a/site.json
+++ b/site.json
@@ -2008,7 +2008,7 @@
             "exampleCode":
                 "live-examples/js-examples/object-prototype-tostring.html",
             "fileName": "object-prototype-tostring.html",
-            "title": "JavaScript Demo: Object.prototype.tostring()",
+            "title": "JavaScript Demo: Object.prototype.toString()",
             "type": "js"
         },
         "objectPrototypeValueOf": {
@@ -2016,7 +2016,7 @@
             "exampleCode":
                 "live-examples/js-examples/object-prototype-valueof.html",
             "fileName": "object-prototype-valueof.html",
-            "title": "JavaScript Demo: Object.prototype.valueof()",
+            "title": "JavaScript Demo: Object.prototype.valueOf()",
             "type": "js"
         },
         "objectValues": {


### PR DESCRIPTION
Same errors as in https://github.com/mdn/interactive-examples/pull/383, but for Object:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString