### PR TITLE
Add line-height CSS example

### DIFF
--- a/live-examples/css-examples/css/line-height.css
+++ b/live-examples/css-examples/css/line-height.css
@@ -1,0 +1,4 @@
+#example-element {
+    font-family: Georgia, sans-serif;
+    max-width: 200px;
+}

--- a/live-examples/css-examples/line-height.html
+++ b/live-examples/css-examples/line-height.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="padding">
+<section id="example-choice-list" class="example-choice-list large" data-property="lineHeight">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">line-height: normal;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">

--- a/live-examples/css-examples/line-height.html
+++ b/live-examples/css-examples/line-height.html
@@ -1,0 +1,43 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="padding">
+<div class="example-choice">
+<pre><code id="example_one" class="language-css">line-height: normal;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_two" class="language-css">line-height: 2.5;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_three" class="language-css">line-height: 3em;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_four" class="language-css">line-height: 150%;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_five" class="language-css">line-height: 32px;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example">
+        <div class="transition-all" id="example-element">Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a small unregarded yellow sun.</div>
+    </section>
+</div>

--- a/site.json
+++ b/site.json
@@ -3324,6 +3324,15 @@
             "title": "CSS Demo: font-weight",
             "type": "css"
         },
+		"lineHeight": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/css/line-height.css",
+            "exampleCode": "live-examples/css-examples/line-height.html",
+            "fileName": "line-height.html",
+            "title": "CSS Demo: line-height",
+            "type": "css"
+        },
         "margin": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":


### PR DESCRIPTION
Fixes: CSS examples: need example for line-height #466 

![image](https://user-images.githubusercontent.com/5341898/35468645-5181bdd8-02d7-11e8-95e5-7c9d4dd0be25.png)
