### PR TITLE
Fix CSS example titles; update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,9 +181,12 @@ Copy and paste the example then update it to apply to your new example, noting t
     "cssExampleSrc": "../../live-examples/css-examples/css/border-radius.css",
     "exampleCode": "live-examples/css-examples/border-radius.html",
     "fileName": "border-radius.html",
+    "title": "CSS Demo: border-radius"
     "type": "css"
 },
 ```
+
+The `title` property is displayed above the editor, and should be of the form: "CSS Demo: {item}", where {item} is the name of the item that the example is for. If you're not sure what to use for {item}, use the title of the page.
 
 ### Testing
 All that remains is to test that your page generates and displays as intended, then open a pull request for review.
@@ -249,6 +252,8 @@ You entry will look something like the following when edited:
     "type": "js"
 },
 ```
+
+The `title` property is displayed above the editor, and should be of the form: "JavaScript Demo: {item}", where {item} is the name of the item that the example is for. If you're not sure what to use for {item}, use the title of the page.
 
 ### Testing
 From your command line run:

--- a/site.json
+++ b/site.json
@@ -3061,7 +3061,7 @@
                 "../../live-examples/css-examples/css/animation.css",
             "exampleCode": "live-examples/css-examples/animation.html",
             "fileName": "animation.html",
-            "title": "CSS Demo: Animation",
+            "title": "CSS Demo: animation",
             "type": "css"
         },
         "backgroundClip": {
@@ -3070,7 +3070,7 @@
                 "../../live-examples/css-examples/css/background-clip.css",
             "exampleCode": "live-examples/css-examples/background-clip.html",
             "fileName": "background-clip.html",
-            "title": "CSS Demo: Background Clip",
+            "title": "CSS Demo: background-clip",
             "type": "css"
         },
         "backgroundColor": {
@@ -3079,7 +3079,7 @@
                 "../../live-examples/css-examples/css/background-color.css",
             "exampleCode": "live-examples/css-examples/background-color.html",
             "fileName": "background-color.html",
-            "title": "CSS Demo: Background Color",
+            "title": "CSS Demo: background-color",
             "type": "css"
         },
         "backgroundImage": {
@@ -3088,7 +3088,7 @@
                 "../../live-examples/css-examples/css/background-image.css",
             "exampleCode": "live-examples/css-examples/background-image.html",
             "fileName": "background-image.html",
-            "title": "CSS Demo: Background Image",
+            "title": "CSS Demo: background-image",
             "type": "css"
         },
         "backgroundPosition": {
@@ -3098,7 +3098,7 @@
             "exampleCode":
                 "live-examples/css-examples/background-position.html",
             "fileName": "background-position.html",
-            "title": "CSS Demo: Background Position",
+            "title": "CSS Demo: background-position",
             "type": "css"
         },
         "backgroundRepeat": {
@@ -3107,7 +3107,7 @@
                 "../../live-examples/css-examples/css/background-repeat.css",
             "exampleCode": "live-examples/css-examples/background-repeat.html",
             "fileName": "background-repeat.html",
-            "title": "CSS Demo: Background Repeat",
+            "title": "CSS Demo: background-repeat",
             "type": "css"
         },
         "backgroundSize": {
@@ -3116,7 +3116,7 @@
                 "../../live-examples/css-examples/css/background-size.css",
             "exampleCode": "live-examples/css-examples/background-size.html",
             "fileName": "background-size.html",
-            "title": "CSS Demo: Background Size",
+            "title": "CSS Demo: background-size",
             "type": "css"
         },
         "borderImage": {
@@ -3125,7 +3125,7 @@
                 "../../live-examples/css-examples/css/border-image.css",
             "exampleCode": "live-examples/css-examples/border-image.html",
             "fileName": "border-image.html",
-            "title": "CSS Demo: Background Image",
+            "title": "CSS Demo: border-image",
             "type": "css"
         },
         "borderStyle": {
@@ -3134,7 +3134,7 @@
                 "../../live-examples/css-examples/css/border-style.css",
             "exampleCode": "live-examples/css-examples/border-style.html",
             "fileName": "border-style.html",
-            "title": "CSS Demo: Border Style",
+            "title": "CSS Demo: border-style",
             "type": "css"
         },
         "borderTopColor": {
@@ -3143,7 +3143,7 @@
                 "../../live-examples/css-examples/css/border-top-color.css",
             "exampleCode": "live-examples/css-examples/border-top-color.html",
             "fileName": "border-top-color.html",
-            "title": "CSS Demo: Border Top Color",
+            "title": "CSS Demo: border-top-color",
             "type": "css"
         },
         "boxShadow": {
@@ -3152,7 +3152,7 @@
                 "../../live-examples/css-examples/css/box-shadow.css",
             "exampleCode": "live-examples/css-examples/box-shadow.html",
             "fileName": "box-shadow.html",
-            "title": "CSS Demo: Box Shadow",
+            "title": "CSS Demo: box-shadow",
             "type": "css"
         },
         "boxSizing": {
@@ -3161,7 +3161,7 @@
                 "../../live-examples/css-examples/css/box-sizing.css",
             "exampleCode": "live-examples/css-examples/box-sizing.html",
             "fileName": "box-sizing.html",
-            "title": "CSS Demo: Box Sizing",
+            "title": "CSS Demo: box-sizing",
             "type": "css"
         },
         "color": {
@@ -3169,14 +3169,14 @@
             "cssExampleSrc": "../../live-examples/css-examples/css/color.css",
             "exampleCode": "live-examples/css-examples/color.html",
             "fileName": "color.html",
-            "title": "CSS Demo: Color",
+            "title": "CSS Demo: color",
             "type": "css"
         },
         "filter": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "exampleCode": "live-examples/css-examples/filter.html",
             "fileName": "filter.html",
-            "title": "CSS Demo: Filter",
+            "title": "CSS Demo: filter",
             "type": "css"
         },
         "font": {
@@ -3184,7 +3184,7 @@
             "cssExampleSrc": "../../live-examples/css-examples/css/font.css",
             "exampleCode": "live-examples/css-examples/font.html",
             "fileName": "font.html",
-            "title": "CSS Demo: Font",
+            "title": "CSS Demo: font",
             "type": "css"
         },
         "fontFamily": {
@@ -3192,7 +3192,7 @@
             "cssExampleSrc": "../../live-examples/css-examples/css/font-family.css",
             "exampleCode": "live-examples/css-examples/font-family.html",
             "fileName": "font-family.html",
-            "title": "CSS Demo: Font Family",
+            "title": "CSS Demo: font-family",
             "type": "css"
         },
         "fontStyle": {
@@ -3201,7 +3201,7 @@
                 "../../live-examples/css-examples/css/font-style.css",
             "exampleCode": "live-examples/css-examples/font-style.html",
             "fileName": "font-style.html",
-            "title": "CSS Demo: Font Style",
+            "title": "CSS Demo: font-style",
             "type": "css"
         },
         "fontWeight": {
@@ -3210,7 +3210,7 @@
                 "../../live-examples/css-examples/css/font-weight.css",
             "exampleCode": "live-examples/css-examples/font-weight.html",
             "fileName": "font-weight.html",
-            "title": "CSS Demo: Font Weight",
+            "title": "CSS Demo: font-weight",
             "type": "css"
         },
         "margin": {
@@ -3219,7 +3219,7 @@
                 "../../live-examples/css-examples/css/margin.css",
             "exampleCode": "live-examples/css-examples/margin.html",
             "fileName": "margin.html",
-            "title": "CSS Demo: Margin",
+            "title": "CSS Demo: margin",
             "type": "css"
         },
         "objectFit": {
@@ -3228,7 +3228,7 @@
                 "../../live-examples/css-examples/css/object-fit.css",
             "exampleCode": "live-examples/css-examples/object-fit.html",
             "fileName": "object-fit.html",
-            "title": "CSS Demo: Object Fit",
+            "title": "CSS Demo: object-fit",
             "type": "css"
         },
         "opacity": {
@@ -3237,7 +3237,7 @@
                 "../../live-examples/css-examples/css/opacity.css",
             "exampleCode": "live-examples/css-examples/opacity.html",
             "fileName": "opacity.html",
-            "title": "CSS Demo: Opacity",
+            "title": "CSS Demo: opacity",
             "type": "css"
         },
         "padding": {
@@ -3246,7 +3246,7 @@
                 "../../live-examples/css-examples/css/padding.css",
             "exampleCode": "live-examples/css-examples/padding.html",
             "fileName": "padding.html",
-            "title": "CSS Demo: Padding",
+            "title": "CSS Demo: padding",
             "type": "css"
         },
         "position": {
@@ -3255,7 +3255,7 @@
                 "../../live-examples/css-examples/css/position.css",
             "exampleCode": "live-examples/css-examples/position.html",
             "fileName": "position.html",
-            "title": "CSS Demo: Position",
+            "title": "CSS Demo: position",
             "type": "css"
         },
         "textAlign": {
@@ -3264,7 +3264,7 @@
                 "../../live-examples/css-examples/css/fonts-base.css",
             "exampleCode": "live-examples/css-examples/text-align.html",
             "fileName": "text-align.html",
-            "title": "CSS Demo: Text Align",
+            "title": "CSS Demo: text-align",
             "type": "css"
         },
         "textDecoration": {
@@ -3273,7 +3273,7 @@
                 "../../live-examples/css-examples/css/text-decoration.css",
             "exampleCode": "live-examples/css-examples/text-decoration.html",
             "fileName": "text-decoration.html",
-            "title": "CSS Demo: Text Decoration",
+            "title": "CSS Demo: text-decoration",
             "type": "css"
         },
         "textDecorationSkipInk": {
@@ -3282,7 +3282,7 @@
                 "../../live-examples/css-examples/css/text-decoration-skip-ink.css",
             "exampleCode": "live-examples/css-examples/text-decoration-skip-ink.html",
             "fileName": "text-decoration-skip-ink.html",
-            "title": "CSS Demo: Text Decoration Skip Ink",
+            "title": "CSS Demo: text-decoration-skip-ink",
             "type": "css"
         },
         "textOverflow": {
@@ -3291,7 +3291,7 @@
                 "../../live-examples/css-examples/css/text-overflow.css",
             "exampleCode": "live-examples/css-examples/text-overflow.html",
             "fileName": "text-overflow.html",
-            "title": "CSS Demo: Text Overflow",
+            "title": "CSS Demo: text-overflow",
             "type": "css"
         },
         "textShadow": {
@@ -3300,14 +3300,14 @@
                 "../../live-examples/css-examples/css/text-shadow.css",
             "exampleCode": "live-examples/css-examples/text-shadow.html",
             "fileName": "text-shadow.html",
-            "title": "CSS Demo: Text Shadow",
+            "title": "CSS Demo: text-shadow",
             "type": "css"
         },
         "transform": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "exampleCode": "live-examples/css-examples/transform.html",
             "fileName": "transform.html",
-            "title": "CSS Demo: Transform",
+            "title": "CSS Demo: transform",
             "type": "css"
         },
         "word-break": {
@@ -3316,7 +3316,7 @@
                 "../../live-examples/css-examples/css/word-break.css",
             "exampleCode": "live-examples/css-examples/word-break.html",
             "fileName": "word-break.html",
-            "title": "CSS Demo: Word Break",
+            "title": "CSS Demo: word-break",
             "type": "css"
         },
         "zIndex": {
@@ -3324,7 +3324,7 @@
             "cssExampleSrc": "../../live-examples/css-examples/css/z-index.css",
             "exampleCode": "live-examples/css-examples/z-index.html",
             "fileName": "z-index.html",
-            "title": "CSS Demo: Z-Index",
+            "title": "CSS Demo: z-index",
             "type": "css"
         }
     }


### PR DESCRIPTION
As discussed in https://github.com/mdn/interactive-examples/pull/412, let's use keywords for titles. I've also updated the docs to talk a little about the `title` property. Note also that one of the titles had the wrong content.
