### PR TITLE
Updates to background-clip example

### DIFF
--- a/live-examples/css-examples/background-clip.html
+++ b/live-examples/css-examples/background-clip.html
@@ -19,12 +19,21 @@
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
+
+<div class="example-choice">
+<pre><code id="example_four" class="language-css">background-clip: text;
+-webkit-background-clip: text;
+color: transparent;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
 </section>
 
 <div id="output" class="output hidden">
     <section id="default-example">
         <div id="example-element">
-            This is the content of the container.
+            This is the content of the element.
         </div>
     </section>
 </div>

--- a/live-examples/css-examples/css/background-clip.css
+++ b/live-examples/css-examples/css/background-clip.css
@@ -1,7 +1,8 @@
 #example-element {
-    background-color: #333;
+    background-image: url('/media/examples/hand.jpg');
     color: #fff;
     padding: 20px;
-    border: 10px dotted #333;
+    border: 10px dashed #333;
     font-size: 2em;
+    font-weight: bold;
 }


### PR DESCRIPTION
Some updates to this example:

* use an image instead of a solid color, as it's a bit more interesting
* add the `text` value (this also needs the `-webkit` prefixed version)
* use a dashed border instead of dotted (looks a bit better IMO)
* slightly reworded the text.
