### PR TITLE
Add `border-*-width` examples

### DIFF
--- a/live-examples/css-examples/border-bottom-width.html
+++ b/live-examples/css-examples/border-bottom-width.html
@@ -1,35 +1,35 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="border-width">
+<section id="example-choice-list" class="example-choice-list large" data-property="border-bottom-width">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">border-width: thick;</code></pre>
+        <pre><code id="example_one" class="language-css">border-bottom-width: thick;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-width: 1em;</code></pre>
+        <pre><code id="example_two" class="language-css">border-bottom-width: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-width: 4px 1.25em;</code></pre>
+        <pre><code id="example_three" class="language-css">border-bottom-width: 4px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-width: 2ex 1.25ex 0.5ex;</code></pre>
+        <pre><code id="example_four" class="language-css">border-bottom-width: 2ex;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-width: 0 4px 8px 12px;</code></pre>
+        <pre><code id="example_five" class="language-css">border-bottom-width: 0;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/border-left-width.html
+++ b/live-examples/css-examples/border-left-width.html
@@ -1,35 +1,35 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="border-width">
+<section id="example-choice-list" class="example-choice-list large" data-property="border-left-width">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">border-width: thick;</code></pre>
+        <pre><code id="example_one" class="language-css">border-left-width: thick;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-width: 1em;</code></pre>
+        <pre><code id="example_two" class="language-css">border-left-width: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-width: 4px 1.25em;</code></pre>
+        <pre><code id="example_three" class="language-css">border-left-width: 4px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-width: 2ex 1.25ex 0.5ex;</code></pre>
+        <pre><code id="example_four" class="language-css">border-left-width: 2ex;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-width: 0 4px 8px 12px;</code></pre>
+        <pre><code id="example_five" class="language-css">border-left-width: 0;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/border-right-width.html
+++ b/live-examples/css-examples/border-right-width.html
@@ -1,35 +1,35 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="border-width">
+<section id="example-choice-list" class="example-choice-list large" data-property="border-right-width">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">border-width: thick;</code></pre>
+        <pre><code id="example_one" class="language-css">border-right-width: thick;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-width: 1em;</code></pre>
+        <pre><code id="example_two" class="language-css">border-right-width: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-width: 4px 1.25em;</code></pre>
+        <pre><code id="example_three" class="language-css">border-right-width: 4px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-width: 2ex 1.25ex 0.5ex;</code></pre>
+        <pre><code id="example_four" class="language-css">border-right-width: 2ex;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-width: 0 4px 8px 12px;</code></pre>
+        <pre><code id="example_five" class="language-css">border-right-width: 0;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/border-top-width.html
+++ b/live-examples/css-examples/border-top-width.html
@@ -1,35 +1,35 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="border-width">
+<section id="example-choice-list" class="example-choice-list large" data-property="border-top-width">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">border-width: thick;</code></pre>
+        <pre><code id="example_one" class="language-css">border-top-width: thick;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-width: 1em;</code></pre>
+        <pre><code id="example_two" class="language-css">border-top-width: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-width: 4px 1.25em;</code></pre>
+        <pre><code id="example_three" class="language-css">border-top-width: 4px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-width: 2ex 1.25ex 0.5ex;</code></pre>
+        <pre><code id="example_four" class="language-css">border-top-width: 2ex;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-width: 0 4px 8px 12px;</code></pre>
+        <pre><code id="example_five" class="language-css">border-top-width: 0;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/css/border-width.css
+++ b/live-examples/css-examples/css/border-width.css
@@ -1,6 +1,7 @@
 #example-element {
     background-color: palegreen;
-    border: 1px solid crimson;
+    border: 0 solid crimson;
+    padding: .75em;
     width: 80%;
     height: 100px;
 }

--- a/site.json
+++ b/site.json
@@ -3240,6 +3240,15 @@
             "title": "CSS Demo: background-size",
             "type": "css"
         },
+        "borderBottomWidth": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/css/border-width.css",
+            "exampleCode": "live-examples/css-examples/border-bottom-width.html",
+            "fileName": "border-bottom-width.html",
+            "title": "CSS Demo: border-bottom-width",
+            "type": "css"
+        },
         "borderColor": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":
@@ -3258,6 +3267,24 @@
             "title": "CSS Demo: border-image",
             "type": "css"
         },
+        "borderLeftWidth": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/css/border-width.css",
+            "exampleCode": "live-examples/css-examples/border-left-width.html",
+            "fileName": "border-left-width.html",
+            "title": "CSS Demo: border-left-width",
+            "type": "css"
+        },
+        "borderRightWidth": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/css/border-width.css",
+            "exampleCode": "live-examples/css-examples/border-right-width.html",
+            "fileName": "border-right-width.html",
+            "title": "CSS Demo: border-right-width",
+            "type": "css"
+        },
         "borderStyle": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":
@@ -3274,6 +3301,15 @@
             "exampleCode": "live-examples/css-examples/border-top-color.html",
             "fileName": "border-top-color.html",
             "title": "CSS Demo: border-top-color",
+            "type": "css"
+        },
+        "borderTopWidth": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/css/border-width.css",
+            "exampleCode": "live-examples/css-examples/border-top-width.html",
+            "fileName": "border-top-width.html",
+            "title": "CSS Demo: border-top-width",
             "type": "css"
         },
         "borderWidth": {


### PR DESCRIPTION
Also updates the basic `border-width` example to be a little prettier and illustrate the three-value syntax. Fixes #496.