### PR TITLE
Add text-decoration-line CSS example

### DIFF
--- a/live-examples/css-examples/css/text-decoration-line.css
+++ b/live-examples/css-examples/css/text-decoration-line.css
@@ -1,0 +1,4 @@
+p {
+    font: 1.5em sans-serif;
+    color: #352995;
+}

--- a/live-examples/css-examples/text-decoration-line.html
+++ b/live-examples/css-examples/text-decoration-line.html
@@ -1,0 +1,49 @@
+<section id="example-choice-list" class="example-choice-list" data-property="textDecorationLine">
+<div class="example-choice">
+<pre><code id="example_one" class="language-css">text-decoration-line: none;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice" initial-choice="true">
+<pre><code id="example_two" class="language-css">text-decoration-line: underline;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_three" class="language-css">text-decoration-line: overline;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_four" class="language-css">text-decoration-line: line-through;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_five" class="language-css">text-decoration-line: underline overline;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_six" class="language-css">text-decoration-line: underline line-through;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <p>I'd far rather be <span id="example-element" class="transition-all">happy than right</span> any day.</p>
+    </section>
+</div>

--- a/site.json
+++ b/site.json
@@ -3403,6 +3403,15 @@
             "title": "CSS Demo: text-decoration",
             "type": "css"
         },
+        "textDecorationLine": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/css/text-decoration-line.css",
+            "exampleCode": "live-examples/css-examples/text-decoration-line.html",
+            "fileName": "text-decoration-line.html",
+            "title": "CSS Demo: text-decoration-line",
+            "type": "css"
+        },
         "textDecorationSkipInk": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":


### PR DESCRIPTION
Fixes: #477 reusing some code from `text-decoration`. Didn't include deprecated `blink` and set `underline` as the default.

![image](https://user-images.githubusercontent.com/5341898/35476172-757efd34-0360-11e8-8fe0-242e4025dcca.png)



