### PR TITLE
Add/update padding examples

### DIFF
--- a/live-examples/css-examples/basic-box-model/meta.json
+++ b/live-examples/css-examples/basic-box-model/meta.json
@@ -20,6 +20,46 @@
             "title": "CSS Demo: padding",
             "type": "css"
         },
+        "paddingBottom": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/basic-box-model/padding.css",
+            "exampleCode":
+                "live-examples/css-examples/basic-box-model/padding-bottom.html",
+            "fileName": "padding-bottom.html",
+            "title": "CSS Demo: padding-bottom",
+            "type": "css"
+        },
+        "paddingLeft": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/basic-box-model/padding.css",
+            "exampleCode":
+                "live-examples/css-examples/basic-box-model/padding-left.html",
+            "fileName": "padding-left.html",
+            "title": "CSS Demo: padding-left",
+            "type": "css"
+        },
+        "paddingRight": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/basic-box-model/padding.css",
+            "exampleCode":
+                "live-examples/css-examples/basic-box-model/padding-right.html",
+            "fileName": "padding-right.html",
+            "title": "CSS Demo: padding-right",
+            "type": "css"
+        },
+        "paddingTop": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/basic-box-model/padding.css",
+            "exampleCode":
+                "live-examples/css-examples/basic-box-model/padding-top.html",
+            "fileName": "padding-top.html",
+            "title": "CSS Demo: padding-top",
+            "type": "css"
+        },
         "overflow": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":

--- a/live-examples/css-examples/basic-box-model/padding-bottom.html
+++ b/live-examples/css-examples/basic-box-model/padding-bottom.html
@@ -1,34 +1,34 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="padding">
+<section id="example-choice-list" class="example-choice-list large" data-property="padding-bottom">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">padding: 1em;</code></pre>
+<pre><code id="example_one" class="language-css">padding-bottom: 1em;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">padding: 10% 0;</code></pre>
+<pre><code id="example_two" class="language-css">padding-bottom: 10%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">padding: 10px 50px 20px;</code></pre>
+<pre><code id="example_three" class="language-css">padding-bottom: 20px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">padding: 10px 50px 30px 0;</code></pre>
+<pre><code id="example_four" class="language-css">padding-bottom: 1ch;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">padding: 0;</code></pre>
+<pre><code id="example_five" class="language-css">padding-bottom: 0;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/basic-box-model/padding-left.html
+++ b/live-examples/css-examples/basic-box-model/padding-left.html
@@ -1,34 +1,34 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="padding">
+<section id="example-choice-list" class="example-choice-list large" data-property="padding-left">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">padding: 1em;</code></pre>
+<pre><code id="example_one" class="language-css">padding-left: 1.5em;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">padding: 10% 0;</code></pre>
+<pre><code id="example_two" class="language-css">padding-left: 10%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">padding: 10px 50px 20px;</code></pre>
+<pre><code id="example_three" class="language-css">padding-left: 20px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">padding: 10px 50px 30px 0;</code></pre>
+<pre><code id="example_four" class="language-css">padding-left: 1ch;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">padding: 0;</code></pre>
+<pre><code id="example_five" class="language-css">padding-left: 0;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/basic-box-model/padding-right.html
+++ b/live-examples/css-examples/basic-box-model/padding-right.html
@@ -1,34 +1,34 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="padding">
+<section id="example-choice-list" class="example-choice-list large" data-property="padding-right">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">padding: 1em;</code></pre>
+<pre><code id="example_one" class="language-css">padding-right: 1.5em;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">padding: 10% 0;</code></pre>
+<pre><code id="example_two" class="language-css">padding-right: 10%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">padding: 10px 50px 20px;</code></pre>
+<pre><code id="example_three" class="language-css">padding-right: 20px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">padding: 10px 50px 30px 0;</code></pre>
+<pre><code id="example_four" class="language-css">padding-right: 1ch;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">padding: 0;</code></pre>
+<pre><code id="example_five" class="language-css">padding-right: 0;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/basic-box-model/padding-top.html
+++ b/live-examples/css-examples/basic-box-model/padding-top.html
@@ -1,34 +1,34 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="padding">
+<section id="example-choice-list" class="example-choice-list large" data-property="padding-top">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">padding: 1em;</code></pre>
+<pre><code id="example_one" class="language-css">padding-top: 1em;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">padding: 10% 0;</code></pre>
+<pre><code id="example_two" class="language-css">padding-top: 10%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">padding: 10px 50px 20px;</code></pre>
+<pre><code id="example_three" class="language-css">padding-top: 20px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">padding: 10px 50px 30px 0;</code></pre>
+<pre><code id="example_four" class="language-css">padding-top: 1ch;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">padding: 0;</code></pre>
+<pre><code id="example_five" class="language-css">padding-top: 0;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/basic-box-model/padding.css
+++ b/live-examples/css-examples/basic-box-model/padding.css
@@ -1,11 +1,9 @@
 #example-element {
     background: #ffc129;
-    border: dashed 1px;
-    font-family: Georgia, sans-serif;
     overflow: hidden;
     text-align: left;
 }
 
 .box {
-    background: white;
+    border: dashed 1px;
 }

--- a/live-examples/css-examples/basic-box-model/padding.css
+++ b/live-examples/css-examples/basic-box-model/padding.css
@@ -1,5 +1,5 @@
 #example-element {
-    background: #ffc129;
+    border: 10px solid #ffc129;
     overflow: hidden;
     text-align: left;
 }

--- a/live-examples/css-examples/basic-box-model/padding.css
+++ b/live-examples/css-examples/basic-box-model/padding.css
@@ -1,6 +1,11 @@
 #example-element {
-    border: solid 10px #FFC129;
+    background: #ffc129;
+    border: dashed 1px;
     font-family: Georgia, sans-serif;
     overflow: hidden;
     text-align: left;
+}
+
+.box {
+    background: white;
 }


### PR DESCRIPTION
This is an attempt to add sub-property examples for `padding`. I don't know if I came up with the best solution, but I tried to make it more obvious when/where padding gets added, especially in the `padding-right` example.