### PR TITLE
Fix parameter ordering Math.atan2 example

### DIFF
--- a/live-examples/js-examples/math-atan2.html
+++ b/live-examples/js-examples/math-atan2.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">function calcAngleDegrees(y, x) {
+<code id="static-js">function calcAngleDegrees(x, y) {
   return Math.atan2(y, x) * 180 / Math.PI;
 }
 
@@ -9,7 +9,7 @@ console.log(calcAngleDegrees(5, 5));
 console.log(calcAngleDegrees(10, 10));
 //expected output: 45
 
-console.log(calcAngleDegrees(10, 0));
+console.log(calcAngleDegrees(0, 10));
 //expected output: 90
 </code>
 </pre>

--- a/live-examples/js-examples/math-atan2.html
+++ b/live-examples/js-examples/math-atan2.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">function calcAngleDegrees(x, y) {
-  return Math.atan2(x, y) * 180 / Math.PI;
+<code id="static-js">function calcAngleDegrees(y, x) {
+  return Math.atan2(y, x) * 180 / Math.PI;
 }
 
 console.log(calcAngleDegrees(5, 5));


### PR DESCRIPTION
Small tweak:
Math.atan2 takes parameters in the order `(y, x)`.
I'm updating the example to show that:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2
I think that's how it should be at least 😅 