### PR TITLE
Add `overflow-*` examples

### DIFF
--- a/live-examples/css-examples/css/overflow.css
+++ b/live-examples/css-examples/css/overflow.css
@@ -1,0 +1,7 @@
+#example-element {
+    width: 15em;
+    height: 9em;
+    border: medium dotted;
+    padding: .75em;
+    text-align: left;
+}

--- a/live-examples/css-examples/overflow-x.html
+++ b/live-examples/css-examples/overflow-x.html
@@ -1,0 +1,39 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="overflow-x">
+
+    <div class="example-choice">
+        <pre><code id="example_one" class="language-css">overflow-x: visible;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code id="example_two" class="language-css">overflow-x: hidden;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code id="example_three" class="language-css">overflow-x: scroll;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code id="example_four" class="language-css">overflow-x: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <div id="example-element">The value of Pi is
+          3.1415926535897932384626433832795029. The value of e is
+          2.7182818284590452353602874713526625.</div>
+    </section>
+</div>

--- a/live-examples/css-examples/overflow-y.html
+++ b/live-examples/css-examples/overflow-y.html
@@ -1,0 +1,37 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="overflow-y">
+
+    <div class="example-choice">
+        <pre><code id="example_one" class="language-css">overflow-y: visible;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code id="example_two" class="language-css">overflow-y: hidden;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code id="example_three" class="language-css">overflow-y: scroll;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code id="example_four" class="language-css">overflow-y: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <p id="example-element">Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather. As much mud in the streets as if the waters had but newly retired from the face of the earth.</p>
+    </section>
+</div>

--- a/live-examples/css-examples/overflow.html
+++ b/live-examples/css-examples/overflow.html
@@ -1,0 +1,37 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="overflow">
+
+    <div class="example-choice">
+        <pre><code id="example_one" class="language-css">overflow: visible;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code id="example_two" class="language-css">overflow: hidden;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code id="example_three" class="language-css">overflow: scroll;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code id="example_four" class="language-css">overflow: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <p id="example-element">Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather. As much mud in the streets as if the waters had but newly retired from the face of the earth.</p>
+    </section>
+</div>

--- a/site.json
+++ b/site.json
@@ -3415,7 +3415,7 @@
             "title": "CSS Demo: font-weight",
             "type": "css"
         },
-		"lineHeight": {
+        "lineHeight": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":
                 "../../live-examples/css-examples/css/line-height.css",
@@ -3449,6 +3449,33 @@
             "exampleCode": "live-examples/css-examples/opacity.html",
             "fileName": "opacity.html",
             "title": "CSS Demo: opacity",
+            "type": "css"
+        },
+        "overflow": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/css/overflow.css",
+            "exampleCode": "live-examples/css-examples/overflow.html",
+            "fileName": "overflow.html",
+            "title": "CSS Demo: overflow",
+            "type": "css"
+        },
+        "overflowX": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/css/overflow.css",
+            "exampleCode": "live-examples/css-examples/overflow-x.html",
+            "fileName": "overflow-x.html",
+            "title": "CSS Demo: overflow-x",
+            "type": "css"
+        },
+        "overflowY": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/css/overflow.css",
+            "exampleCode": "live-examples/css-examples/overflow-y.html",
+            "fileName": "overflow-y.html",
+            "title": "CSS Demo: overflow-y",
             "type": "css"
         },
         "overflow-wrap": {


### PR DESCRIPTION
Adds `overflow`, `overflow-x`, and `overflow-y` examples. Fixes #470.