### PR TITLE
Dynamically get clipboard button targets

### DIFF
--- a/js/editor-libs/clippy.js
+++ b/js/editor-libs/clippy.js
@@ -1,3 +1,5 @@
+var mceUtils = require('./mce-utils');
+
 /**
  * Positions the copy to clipboard success message based on the
  * position of the button that triggered the copy event.
@@ -26,7 +28,21 @@ module.exports = {
      */
     addClippy: function() {
         'use strict';
-        var clipboard = new Clipboard('.copy');
+        var clipboard = new Clipboard('.copy', {
+            target: function(clippyButton) {
+                var targetAttr = clippyButton.dataset.clipboardTarget;
+                if (targetAttr) {
+                    // The attribute will override the automated target selection
+                    return document.querySelector(targetAttr);
+                } else {
+                    // Get its parent until it finds an example choice
+                    var choiceElem = mceUtils.findParentChoiceElem(clippyButton);
+                    // Use the first code element to prevent extra text
+                    var firstCodeElem = choiceElem.getElementsByTagName('code')[0];
+                    return firstCodeElem;
+                }
+            }
+        });
 
         clipboard.on('success', function(event) {
             var msgContainer = document.getElementById('user-message');


### PR DESCRIPTION
addClippy will now construct a Clipboard where it finds the example code

Still can be overwritten by using a `data-clipboard-target` attribute, but that's no longer necessary.

Fixes: Test or automate `data-clipboard-target` #489