### PR TITLE
Disables interactive examples for the currently disabled SharedArrayBuffer

### DIFF
--- a/js/editor-libs/feature-detector.js
+++ b/js/editor-libs/feature-detector.js
@@ -11,6 +11,8 @@ function getFeatureObject(feature) {
     case 'array-entries':
         featureObj = Array.prototype.entries;
         break;
+    case 'shared-array-buffer':
+        featureObj = window.SharedArrayBuffer;
     }
 
     return featureObj;

--- a/live-examples/js-examples/sharedarraybuffer-bytelength.html
+++ b/live-examples/js-examples/sharedarraybuffer-bytelength.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">// create a SharedArrayBuffer with a size in bytes
+<code id="static-js" data-feature="shared-array-buffer">// create a SharedArrayBuffer with a size in bytes
 const buffer = new SharedArrayBuffer(8);
 
 console.log(buffer.byteLength);

--- a/live-examples/js-examples/sharedarraybuffer-constructor.html
+++ b/live-examples/js-examples/sharedarraybuffer-constructor.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">// create a SharedArrayBuffer with a size in bytes
+<code id="static-js" data-feature="shared-array-buffer">// create a SharedArrayBuffer with a size in bytes
 const buffer = new SharedArrayBuffer(8);
 
 console.log(buffer.byteLength);

--- a/live-examples/js-examples/sharedarraybuffer-slice.html
+++ b/live-examples/js-examples/sharedarraybuffer-slice.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">// create a SharedArrayBuffer with a size in bytes
+<code id="static-js" data-feature="shared-array-buffer">// create a SharedArrayBuffer with a size in bytes
 const buffer = new SharedArrayBuffer(16);
 const int32View = new Int32Array(buffer); // create the view
 // produces Int32Array [0, 0, 0, 0]


### PR DESCRIPTION
@wbamberg This uses the `featureDetector` to disable `SharedArrayBuffer` interactive examples. Currently this is disabled because of Spectre. There is a message about it on the relevant pages. These examples will start working again once browser vendors have resolved the Spectre issue.

Is this worth doing, or do you feel like we should keep the live examples? Currently clicking run will result in a message of:

`Error: SharedArrayBuffer is not defined`
