### PR TITLE
Creating an example for the sepia filter function

### DIFF
--- a/live-examples/css-examples/sepia.html
+++ b/live-examples/css-examples/sepia.html
@@ -1,0 +1,27 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="filter">
+<div class="example-choice" initial-choice="true">
+<pre><code id="example_one" class="language-css">filter: sepia(60%);</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_two" class="language-css">filter: sepia(0.20);</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_three" class="language-css">filter: sepia(0.80);</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div id="output" class="output large hidden">
+    <section id="default-example">
+        <img id="example-element" src="../../media/examples/firefox-logo.svg" width="200" />
+    </section>
+</div>

--- a/live-examples/css-examples/sepia.html
+++ b/live-examples/css-examples/sepia.html
@@ -19,6 +19,7 @@
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
+</section>
 
 <div id="output" class="output large hidden">
     <section id="default-example">

--- a/site.json
+++ b/site.json
@@ -3272,6 +3272,13 @@
             "title": "CSS Demo: Position",
             "type": "css"
         },
+        "sepia": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "exampleCode": "live-examples/css-examples/sepia.html",
+            "fileName": "sepia.html",
+            "title": "CSS Demo: sepia()",
+            "type": "css"
+        },
         "textAlign": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":


### PR DESCRIPTION
Shamelessly using the existing `filter` interactive example to create an example for https://developer.mozilla.org/fr/docs/Web/CSS/filter-function/sepia