### PR TITLE
fix case for titles

### DIFF
--- a/site.json
+++ b/site.json
@@ -1316,7 +1316,7 @@
             "exampleCode":
                 "live-examples/js-examples/map-prototype-@@iterator.html",
             "fileName": "map-prototype-@@iterator.html",
-            "title": "JavaScript Demo: map.prototype[@@iterator]()",
+            "title": "JavaScript Demo: Map.prototype[@@iterator]()",
             "type": "js"
         },
         "mapPrototype@@ToStringTag": {
@@ -1324,14 +1324,14 @@
             "exampleCode":
                 "live-examples/js-examples/map-prototype-@@tostringtag.html",
             "fileName": "map-prototype-@@tostringtag.html",
-            "title": "JavaScript Demo: map.prototype[@@toStringTag]",
+            "title": "JavaScript Demo: Map.prototype[@@toStringTag]",
             "type": "js"
         },
         "mapPrototypeClear": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/map-prototype-clear.html",
             "fileName": "map-prototype-clear.html",
-            "title": "JavaScript Demo: map.prototype.clear()",
+            "title": "JavaScript Demo: Map.prototype.clear()",
             "type": "js"
         },
         "mapPrototypeDelete": {
@@ -1339,7 +1339,7 @@
             "exampleCode":
                 "live-examples/js-examples/map-prototype-delete.html",
             "fileName": "map-prototype-delete.html",
-            "title": "JavaScript Demo: map.prototype.delete()",
+            "title": "JavaScript Demo: Map.prototype.delete()",
             "type": "js"
         },
         "mapPrototypeEntries": {
@@ -1347,7 +1347,7 @@
             "exampleCode":
                 "live-examples/js-examples/map-prototype-entries.html",
             "fileName": "map-prototype-entries.html",
-            "title": "JavaScript Demo: map.prototype.entries()",
+            "title": "JavaScript Demo: Map.prototype.entries()",
             "type": "js"
         },
         "mapPrototypeForEach": {
@@ -1355,42 +1355,42 @@
             "exampleCode":
                 "live-examples/js-examples/map-prototype-foreach.html",
             "fileName": "map-prototype-foreach.html",
-            "title": "JavaScript Demo: map.prototype.foreach()",
+            "title": "JavaScript Demo: Map.prototype.forEach()",
             "type": "js"
         },
         "mapPrototypeGet": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/map-prototype-get.html",
             "fileName": "map-prototype-get.html",
-            "title": "JavaScript Demo: map.prototype.get()",
+            "title": "JavaScript Demo: Map.prototype.get()",
             "type": "js"
         },
         "mapPrototypeHas": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/map-prototype-has.html",
             "fileName": "map-prototype-has.html",
-            "title": "JavaScript Demo: map.prototype.has()",
+            "title": "JavaScript Demo: Map.prototype.has()",
             "type": "js"
         },
         "mapPrototypeKeys": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/map-prototype-keys.html",
             "fileName": "map-prototype-keys.html",
-            "title": "JavaScript Demo: map.prototype.keys()",
+            "title": "JavaScript Demo: Map.prototype.keys()",
             "type": "js"
         },
         "mapPrototypeSet": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/map-prototype-set.html",
             "fileName": "map-prototype-set.html",
-            "title": "JavaScript Demo: map.prototype.set()",
+            "title": "JavaScript Demo: Map.prototype.set()",
             "type": "js"
         },
         "mapPrototypeSize": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/map-prototype-size.html",
             "fileName": "map-prototype-size.html",
-            "title": "JavaScript Demo: map.prototype.size",
+            "title": "JavaScript Demo: Map.prototype.size",
             "type": "js"
         },
         "mapPrototypeValues": {
@@ -1398,7 +1398,7 @@
             "exampleCode":
                 "live-examples/js-examples/map-prototype-values.html",
             "fileName": "map-prototype-values.html",
-            "title": "JavaScript Demo: map.prototype.values",
+            "title": "JavaScript Demo: Map.prototype.values",
             "type": "js"
         },
         "mathAbs": {
@@ -2458,7 +2458,7 @@
             "exampleCode":
                 "live-examples/js-examples/set-prototype-foreach.html",
             "fileName": "set-prototype-foreach.html",
-            "title": "JavaScript Demo: Set.prototype.foreach()",
+            "title": "JavaScript Demo: Set.prototype.forEach()",
             "type": "js"
         },
         "setPrototypeHas": {
@@ -2709,7 +2709,7 @@
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/symbol-keyfor.html",
             "fileName": "symbol-keyfor.html",
-            "title": "JavaScript Demo: Symbol.keyfor()",
+            "title": "JavaScript Demo: Symbol.keyFor()",
             "type": "js"
         },
         "symbolMatch": {


### PR DESCRIPTION
`map` -> `Map`
`foreach` -> `forEach`
`keyfor` -> `keyFor`