### PR TITLE
Fix case for titles of Expressions examples

### DIFF
--- a/site.json
+++ b/site.json
@@ -818,7 +818,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-bitwiseoperators.html",
             "fileName": "expressions-bitwiseoperators.html",
-            "title": "JavaScript Demo: Expressions - Bitwise Operators",
+            "title": "JavaScript Demo: Expressions - Bitwise operators",
             "type": "js"
         },
         "expressionsClassExpression": {
@@ -826,7 +826,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-classexpression.html",
             "fileName": "expressions-classexpression.html",
-            "title": "JavaScript Demo: Expressions - Class Expression",
+            "title": "JavaScript Demo: Expressions - class expression",
             "type": "js"
         },
         "expressionsCommaOperators": {
@@ -834,7 +834,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-commaoperators.html",
             "fileName": "expressions-commaoperators.html",
-            "title": "JavaScript Demo: Expressions - Comma Operators",
+            "title": "JavaScript Demo: Expressions - Comma operator",
             "type": "js"
         },
         "expressionsComparisonOperators": {
@@ -842,7 +842,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-comparisonoperators.html",
             "fileName": "expressions-comparisonoperators.html",
-            "title": "JavaScript Demo: Expressions - Comparison Operators",
+            "title": "JavaScript Demo: Expressions - Comparison operators",
             "type": "js"
         },
         "expressionsConditionalOperators": {
@@ -850,7 +850,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-conditionaloperators.html",
             "fileName": "expressions-conditionaloperators.html",
-            "title": "JavaScript Demo: Expressions - Conditional Operators",
+            "title": "JavaScript Demo: Expressions - Conditional operator",
             "type": "js"
         },
         "expressionsDeleteOperator": {
@@ -858,7 +858,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-deleteoperator.html",
             "fileName": "expressions-deleteoperator.html",
-            "title": "JavaScript Demo: Expressions - Delete Operator",
+            "title": "JavaScript Demo: Expressions - delete operator",
             "type": "js"
         },
         "expressionsDestructuringAssignment": {
@@ -866,7 +866,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-destructuringassignment.html",
             "fileName": "expressions-destructuringassignment.html",
-            "title": "JavaScript Demo: Expressions - Destructuring Assignment",
+            "title": "JavaScript Demo: Expressions - Destructuring assignment",
             "type": "js"
         },
         "expressionsFunctionAsteriskExpression": {
@@ -874,7 +874,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-functionasteriskexpression.html",
             "fileName": "expressions-functionasteriskexpression.html",
-            "title": "JavaScript Demo: Expressions - Function* Expression",
+            "title": "JavaScript Demo: Expressions - function* expression",
             "type": "js"
         },
         "expressionsFunctionExpression": {
@@ -882,7 +882,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-functionexpression.html",
             "fileName": "expressions-functionexpression.html",
-            "title": "JavaScript Demo: Expressions - Function Expression",
+            "title": "JavaScript Demo: Expressions - function expression",
             "type": "js"
         },
         "expressionsGroupingOperator": {
@@ -890,7 +890,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-groupingoperator.html",
             "fileName": "expressions-groupingoperator.html",
-            "title": "JavaScript Demo: Expressions - Grouping Operator",
+            "title": "JavaScript Demo: Expressions - Grouping operator",
             "type": "js"
         },
         "expressionsInOperator": {
@@ -898,7 +898,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-inoperator.html",
             "fileName": "expressions-inoperator.html",
-            "title": "JavaScript Demo: Expressions - In Operator",
+            "title": "JavaScript Demo: Expressions - in operator",
             "type": "js"
         },
         "expressionsInstanceof": {
@@ -906,7 +906,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-instanceof.html",
             "fileName": "expressions-instanceof.html",
-            "title": "JavaScript Demo: Expressions - Instanceof",
+            "title": "JavaScript Demo: Expressions - instanceof",
             "type": "js"
         },
         "expressionsLogicalOperator": {
@@ -914,7 +914,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-logicaloperator.html",
             "fileName": "expressions-logicaloperator.html",
-            "title": "JavaScript Demo: Expressions - Logical Operator",
+            "title": "JavaScript Demo: Expressions - Logical operator",
             "type": "js"
         },
         "expressionsNewOperator": {
@@ -922,7 +922,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-newoperator.html",
             "fileName": "expressions-newoperator.html",
-            "title": "JavaScript Demo: Expressions - New Operator",
+            "title": "JavaScript Demo: Expressions - new operator",
             "type": "js"
         },
         "expressionsNewTarget": {
@@ -930,7 +930,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-newtarget.html",
             "fileName": "expressions-newtarget.html",
-            "title": "JavaScript Demo: Expressions - New Target",
+            "title": "JavaScript Demo: Expressions - new.target",
             "type": "js"
         },
         "expressionsObjectInitializer": {
@@ -938,7 +938,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-objectinitializer.html",
             "fileName": "expressions-objectinitializer.html",
-            "title": "JavaScript Demo: Expressions - Object Initializer",
+            "title": "JavaScript Demo: Expressions - Object initializer",
             "type": "js"
         },
         "expressionsOperatorPrecedence": {
@@ -946,7 +946,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-operatorprecedence.html",
             "fileName": "expressions-operatorprecedence.html",
-            "title": "JavaScript Demo: Expressions - Operator Precedence",
+            "title": "JavaScript Demo: Expressions - Operator precedence",
             "type": "js"
         },
         "expressionsPropertyAccessors": {
@@ -954,7 +954,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-propertyaccessors.html",
             "fileName": "expressions-propertyaccessors.html",
-            "title": "JavaScript Demo: Expressions - Property Accessors",
+            "title": "JavaScript Demo: Expressions - Property accessors",
             "type": "js"
         },
         "expressionsSpreadSyntax": {
@@ -962,21 +962,21 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-spreadsyntax.html",
             "fileName": "expressions-spreadsyntax.html",
-            "title": "JavaScript Demo: Expressions - Spread Syntax",
+            "title": "JavaScript Demo: Expressions - Spread syntax",
             "type": "js"
         },
         "expressionsThis": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/expressions-this.html",
             "fileName": "expressions-this.html",
-            "title": "JavaScript Demo: Expressions - This",
+            "title": "JavaScript Demo: Expressions - this",
             "type": "js"
         },
         "expressionsTypeof": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/expressions-typeof.html",
             "fileName": "expressions-typeof.html",
-            "title": "JavaScript Demo: Expressions - Typeof",
+            "title": "JavaScript Demo: Expressions - typeof",
             "type": "js"
         },
         "expressionsVoidOperator": {
@@ -984,14 +984,14 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-voidoperator.html",
             "fileName": "expressions-voidoperator.html",
-            "title": "JavaScript Demo: Expressions - Void Operator",
+            "title": "JavaScript Demo: Expressions - void operator",
             "type": "js"
         },
         "expressionsYield": {
             "baseTmpl": "tmpl/live-js-tmpl.html",
             "exampleCode": "live-examples/js-examples/expressions-yield.html",
             "fileName": "expressions-yield.html",
-            "title": "JavaScript Demo: Expressions - Yield",
+            "title": "JavaScript Demo: Expressions - yield",
             "type": "js"
         },
         "expressionsYieldAsterisk": {
@@ -999,7 +999,7 @@
             "exampleCode":
                 "live-examples/js-examples/expressions-yieldasterisk.html",
             "fileName": "expressions-yieldasterisk.html",
-            "title": "JavaScript Demo: Expressions - Yield*",
+            "title": "JavaScript Demo: Expressions - yield*",
             "type": "js"
         },
         "functionApply": {


### PR DESCRIPTION
This adjusts the case of the titles used for ["Expressions and Operators"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators) examples, basically to match the title of the document.

This means:

* preserve case for keywords (`yield` not `Yield`)
* sentence case otherwise (`Operator precedence` not `Operator Precedence`)

I'm happy to discuss this if you disagree, but this seems like the best approach to me.

(I think we should do the same for CSS too - i.e. `box-shadow` not `Box Shadow`.)