### PR TITLE
Fixed some (all?) `data-clipboard-target` for CSS examples

### DIFF
--- a/live-examples/css-examples/filter.html
+++ b/live-examples/css-examples/filter.html
@@ -15,28 +15,28 @@
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">filter: contrast(200%);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">filter: grayscale(80%);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_five" class="language-css">filter: hue-rotate(90deg);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">filter: drop-shadow(16px 16px 20px red) invert(75%);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_ten">
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/font-family.html
+++ b/live-examples/css-examples/font-family.html
@@ -22,21 +22,21 @@
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">font-family: serif;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
-    <span class="visually-hidden">Copy to Clipboard</span>
-</button>
-</div>
-
-<div class="example-choice">
-<pre><code id="example_five" class="language-css">font-family: cursive;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">font-family: system-ui;</code></pre>
+<pre><code id="example_five" class="language-css">font-family: cursive;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_six" class="language-css">font-family: system-ui;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/font-weight.html
+++ b/live-examples/css-examples/font-weight.html
@@ -22,21 +22,21 @@
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">font-weight: bolder;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
-    <span class="visually-hidden">Copy to Clipboard</span>
-</button>
-</div>
-
-<div class="example-choice">
-<pre><code id="example_five" class="language-css">font-weight: 100;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">font-weight: 900;</code></pre>
+<pre><code id="example_five" class="language-css">font-weight: 100;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_six" class="language-css">font-weight: 900;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/position.html
+++ b/live-examples/css-examples/position.html
@@ -10,7 +10,7 @@
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">position: relative;
 top: 65px; left: 65px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -18,7 +18,7 @@ top: 65px; left: 65px;</code></pre>
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">position: absolute;
 top: 40px; left: 40px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/text-decoration.html
+++ b/live-examples/css-examples/text-decoration.html
@@ -29,7 +29,7 @@
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">text-decoration: underline overline #FF3028;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/text-shadow.html
+++ b/live-examples/css-examples/text-shadow.html
@@ -29,14 +29,14 @@
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">text-shadow: 5px 10px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">text-shadow: 1px 1px 2px red, 0 0 1em blue, 0 0 0.2em blue;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/transform.html
+++ b/live-examples/css-examples/transform.html
@@ -36,7 +36,7 @@
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">transform: scale(0.5) translate(-100%, -100%);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_seven">
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>


### PR DESCRIPTION
Easy to overlook, and I bet someone or myself will be making this oopsie down the road. Maybe should be automated or tested for?

![image](https://user-images.githubusercontent.com/5341898/35468913-ffd92b40-02dd-11e8-9944-e7137e96edb9.png)
