### PR TITLE
Remove data-clipboard-target attribute

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Inside this newly created file, copy and paste the following code:
 
     <div class="example-choice" initial-choice="true">
         <pre><code id="example_one" class="language-css">Your CSS goes here</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
@@ -97,21 +97,21 @@ Next, let's add the example CSS choices. Think of a few different ways that `bor
 
     <div class="example-choice" initial-choice="true">
         <pre><code id="example_one" class="language-css">border-radius: 10px;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_two" class="language-css">border-radius: 10px 50%;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_three" class="language-css">border-radius: 10px 5px 6em / 20px 25px 30%;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
@@ -130,21 +130,21 @@ Now we've finished writing the HTML for the example. The final version of `borde
 
     <div class="example-choice" initial-choice="true">
         <pre><code id="example_one" class="language-css">border-radius: 10px;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_two" class="language-css">border-radius: 10px 50%;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_three" class="language-css">border-radius: 10px 5px 6em / 20px 25px 30%;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>

--- a/live-examples/css-examples/angle.html
+++ b/live-examples/css-examples/angle.html
@@ -2,28 +2,28 @@
 
     <div class="example-choice" initial-choice="true">
         <pre><code id="example_one" class="language-css">transform: rotate(45deg);</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_two" class="language-css">transform: rotate(3.1416rad);</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_three" class="language-css">transform: rotate(-50grad);</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_four" class="language-css">transform: rotate(1.75turn);</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>

--- a/live-examples/css-examples/animation.html
+++ b/live-examples/css-examples/animation.html
@@ -1,28 +1,28 @@
 <section id="example-choice-list" class="example-choice-list" data-property="animation">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">animation: slidein 3s ease-in 1s infinite reverse both running;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">animation: slidein 3s linear 1s infinite running;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">animation: slidein 3s linear 1s infinite alternate;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">animation: slidein .5s linear 1s infinite alternate;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/background-clip.html
+++ b/live-examples/css-examples/background-clip.html
@@ -1,21 +1,21 @@
 <section id="example-choice-list" class="example-choice-list" data-property="backgroundClip">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">background-clip: border-box;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">background-clip: padding-box;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">background-clip: content-box;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -24,7 +24,7 @@
 <pre><code id="example_four" class="language-css">background-clip: text;
 -webkit-background-clip: text;
 color: transparent;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/background-color.html
+++ b/live-examples/css-examples/background-color.html
@@ -1,42 +1,42 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="backgroundColor">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">background-color: brown;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">background-color: #74992e;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">background-color: rgb(255, 255, 128);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">background-color: rgba(255, 255, 128, .5);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">background-color: hsl(50, 33%, 25%);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">background-color: hsla(50, 33%, 25%, .75);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/background-image.html
+++ b/live-examples/css-examples/background-image.html
@@ -1,7 +1,7 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="backgroundImage">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">background-image: url("../../media/examples/lizard.png");</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -9,7 +9,7 @@
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">background-image: url("../../media/examples/lizard.png"),
                   url("../../media/examples/star.png");</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -17,7 +17,7 @@
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">background-image: url("../../media/examples/star.png"),
                   url("../../media/examples/lizard.png");</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -25,7 +25,7 @@
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_four" class="language-css">background-image: linear-gradient(rgba(0, 0, 255, 0.5), rgba(255, 255, 0, 0.5)),
                   url("../../media/examples/lizard.png");</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/background-position.html
+++ b/live-examples/css-examples/background-position.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="backgroundPosition">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">background-position: top;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">background-position: bottom;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">background-position: left;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">background-position: right;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">background-position: center;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -37,7 +37,7 @@
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">/* Percentage values */
 background-position: 25% 75%;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -45,14 +45,14 @@ background-position: 25% 75%;</code></pre>
 <div class="example-choice">
 <pre><code id="example_seven" class="language-css">/* Edge offsets values */
 background-position: bottom 10px right 20px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_seven">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_eight" class="language-css">background-position: right 3em bottom 10px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_eight">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/background-repeat.html
+++ b/live-examples/css-examples/background-repeat.html
@@ -1,42 +1,42 @@
 <section id="example-choice-list" class="example-choice-list large"  data-property="backgroundRepeat">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">background-repeat: repeat-x;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">background-repeat: repeat-y;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">background-repeat: repeat;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">background-repeat: space;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">background-repeat: round;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">background-repeat: no-repeat;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -44,14 +44,14 @@
 <div class="example-choice">
 <pre><code id="example_seven" class="language-css">/* Two-value syntax: horizontal | vertical */
 background-repeat: repeat space;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_seven">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_eight" class="language-css">background-repeat: space round;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_eight">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/background-size.html
+++ b/live-examples/css-examples/background-size.html
@@ -1,7 +1,7 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="backgroundSize">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">background-size: contain;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -9,28 +9,28 @@
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_two" class="language-css">background-size: contain;
 background-repeat: no-repeat;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">background-size: cover;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">background-size: 30%;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">background-size: 200px 100px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/border-bottom-color.html
+++ b/live-examples/css-examples/border-bottom-color.html
@@ -2,35 +2,35 @@
 
     <div class="example-choice">
         <pre><code id="example_one" class="language-css">border-bottom-color: red;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_two" class="language-css">border-bottom-color: #32a1ce;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_three" class="language-css">border-bottom-color: rgb(170, 50, 220, .6);</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_four" class="language-css">border-bottom-color: hsl(60, 90%, 50%, .8);</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_five" class="language-css">border-bottom-color: transparent;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>

--- a/live-examples/css-examples/border-bottom-style.html
+++ b/live-examples/css-examples/border-bottom-style.html
@@ -1,42 +1,42 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="borderBottomStyle">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">border-bottom-style: none;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_two" class="language-css">border-bottom-style: dotted;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">border-bottom-style: dashed;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">border-bottom-style: solid;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">border-bottom-style: groove;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">border-bottom-style: inset;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/border-bottom-width.html
+++ b/live-examples/css-examples/border-bottom-width.html
@@ -2,35 +2,35 @@
 
     <div class="example-choice" initial-choice="true">
         <pre><code id="example_one" class="language-css">border-bottom-width: thick;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_two" class="language-css">border-bottom-width: 2em;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_three" class="language-css">border-bottom-width: 4px;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_four" class="language-css">border-bottom-width: 2ex;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_five" class="language-css">border-bottom-width: 0;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>

--- a/live-examples/css-examples/border-color.html
+++ b/live-examples/css-examples/border-color.html
@@ -2,35 +2,35 @@
 
     <div class="example-choice">
         <pre><code id="example_one" class="language-css">border-color: red;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_two" class="language-css">border-color: red #32a1ce;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_three" class="language-css">border-color: red rgb(170, 50, 220, .6) green;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_four" class="language-css">border-color: red yellow green hsl(60, 90%, 50%, .8);</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_five" class="language-css">border-color: red yellow green transparent;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>

--- a/live-examples/css-examples/border-image.html
+++ b/live-examples/css-examples/border-image.html
@@ -2,14 +2,14 @@
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">/* image-source | height | width | repeat */
 border-image: url('https://mdn.mozillademos.org/files/4127/border.png') 40 40 repeat;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">border-image: linear-gradient(#51174e, #fff) 20;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -17,7 +17,7 @@ border-image: url('https://mdn.mozillademos.org/files/4127/border.png') 40 40 re
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">/* image-source | border-image-slice | border-image-width | border-image-outset */
 border-image: linear-gradient(#74992E, #fff) 50 / 12 / 10;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/border-left-color.html
+++ b/live-examples/css-examples/border-left-color.html
@@ -2,35 +2,35 @@
 
     <div class="example-choice">
         <pre><code id="example_one" class="language-css">border-left-color: red;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_two" class="language-css">border-left-color: #32a1ce;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_three" class="language-css">border-left-color: rgb(170, 50, 220, .6);</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_four" class="language-css">border-left-color: hsl(60, 90%, 50%, .8);</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_five" class="language-css">border-left-color: transparent;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>

--- a/live-examples/css-examples/border-left-style.html
+++ b/live-examples/css-examples/border-left-style.html
@@ -1,42 +1,42 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="borderLeftStyle">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">border-left-style: none;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_two" class="language-css">border-left-style: dotted;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">border-left-style: dashed;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">border-left-style: solid;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">border-left-style: groove;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">border-left-style: inset;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/border-left-width.html
+++ b/live-examples/css-examples/border-left-width.html
@@ -2,35 +2,35 @@
 
     <div class="example-choice" initial-choice="true">
         <pre><code id="example_one" class="language-css">border-left-width: thick;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_two" class="language-css">border-left-width: 2em;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_three" class="language-css">border-left-width: 4px;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_four" class="language-css">border-left-width: 2ex;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_five" class="language-css">border-left-width: 0;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>

--- a/live-examples/css-examples/border-right-color.html
+++ b/live-examples/css-examples/border-right-color.html
@@ -2,35 +2,35 @@
 
     <div class="example-choice">
         <pre><code id="example_one" class="language-css">border-right-color: red;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_two" class="language-css">border-right-color: #32a1ce;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_three" class="language-css">border-right-color: rgb(170, 50, 220, .6);</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_four" class="language-css">border-right-color: hsl(60, 90%, 50%, .8);</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_five" class="language-css">border-right-color: transparent;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>

--- a/live-examples/css-examples/border-right-style.html
+++ b/live-examples/css-examples/border-right-style.html
@@ -1,42 +1,42 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="borderRightStyle">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">border-right-style: none;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_two" class="language-css">border-right-style: dotted;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">border-right-style: dashed;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">border-right-style: solid;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">border-right-style: groove;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">border-right-style: inset;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/border-right-width.html
+++ b/live-examples/css-examples/border-right-width.html
@@ -2,35 +2,35 @@
 
     <div class="example-choice" initial-choice="true">
         <pre><code id="example_one" class="language-css">border-right-width: thick;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_two" class="language-css">border-right-width: 2em;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_three" class="language-css">border-right-width: 4px;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_four" class="language-css">border-right-width: 2ex;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_five" class="language-css">border-right-width: 0;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>

--- a/live-examples/css-examples/border-style.html
+++ b/live-examples/css-examples/border-style.html
@@ -1,42 +1,42 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="borderStyle">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">border-style: none;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_two" class="language-css">border-style: dotted;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">border-style: inset;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">border-style: dashed solid;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">border-style: dashed double none;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">border-style: dashed groove none dotted;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/border-top-color.html
+++ b/live-examples/css-examples/border-top-color.html
@@ -2,35 +2,35 @@
 
     <div class="example-choice">
         <pre><code id="example_one" class="language-css">border-top-color: red;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_two" class="language-css">border-top-color: #32a1ce;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_three" class="language-css">border-top-color: rgb(170, 50, 220, .6);</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_four" class="language-css">border-top-color: hsl(60, 90%, 50%, .8);</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_five" class="language-css">border-top-color: transparent;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>

--- a/live-examples/css-examples/border-top-style.html
+++ b/live-examples/css-examples/border-top-style.html
@@ -1,42 +1,42 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="borderTopStyle">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">border-top-style: none;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_two" class="language-css">border-top-style: dotted;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">border-top-style: dashed;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">border-top-style: solid;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">border-top-style: groove;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">border-top-style: inset;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/border-top-width.html
+++ b/live-examples/css-examples/border-top-width.html
@@ -2,35 +2,35 @@
 
     <div class="example-choice" initial-choice="true">
         <pre><code id="example_one" class="language-css">border-top-width: thick;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_two" class="language-css">border-top-width: 2em;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_three" class="language-css">border-top-width: 4px;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_four" class="language-css">border-top-width: 2ex;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_five" class="language-css">border-top-width: 0;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>

--- a/live-examples/css-examples/border-width.html
+++ b/live-examples/css-examples/border-width.html
@@ -2,35 +2,35 @@
 
     <div class="example-choice" initial-choice="true">
         <pre><code id="example_one" class="language-css">border-width: thick;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_two" class="language-css">border-width: 1em;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_three" class="language-css">border-width: 4px 1.25em;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_four" class="language-css">border-width: 2ex 1.25ex 0.5ex;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
         <pre><code id="example_five" class="language-css">border-width: 0 4px 8px 12px;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>

--- a/live-examples/css-examples/box-shadow.html
+++ b/live-examples/css-examples/box-shadow.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list" data-property="boxShadow">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">box-shadow: 10px 5px 5px red;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">box-shadow: 60px -16px teal;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, .2);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">box-shadow: inset 5em 1em gold;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">box-shadow: 3px 3px red, -1em 0 .4em olive;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/box-sizing.html
+++ b/live-examples/css-examples/box-sizing.html
@@ -2,7 +2,7 @@
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">box-sizing: content-box;
 width: 100%;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -12,7 +12,7 @@ width: 100%;</code></pre>
 width: 100%;
 border: solid #5B6DCD 10px;
 padding: 5px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -22,7 +22,7 @@ padding: 5px;</code></pre>
 width: 100%;
 border: solid #5B6DCD 10px;
 padding: 5px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/color.html
+++ b/live-examples/css-examples/color.html
@@ -1,56 +1,56 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="color">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">color: currentcolor;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">color: rebeccapurple;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">color: #00ff00;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">color: rgb(34, 12, 64);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">color: rgba(34, 12, 64, 0.3);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">color: hsl(30, 100%, 50%);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_seven" class="language-css">color: hsla(30, 100%, 50%, 0.3);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_seven">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_eight" class="language-css">color: initial;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_eight">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/filter.html
+++ b/live-examples/css-examples/filter.html
@@ -1,42 +1,42 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="filter">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">filter: url("../../media/examples/shadow.svg#element-id");</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">filter: blur(5px);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">filter: contrast(200%);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">filter: grayscale(80%);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_five" class="language-css">filter: hue-rotate(90deg);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">filter: drop-shadow(16px 16px 20px red) invert(75%);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/font-family.html
+++ b/live-examples/css-examples/font-family.html
@@ -1,42 +1,42 @@
 <section id="example-choice-list" class="example-choice-list" data-property="font-family">
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_one" class="language-css">font-family: Georgia, serif;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">font-family: "Gill Sans", sans-serif;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">font-family: sans-serif;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">font-family: serif;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">font-family: cursive;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">font-family: system-ui;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/font-style.html
+++ b/live-examples/css-examples/font-style.html
@@ -1,21 +1,21 @@
 <section id="example-choice-list" class="example-choice-list" data-property="fontStyle">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">font-style: normal;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">font-style: italic;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">font-style: oblique;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/font-weight.html
+++ b/live-examples/css-examples/font-weight.html
@@ -1,42 +1,42 @@
 <section id="example-choice-list" class="example-choice-list" data-property="font-family">
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_one" class="language-css">font-weight: normal;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">font-weight: bold;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">font-weight: lighter;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">font-weight: bolder;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">font-weight: 100;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">font-weight: 900;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/font.html
+++ b/live-examples/css-examples/font.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list" data-property="font">
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_one" class="language-css">font: 1.2em "Fira Sans", sans-serif;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_two" class="language-css">font: italic 1.2em "Fira Sans", serif;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">font: italic small-caps bold 16px/2 cursive;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">font: small-caps bold 24px/1 sans-serif;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">font: caption;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/line-height.html
+++ b/live-examples/css-examples/line-height.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="lineHeight">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">line-height: normal;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">line-height: 2.5;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">line-height: 3em;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">line-height: 150%;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">line-height: 32px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/margin.html
+++ b/live-examples/css-examples/margin.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="margin">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">margin: 1em;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">margin: 5% 0;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">margin: 10px 50px 20px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">margin: 10px 50px 20px 0;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">margin: 0;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/object-fit.html
+++ b/live-examples/css-examples/object-fit.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list" data-property="objectFit">
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_one" class="language-css">object-fit: fill;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_two" class="language-css">object-fit: contain;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">object-fit: cover;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">object-fit: none;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">object-fit: scale-down;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/opacity.html
+++ b/live-examples/css-examples/opacity.html
@@ -2,19 +2,19 @@
 
     <div class="example-choice">
         <pre><code id="example_one" class="language-css">opacity: 0;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
     <div class="example-choice" initial-choice="true">
         <pre><code id="example_two" class="language-css">opacity: 0.33;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
     <div class="example-choice">
         <pre><code id="example_three" class="language-css">opacity: 1;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>

--- a/live-examples/css-examples/overflow-wrap.html
+++ b/live-examples/css-examples/overflow-wrap.html
@@ -2,14 +2,14 @@
 
     <div class="example-choice" initial-choice="true">
         <pre><code id="example_one" class="language-css">overflow-wrap: normal;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice" initial-choice="true">
         <pre><code id="example_two" class="language-css">overflow-wrap: break-word;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>

--- a/live-examples/css-examples/padding.html
+++ b/live-examples/css-examples/padding.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="padding">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">padding: 1em;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">padding: 10% 0;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">padding: 10px 50px 20px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">padding: 10px 50px 30px 0;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">padding: 0;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/position.html
+++ b/live-examples/css-examples/position.html
@@ -2,7 +2,7 @@
 
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_one" class="language-css">position: static;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -10,7 +10,7 @@
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">position: relative;
 top: 65px; left: 65px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -18,7 +18,7 @@ top: 65px; left: 65px;</code></pre>
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">position: absolute;
 top: 40px; left: 40px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
@@ -26,7 +26,7 @@ top: 40px; left: 40px;</code></pre>
 <div id="choice-sticky" class="example-choice">
 <pre><code id="example_four" class="language-css">position: sticky;
 top: 20px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/sepia.html
+++ b/live-examples/css-examples/sepia.html
@@ -1,21 +1,21 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="filter">
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_one" class="language-css">filter: sepia(60%);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">filter: sepia(0.20);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">filter: sepia(0.80);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/text-align.html
+++ b/live-examples/css-examples/text-align.html
@@ -1,28 +1,28 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textAlign">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">text-align: left;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">text-align: right;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">text-align: center;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">text-align: justify;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/text-decoration-line.html
+++ b/live-examples/css-examples/text-decoration-line.html
@@ -1,42 +1,42 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textDecorationLine">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">text-decoration-line: none;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_two" class="language-css">text-decoration-line: underline;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">text-decoration-line: overline;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">text-decoration-line: line-through;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">text-decoration-line: underline overline;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">text-decoration-line: underline line-through;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/text-decoration-skip-ink.html
+++ b/live-examples/css-examples/text-decoration-skip-ink.html
@@ -1,14 +1,14 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textDecorationSkipInk">
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_one" class="language-css">text-decoration-skip-ink: auto;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">text-decoration-skip-ink: none;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/text-decoration-style.html
+++ b/live-examples/css-examples/text-decoration-style.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textDecorationStyle">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">text-decoration-style: solid;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">text-decoration-style: double;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">text-decoration-style: dotted;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">text-decoration-style: dashed;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">text-decoration-style: wavy;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/text-decoration.html
+++ b/live-examples/css-examples/text-decoration.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textDecoration">
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_one" class="language-css">text-decoration: underline;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">text-decoration: underline dotted;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">text-decoration: underline dotted red;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">text-decoration: green wavy underline;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">text-decoration: underline overline #FF3028;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/text-overflow.html
+++ b/live-examples/css-examples/text-overflow.html
@@ -1,28 +1,28 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textOverflow">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">text-overflow: clip;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_two" class="language-css">text-overflow: ellipsis;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">text-overflow: "-";</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">text-overflow: "";</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/text-shadow.html
+++ b/live-examples/css-examples/text-shadow.html
@@ -1,42 +1,42 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textShadow">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">text-shadow: 1px 1px 2px pink;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_two" class="language-css">text-shadow: #FC0 1px 0 10px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">text-shadow: 5px 5px #558ABB;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">text-shadow: red 2px 5px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">text-shadow: 5px 10px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">text-shadow: 1px 1px 2px red, 0 0 1em blue, 0 0 0.2em blue;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/text-transform.html
+++ b/live-examples/css-examples/text-transform.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="textTransform">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">text-transform: capitalize;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">text-transform: uppercase;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">text-transform: lowercase;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">text-transform: none;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">text-transform: full-width;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/transform.html
+++ b/live-examples/css-examples/transform.html
@@ -1,42 +1,42 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">transform: matrix(1, 2, 3, 4, 5, 6);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">transform: translate(120px, 50%);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">transform: scale(2, 0.5);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
 <pre><code id="example_four" class="language-css">transform: rotate(0.5turn);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_five" class="language-css">transform: skew(30deg, 20deg);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_five">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_six" class="language-css">transform: scale(0.5) translate(-100%, -100%);</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_six">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>

--- a/live-examples/css-examples/word-break.html
+++ b/live-examples/css-examples/word-break.html
@@ -1,25 +1,25 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="wordBreak">
     <div class="example-choice" initial-choice="true">
         <pre><code id="example_one" class="language-css">word-break: normal;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
     <div class="example-choice">
         <pre><code id="example_two" class="language-css">word-break: break-all;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
     <div class="example-choice">
         <pre><code id="example_three" class="language-css">word-break: keep-all;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
     <div class="example-choice">
         <pre><code id="example_four" class="language-css">word-break: break-word;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+        <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>

--- a/live-examples/css-examples/z-index.html
+++ b/live-examples/css-examples/z-index.html
@@ -1,28 +1,28 @@
 <section id="example-choice-list" class="example-choice-list" data-property="zIndex">
 <div class="example-choice">
 <pre><code id="example_one" class="language-css">z-index: 1;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_one">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_two" class="language-css">z-index: 3;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_two">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_three" class="language-css">z-index: 5;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_three">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
 <pre><code id="example_four" class="language-css">z-index: 7;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true" data-clipboard-target="#example_four">
+<button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>


### PR DESCRIPTION
Follow up to #491

It's now removed in all examples and the docs. The targets still work as intended.