### PR TITLE
Add text-decoration-style CSS example

### DIFF
--- a/live-examples/css-examples/css/text-decoration-style.css
+++ b/live-examples/css-examples/css/text-decoration-style.css
@@ -1,0 +1,8 @@
+p {
+    font: 1.5em sans-serif;
+    color: #352995;
+}
+
+#example-element {
+	text-decoration-line: underline;
+}

--- a/live-examples/css-examples/text-decoration-style.html
+++ b/live-examples/css-examples/text-decoration-style.html
@@ -1,0 +1,42 @@
+<section id="example-choice-list" class="example-choice-list" data-property="textDecorationStyle">
+<div class="example-choice">
+<pre><code id="example_one" class="language-css">text-decoration-style: solid;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_two" class="language-css">text-decoration-style: double;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_three" class="language-css">text-decoration-style: dotted;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_four" class="language-css">text-decoration-style: dashed;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code id="example_five" class="language-css">text-decoration-style: wavy;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <p>I'd far rather be <span id="example-element" class="transition-all">happy than right</span> any day.</p>
+    </section>
+</div>

--- a/site.json
+++ b/site.json
@@ -3412,6 +3412,15 @@
             "title": "CSS Demo: text-decoration-skip-ink",
             "type": "css"
         },
+        "textDecorationStyle": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/css/text-decoration-style.css",
+            "exampleCode": "live-examples/css-examples/text-decoration-style.html",
+            "fileName": "text-decoration-style.html",
+            "title": "CSS Demo: text-decoration-style",
+            "type": "css"
+        },
         "textOverflow": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":


### PR DESCRIPTION
Fixes: #478 reusing some code from `text-decoration`. `text-decoration-line: underline;` is added via CSS file and not shown per [CSS-Example-Style-Guide > Multiple declarations](https://github.com/mdn/interactive-examples/blob/master/CSS-Example-Style-Guide.md#multiple-declarations).

![image](https://user-images.githubusercontent.com/5341898/35469124-5afded8a-02e3-11e8-8d0b-88b1d0c2ba4f.png)
