### PR TITLE
2 small docs updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,16 @@ Next, let's provide some extra styling for the example element. Create a new CSS
 }
 ```
 
+### Including media
+
+Some examples will need to reference media, such as images, from the CSS. Make sure that the license terms for any images are acceptable.
+
+Media files should be stored in the [/media/examples](https://github.com/mdn/interactive-examples/tree/master/media/examples) directory, and can be referenced using a path like `"/media/examples/my-file"`:
+
+```
+background-image: url("/media/examples/lizard.png");
+```
+
 ### Updating the metadata
 
 Next, you need to tell the page generator about your new page and its dependencies. To do this, open up the `meta.json` file in the current folder (i.e. "live-examples/css-examples/backgrounds-and-borders/meta.json").

--- a/CSS-Example-Style-Guide.md
+++ b/CSS-Example-Style-Guide.md
@@ -64,3 +64,9 @@ Sometimes you'll want to include images with the example. If you do:
 
 * make sure their license allows you to use them. It's difficult for us to satisfy an attribution requirement with the editor, so try to use images that have a very permissive license such as [CC0](https://creativecommons.org/share-your-work/public-domain/cc0/).
 * run them through https://tinypng.com or https://imageoptim.com, to reduce the page weight of the examples.
+
+## Output width considerations
+
+On MDN pages the editor is laid out "side by side": that is with the example choices on the left and the output on the right, as it is in the local server that's started by `npm run start`. Then if the page width goes below some threshold it switches to "top and bottom", with the example choices above and the output below.
+
+This means that ideally, the example should still work with an editor width of about 730 pixels: https://screenshots.firefox.com/YYrEvqLEmLjJCddS/developer.mozilla.org. This can be a difficult constraint to satisfy, but you should test at this width, and try to make it work, if it's possible.


### PR DESCRIPTION
A couple of docs updates:

* how to reference media from CSS. This should I think enable us to close https://github.com/mdn/interactive-examples/issues/344
* output width considerations
