### PR TITLE
Remove CSS example id attributes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Inside this newly created file, copy and paste the following code:
 <section id="example-choice-list" class="example-choice-list large" data-property="border-radius">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">Your CSS goes here</code></pre>
+        <pre><code class="language-css">Your CSS goes here</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -96,21 +96,21 @@ Next, let's add the example CSS choices. Think of a few different ways that `bor
 <section id="example-choice-list" class="example-choice-list large" data-property="border-radius">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">border-radius: 10px;</code></pre>
+        <pre><code class="language-css">border-radius: 10px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-radius: 10px 50%;</code></pre>
+        <pre><code class="language-css">border-radius: 10px 50%;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-radius: 10px 5px 6em / 20px 25px 30%;</code></pre>
+        <pre><code class="language-css">border-radius: 10px 5px 6em / 20px 25px 30%;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -121,7 +121,7 @@ Next, let's add the example CSS choices. Think of a few different ways that `bor
 
 The first thing to note is that the `section` element has a `data-property` attribute whose value is the name of the property, `border-radius` in this case. The editor uses this to test whether the user's browser supports the property. If it doesn't, then an interactive example won't work, and we just display the CSS options without their output. If you know that the example property has good cross-browser support, you can omit this attribute (for example, the `border-radius` example could certainly omit it).
 
-Next, we have three `div` elements, one for each example CSS choice. Note that each choice gets its own ID: `example_one`, `example_two`, `example_three` and so on. You can choose which option will be shown at first by setting the `initial-choice` attribute to `true` (only one choice should have this).
+Next, we have three `div` elements, one for each example CSS choice. You can choose which option will be shown at first by setting the `initial-choice` attribute to `true` (only one choice should have this).
 
 Now we've finished writing the HTML for the example. The final version of `border-radius.html` should look like this:
 
@@ -129,21 +129,21 @@ Now we've finished writing the HTML for the example. The final version of `borde
 <section id="example-choice-list" class="example-choice-list large" data-property="border-radius">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">border-radius: 10px;</code></pre>
+        <pre><code class="language-css">border-radius: 10px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-radius: 10px 50%;</code></pre>
+        <pre><code class="language-css">border-radius: 10px 50%;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-radius: 10px 5px 6em / 20px 25px 30%;</code></pre>
+        <pre><code class="language-css">border-radius: 10px 5px 6em / 20px 25px 30%;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/animation/animation.html
+++ b/live-examples/css-examples/animation/animation.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list" data-property="animation">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">animation: slidein 3s ease-in 1s infinite reverse both running;</code></pre>
+<pre><code class="language-css">animation: slidein 3s ease-in 1s infinite reverse both running;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">animation: slidein 3s linear 1s infinite running;</code></pre>
+<pre><code class="language-css">animation: slidein 3s linear 1s infinite running;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">animation: slidein 3s linear 1s infinite alternate;</code></pre>
+<pre><code class="language-css">animation: slidein 3s linear 1s infinite alternate;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">animation: slidein .5s linear 1s infinite alternate;</code></pre>
+<pre><code class="language-css">animation: slidein .5s linear 1s infinite alternate;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/backgrounds-and-borders/background-clip.html
+++ b/live-examples/css-examples/backgrounds-and-borders/background-clip.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list" data-property="backgroundClip">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">background-clip: border-box;</code></pre>
+<pre><code class="language-css">background-clip: border-box;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">background-clip: padding-box;</code></pre>
+<pre><code class="language-css">background-clip: padding-box;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">background-clip: content-box;</code></pre>
+<pre><code class="language-css">background-clip: content-box;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">background-clip: text;
+<pre><code class="language-css">background-clip: text;
 -webkit-background-clip: text;
 color: transparent;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">

--- a/live-examples/css-examples/backgrounds-and-borders/background-color.html
+++ b/live-examples/css-examples/backgrounds-and-borders/background-color.html
@@ -1,41 +1,41 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="backgroundColor">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">background-color: brown;</code></pre>
+<pre><code class="language-css">background-color: brown;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">background-color: #74992e;</code></pre>
+<pre><code class="language-css">background-color: #74992e;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">background-color: rgb(255, 255, 128);</code></pre>
+<pre><code class="language-css">background-color: rgb(255, 255, 128);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">background-color: rgba(255, 255, 128, .5);</code></pre>
+<pre><code class="language-css">background-color: rgba(255, 255, 128, .5);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">background-color: hsl(50, 33%, 25%);</code></pre>
+<pre><code class="language-css">background-color: hsl(50, 33%, 25%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">background-color: hsla(50, 33%, 25%, .75);</code></pre>
+<pre><code class="language-css">background-color: hsla(50, 33%, 25%, .75);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/backgrounds-and-borders/background-image.html
+++ b/live-examples/css-examples/backgrounds-and-borders/background-image.html
@@ -1,13 +1,13 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="backgroundImage">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">background-image: url("../../media/examples/lizard.png");</code></pre>
+<pre><code class="language-css">background-image: url("../../media/examples/lizard.png");</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">background-image: url("../../media/examples/lizard.png"),
+<pre><code class="language-css">background-image: url("../../media/examples/lizard.png"),
                   url("../../media/examples/star.png");</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -15,7 +15,7 @@
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">background-image: url("../../media/examples/star.png"),
+<pre><code class="language-css">background-image: url("../../media/examples/star.png"),
                   url("../../media/examples/lizard.png");</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -23,7 +23,7 @@
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_four" class="language-css">background-image: linear-gradient(rgba(0, 0, 255, 0.5), rgba(255, 255, 0, 0.5)),
+<pre><code class="language-css">background-image: linear-gradient(rgba(0, 0, 255, 0.5), rgba(255, 255, 0, 0.5)),
                   url("../../media/examples/lizard.png");</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/backgrounds-and-borders/background-position-x.html
+++ b/live-examples/css-examples/backgrounds-and-borders/background-position-x.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="backgroundPositionX">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">background-position-x: left;</code></pre>
+<pre><code class="language-css">background-position-x: left;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">background-position-x: center;</code></pre>
+<pre><code class="language-css">background-position-x: center;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">background-position-x: 25%;</code></pre>
+<pre><code class="language-css">background-position-x: 25%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">background-position-x: 2rem;</code></pre>
+<pre><code class="language-css">background-position-x: 2rem;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">background-position-x: right 32px;</code></pre>
+<pre><code class="language-css">background-position-x: right 32px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/backgrounds-and-borders/background-position-y.html
+++ b/live-examples/css-examples/backgrounds-and-borders/background-position-y.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="backgroundPositionY">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">background-position-y: top;</code></pre>
+<pre><code class="language-css">background-position-y: top;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">background-position-y: center;</code></pre>
+<pre><code class="language-css">background-position-y: center;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">background-position-y: 25%;</code></pre>
+<pre><code class="language-css">background-position-y: 25%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">background-position-y: 2rem;</code></pre>
+<pre><code class="language-css">background-position-y: 2rem;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">background-position-y: bottom 32px;</code></pre>
+<pre><code class="language-css">background-position-y: bottom 32px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/backgrounds-and-borders/background-position.html
+++ b/live-examples/css-examples/backgrounds-and-borders/background-position.html
@@ -1,41 +1,41 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="backgroundPosition">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">background-position: top;</code></pre>
+<pre><code class="language-css">background-position: top;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">background-position: left;</code></pre>
+<pre><code class="language-css">background-position: left;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">background-position: center;</code></pre>
+<pre><code class="language-css">background-position: center;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">background-position: 25% 75%;</code></pre>
+<pre><code class="language-css">background-position: 25% 75%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">background-position: bottom 50px right 100px;</code></pre>
+<pre><code class="language-css">background-position: bottom 50px right 100px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">background-position: right 35% bottom 45%;</code></pre>
+<pre><code class="language-css">background-position: right 35% bottom 45%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/backgrounds-and-borders/background-repeat.html
+++ b/live-examples/css-examples/backgrounds-and-borders/background-repeat.html
@@ -1,48 +1,48 @@
 <section id="example-choice-list" class="example-choice-list large"  data-property="backgroundRepeat">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">background-repeat: repeat-x;</code></pre>
+<pre><code class="language-css">background-repeat: repeat-x;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">background-repeat: repeat-y;</code></pre>
+<pre><code class="language-css">background-repeat: repeat-y;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">background-repeat: repeat;</code></pre>
+<pre><code class="language-css">background-repeat: repeat;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">background-repeat: space;</code></pre>
+<pre><code class="language-css">background-repeat: space;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">background-repeat: round;</code></pre>
+<pre><code class="language-css">background-repeat: round;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">background-repeat: no-repeat;</code></pre>
+<pre><code class="language-css">background-repeat: no-repeat;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_seven" class="language-css">/* Two-value syntax: horizontal | vertical */
+<pre><code class="language-css">/* Two-value syntax: horizontal | vertical */
 background-repeat: repeat space;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -50,7 +50,7 @@ background-repeat: repeat space;</code></pre>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_eight" class="language-css">background-repeat: space round;</code></pre>
+<pre><code class="language-css">background-repeat: space round;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/backgrounds-and-borders/background-size.html
+++ b/live-examples/css-examples/backgrounds-and-borders/background-size.html
@@ -1,13 +1,13 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="backgroundSize">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">background-size: contain;</code></pre>
+<pre><code class="language-css">background-size: contain;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">background-size: contain;
+<pre><code class="language-css">background-size: contain;
 background-repeat: no-repeat;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -15,21 +15,21 @@ background-repeat: no-repeat;</code></pre>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">background-size: cover;</code></pre>
+<pre><code class="language-css">background-size: cover;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">background-size: 30%;</code></pre>
+<pre><code class="language-css">background-size: 30%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">background-size: 200px 100px;</code></pre>
+<pre><code class="language-css">background-size: 200px 100px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-bottom-color.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-bottom-color.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-bottom-color">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">border-bottom-color: red;</code></pre>
+        <pre><code class="language-css">border-bottom-color: red;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-bottom-color: #32a1ce;</code></pre>
+        <pre><code class="language-css">border-bottom-color: #32a1ce;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-bottom-color: rgb(170, 50, 220, .6);</code></pre>
+        <pre><code class="language-css">border-bottom-color: rgb(170, 50, 220, .6);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-bottom-color: hsl(60, 90%, 50%, .8);</code></pre>
+        <pre><code class="language-css">border-bottom-color: hsl(60, 90%, 50%, .8);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-bottom-color: transparent;</code></pre>
+        <pre><code class="language-css">border-bottom-color: transparent;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-bottom-style.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-bottom-style.html
@@ -1,41 +1,41 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="borderBottomStyle">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">border-bottom-style: none;</code></pre>
+<pre><code class="language-css">border-bottom-style: none;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">border-bottom-style: dotted;</code></pre>
+<pre><code class="language-css">border-bottom-style: dotted;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">border-bottom-style: dashed;</code></pre>
+<pre><code class="language-css">border-bottom-style: dashed;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">border-bottom-style: solid;</code></pre>
+<pre><code class="language-css">border-bottom-style: solid;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">border-bottom-style: groove;</code></pre>
+<pre><code class="language-css">border-bottom-style: groove;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">border-bottom-style: inset;</code></pre>
+<pre><code class="language-css">border-bottom-style: inset;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-bottom-width.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-bottom-width.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-bottom-width">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">border-bottom-width: thick;</code></pre>
+        <pre><code class="language-css">border-bottom-width: thick;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-bottom-width: 2em;</code></pre>
+        <pre><code class="language-css">border-bottom-width: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-bottom-width: 4px;</code></pre>
+        <pre><code class="language-css">border-bottom-width: 4px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-bottom-width: 2ex;</code></pre>
+        <pre><code class="language-css">border-bottom-width: 2ex;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-bottom-width: 0;</code></pre>
+        <pre><code class="language-css">border-bottom-width: 0;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-bottom.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-bottom.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-bottom">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">border-bottom: solid;</code></pre>
+        <pre><code class="language-css">border-bottom: solid;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-bottom: dashed red;</code></pre>
+        <pre><code class="language-css">border-bottom: dashed red;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-bottom: 1rem solid;</code></pre>
+        <pre><code class="language-css">border-bottom: 1rem solid;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-bottom: thick double #32a1ce;</code></pre>
+        <pre><code class="language-css">border-bottom: thick double #32a1ce;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-bottom: 4mm ridge rgb(170, 50, 220, .6);</code></pre>
+        <pre><code class="language-css">border-bottom: 4mm ridge rgb(170, 50, 220, .6);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-color.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-color.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-color">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">border-color: red;</code></pre>
+        <pre><code class="language-css">border-color: red;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-color: red #32a1ce;</code></pre>
+        <pre><code class="language-css">border-color: red #32a1ce;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-color: red rgb(170, 50, 220, .6) green;</code></pre>
+        <pre><code class="language-css">border-color: red rgb(170, 50, 220, .6) green;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-color: red yellow green hsl(60, 90%, 50%, .8);</code></pre>
+        <pre><code class="language-css">border-color: red yellow green hsl(60, 90%, 50%, .8);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-color: red yellow green transparent;</code></pre>
+        <pre><code class="language-css">border-color: red yellow green transparent;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-image.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-image.html
@@ -1,6 +1,6 @@
 <section id="example-choice-list" class="example-choice-list" data-property="borderImage">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">/* image-source | height | width | repeat */
+<pre><code class="language-css">/* image-source | height | width | repeat */
 border-image: url('https://mdn.mozillademos.org/files/4127/border.png') 40 40 repeat;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -8,14 +8,14 @@ border-image: url('https://mdn.mozillademos.org/files/4127/border.png') 40 40 re
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">border-image: linear-gradient(#51174e, #fff) 20;</code></pre>
+<pre><code class="language-css">border-image: linear-gradient(#51174e, #fff) 20;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">/* image-source | border-image-slice | border-image-width | border-image-outset */
+<pre><code class="language-css">/* image-source | border-image-slice | border-image-width | border-image-outset */
 border-image: linear-gradient(#74992E, #fff) 50 / 12 / 10;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/backgrounds-and-borders/border-left-color.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-left-color.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-left-color">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">border-left-color: red;</code></pre>
+        <pre><code class="language-css">border-left-color: red;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-left-color: #32a1ce;</code></pre>
+        <pre><code class="language-css">border-left-color: #32a1ce;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-left-color: rgb(170, 50, 220, .6);</code></pre>
+        <pre><code class="language-css">border-left-color: rgb(170, 50, 220, .6);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-left-color: hsl(60, 90%, 50%, .8);</code></pre>
+        <pre><code class="language-css">border-left-color: hsl(60, 90%, 50%, .8);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-left-color: transparent;</code></pre>
+        <pre><code class="language-css">border-left-color: transparent;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-left-style.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-left-style.html
@@ -1,41 +1,41 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="borderLeftStyle">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">border-left-style: none;</code></pre>
+<pre><code class="language-css">border-left-style: none;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">border-left-style: dotted;</code></pre>
+<pre><code class="language-css">border-left-style: dotted;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">border-left-style: dashed;</code></pre>
+<pre><code class="language-css">border-left-style: dashed;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">border-left-style: solid;</code></pre>
+<pre><code class="language-css">border-left-style: solid;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">border-left-style: groove;</code></pre>
+<pre><code class="language-css">border-left-style: groove;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">border-left-style: inset;</code></pre>
+<pre><code class="language-css">border-left-style: inset;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-left-width.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-left-width.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-left-width">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">border-left-width: thick;</code></pre>
+        <pre><code class="language-css">border-left-width: thick;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-left-width: 2em;</code></pre>
+        <pre><code class="language-css">border-left-width: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-left-width: 4px;</code></pre>
+        <pre><code class="language-css">border-left-width: 4px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-left-width: 2ex;</code></pre>
+        <pre><code class="language-css">border-left-width: 2ex;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-left-width: 0;</code></pre>
+        <pre><code class="language-css">border-left-width: 0;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-left.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-left.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-left">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">border-left: solid;</code></pre>
+        <pre><code class="language-css">border-left: solid;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-left: dashed red;</code></pre>
+        <pre><code class="language-css">border-left: dashed red;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-left: 1rem solid;</code></pre>
+        <pre><code class="language-css">border-left: 1rem solid;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-left: thick double #32a1ce;</code></pre>
+        <pre><code class="language-css">border-left: thick double #32a1ce;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-left: 4mm ridge rgb(170, 50, 220, .6);</code></pre>
+        <pre><code class="language-css">border-left: 4mm ridge rgb(170, 50, 220, .6);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-radius.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-radius.html
@@ -1,42 +1,42 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-radius">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">border-radius: 30px;</code></pre>
+        <pre><code class="language-css">border-radius: 30px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-radius: 25% 10%;</code></pre>
+        <pre><code class="language-css">border-radius: 25% 10%;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-radius: 10% 30% 50% 70%;</code></pre>
+        <pre><code class="language-css">border-radius: 10% 30% 50% 70%;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-radius: 10% / 50%;</code></pre>
+        <pre><code class="language-css">border-radius: 10% / 50%;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-radius: 10px 100px / 120px;</code></pre>
+        <pre><code class="language-css">border-radius: 10px 100px / 120px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_six" class="language-css">border-radius: 50% 20% / 10% 40%;</code></pre>
+        <pre><code class="language-css">border-radius: 50% 20% / 10% 40%;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-right-color.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-right-color.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-right-color">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">border-right-color: red;</code></pre>
+        <pre><code class="language-css">border-right-color: red;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-right-color: #32a1ce;</code></pre>
+        <pre><code class="language-css">border-right-color: #32a1ce;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-right-color: rgb(170, 50, 220, .6);</code></pre>
+        <pre><code class="language-css">border-right-color: rgb(170, 50, 220, .6);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-right-color: hsl(60, 90%, 50%, .8);</code></pre>
+        <pre><code class="language-css">border-right-color: hsl(60, 90%, 50%, .8);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-right-color: transparent;</code></pre>
+        <pre><code class="language-css">border-right-color: transparent;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-right-style.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-right-style.html
@@ -1,41 +1,41 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="borderRightStyle">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">border-right-style: none;</code></pre>
+<pre><code class="language-css">border-right-style: none;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">border-right-style: dotted;</code></pre>
+<pre><code class="language-css">border-right-style: dotted;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">border-right-style: dashed;</code></pre>
+<pre><code class="language-css">border-right-style: dashed;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">border-right-style: solid;</code></pre>
+<pre><code class="language-css">border-right-style: solid;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">border-right-style: groove;</code></pre>
+<pre><code class="language-css">border-right-style: groove;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">border-right-style: inset;</code></pre>
+<pre><code class="language-css">border-right-style: inset;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-right-width.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-right-width.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-right-width">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">border-right-width: thick;</code></pre>
+        <pre><code class="language-css">border-right-width: thick;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-right-width: 2em;</code></pre>
+        <pre><code class="language-css">border-right-width: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-right-width: 4px;</code></pre>
+        <pre><code class="language-css">border-right-width: 4px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-right-width: 2ex;</code></pre>
+        <pre><code class="language-css">border-right-width: 2ex;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-right-width: 0;</code></pre>
+        <pre><code class="language-css">border-right-width: 0;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-right.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-right.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-right">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">border-right: solid;</code></pre>
+        <pre><code class="language-css">border-right: solid;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-right: dashed red;</code></pre>
+        <pre><code class="language-css">border-right: dashed red;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-right: 1rem solid;</code></pre>
+        <pre><code class="language-css">border-right: 1rem solid;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-right: thick double #32a1ce;</code></pre>
+        <pre><code class="language-css">border-right: thick double #32a1ce;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-right: 4mm ridge rgb(170, 50, 220, .6);</code></pre>
+        <pre><code class="language-css">border-right: 4mm ridge rgb(170, 50, 220, .6);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-style.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-style.html
@@ -1,41 +1,41 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="borderStyle">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">border-style: none;</code></pre>
+<pre><code class="language-css">border-style: none;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">border-style: dotted;</code></pre>
+<pre><code class="language-css">border-style: dotted;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">border-style: inset;</code></pre>
+<pre><code class="language-css">border-style: inset;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">border-style: dashed solid;</code></pre>
+<pre><code class="language-css">border-style: dashed solid;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">border-style: dashed double none;</code></pre>
+<pre><code class="language-css">border-style: dashed double none;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">border-style: dashed groove none dotted;</code></pre>
+<pre><code class="language-css">border-style: dashed groove none dotted;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-top-color.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-top-color.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-top-color">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">border-top-color: red;</code></pre>
+        <pre><code class="language-css">border-top-color: red;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-top-color: #32a1ce;</code></pre>
+        <pre><code class="language-css">border-top-color: #32a1ce;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-top-color: rgb(170, 50, 220, .6);</code></pre>
+        <pre><code class="language-css">border-top-color: rgb(170, 50, 220, .6);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-top-color: hsl(60, 90%, 50%, .8);</code></pre>
+        <pre><code class="language-css">border-top-color: hsl(60, 90%, 50%, .8);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-top-color: transparent;</code></pre>
+        <pre><code class="language-css">border-top-color: transparent;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-top-style.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-top-style.html
@@ -1,41 +1,41 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="borderTopStyle">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">border-top-style: none;</code></pre>
+<pre><code class="language-css">border-top-style: none;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">border-top-style: dotted;</code></pre>
+<pre><code class="language-css">border-top-style: dotted;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">border-top-style: dashed;</code></pre>
+<pre><code class="language-css">border-top-style: dashed;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">border-top-style: solid;</code></pre>
+<pre><code class="language-css">border-top-style: solid;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">border-top-style: groove;</code></pre>
+<pre><code class="language-css">border-top-style: groove;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">border-top-style: inset;</code></pre>
+<pre><code class="language-css">border-top-style: inset;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-top-width.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-top-width.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-top-width">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">border-top-width: thick;</code></pre>
+        <pre><code class="language-css">border-top-width: thick;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-top-width: 2em;</code></pre>
+        <pre><code class="language-css">border-top-width: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-top-width: 4px;</code></pre>
+        <pre><code class="language-css">border-top-width: 4px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-top-width: 2ex;</code></pre>
+        <pre><code class="language-css">border-top-width: 2ex;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-top-width: 0;</code></pre>
+        <pre><code class="language-css">border-top-width: 0;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-top.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-top.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-top">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">border-top: solid;</code></pre>
+        <pre><code class="language-css">border-top: solid;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-top: dashed red;</code></pre>
+        <pre><code class="language-css">border-top: dashed red;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-top: 1rem solid;</code></pre>
+        <pre><code class="language-css">border-top: 1rem solid;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-top: thick double #32a1ce;</code></pre>
+        <pre><code class="language-css">border-top: thick double #32a1ce;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-top: 4mm ridge rgb(170, 50, 220, .6);</code></pre>
+        <pre><code class="language-css">border-top: 4mm ridge rgb(170, 50, 220, .6);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-width.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-width.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-width">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">border-width: thick;</code></pre>
+        <pre><code class="language-css">border-width: thick;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border-width: 1em;</code></pre>
+        <pre><code class="language-css">border-width: 1em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border-width: 4px 1.25em;</code></pre>
+        <pre><code class="language-css">border-width: 4px 1.25em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border-width: 2ex 1.25ex 0.5ex;</code></pre>
+        <pre><code class="language-css">border-width: 2ex 1.25ex 0.5ex;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border-width: 0 4px 8px 12px;</code></pre>
+        <pre><code class="language-css">border-width: 0 4px 8px 12px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">border: solid;</code></pre>
+        <pre><code class="language-css">border: solid;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">border: dashed red;</code></pre>
+        <pre><code class="language-css">border: dashed red;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">border: 1rem solid;</code></pre>
+        <pre><code class="language-css">border: 1rem solid;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">border: thick double #32a1ce;</code></pre>
+        <pre><code class="language-css">border: thick double #32a1ce;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">border: 4mm ridge rgb(170, 50, 220, .6);</code></pre>
+        <pre><code class="language-css">border: 4mm ridge rgb(170, 50, 220, .6);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/box-shadow.html
+++ b/live-examples/css-examples/backgrounds-and-borders/box-shadow.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list" data-property="boxShadow">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">box-shadow: 10px 5px 5px red;</code></pre>
+<pre><code class="language-css">box-shadow: 10px 5px 5px red;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">box-shadow: 60px -16px teal;</code></pre>
+<pre><code class="language-css">box-shadow: 60px -16px teal;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, .2);</code></pre>
+<pre><code class="language-css">box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, .2);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">box-shadow: inset 5em 1em gold;</code></pre>
+<pre><code class="language-css">box-shadow: inset 5em 1em gold;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">box-shadow: 3px 3px red, -1em 0 .4em olive;</code></pre>
+<pre><code class="language-css">box-shadow: 3px 3px red, -1em 0 .4em olive;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/basic-box-model/margin.html
+++ b/live-examples/css-examples/basic-box-model/margin.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="margin">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">margin: 1em;</code></pre>
+<pre><code class="language-css">margin: 1em;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">margin: 5% 0;</code></pre>
+<pre><code class="language-css">margin: 5% 0;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">margin: 10px 50px 20px;</code></pre>
+<pre><code class="language-css">margin: 10px 50px 20px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">margin: 10px 50px 20px 0;</code></pre>
+<pre><code class="language-css">margin: 10px 50px 20px 0;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">margin: 0;</code></pre>
+<pre><code class="language-css">margin: 0;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/basic-box-model/overflow-x.html
+++ b/live-examples/css-examples/basic-box-model/overflow-x.html
@@ -1,28 +1,28 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="overflow-x">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">overflow-x: visible;</code></pre>
+        <pre><code class="language-css">overflow-x: visible;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">overflow-x: hidden;</code></pre>
+        <pre><code class="language-css">overflow-x: hidden;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">overflow-x: scroll;</code></pre>
+        <pre><code class="language-css">overflow-x: scroll;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">overflow-x: auto;</code></pre>
+        <pre><code class="language-css">overflow-x: auto;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/basic-box-model/overflow-y.html
+++ b/live-examples/css-examples/basic-box-model/overflow-y.html
@@ -1,28 +1,28 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="overflow-y">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">overflow-y: visible;</code></pre>
+        <pre><code class="language-css">overflow-y: visible;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">overflow-y: hidden;</code></pre>
+        <pre><code class="language-css">overflow-y: hidden;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">overflow-y: scroll;</code></pre>
+        <pre><code class="language-css">overflow-y: scroll;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">overflow-y: auto;</code></pre>
+        <pre><code class="language-css">overflow-y: auto;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/basic-box-model/overflow.html
+++ b/live-examples/css-examples/basic-box-model/overflow.html
@@ -1,28 +1,28 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="overflow">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">overflow: visible;</code></pre>
+        <pre><code class="language-css">overflow: visible;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">overflow: hidden;</code></pre>
+        <pre><code class="language-css">overflow: hidden;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">overflow: scroll;</code></pre>
+        <pre><code class="language-css">overflow: scroll;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">overflow: auto;</code></pre>
+        <pre><code class="language-css">overflow: auto;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/basic-box-model/padding-bottom.html
+++ b/live-examples/css-examples/basic-box-model/padding-bottom.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="padding-bottom">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">padding-bottom: 1em;</code></pre>
+<pre><code class="language-css">padding-bottom: 1em;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">padding-bottom: 10%;</code></pre>
+<pre><code class="language-css">padding-bottom: 10%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">padding-bottom: 20px;</code></pre>
+<pre><code class="language-css">padding-bottom: 20px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">padding-bottom: 1ch;</code></pre>
+<pre><code class="language-css">padding-bottom: 1ch;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">padding-bottom: 0;</code></pre>
+<pre><code class="language-css">padding-bottom: 0;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/basic-box-model/padding-left.html
+++ b/live-examples/css-examples/basic-box-model/padding-left.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="padding-left">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">padding-left: 1.5em;</code></pre>
+<pre><code class="language-css">padding-left: 1.5em;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">padding-left: 10%;</code></pre>
+<pre><code class="language-css">padding-left: 10%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">padding-left: 20px;</code></pre>
+<pre><code class="language-css">padding-left: 20px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">padding-left: 1ch;</code></pre>
+<pre><code class="language-css">padding-left: 1ch;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">padding-left: 0;</code></pre>
+<pre><code class="language-css">padding-left: 0;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/basic-box-model/padding-right.html
+++ b/live-examples/css-examples/basic-box-model/padding-right.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="padding-right">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">padding-right: 1.5em;</code></pre>
+<pre><code class="language-css">padding-right: 1.5em;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">padding-right: 10%;</code></pre>
+<pre><code class="language-css">padding-right: 10%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">padding-right: 20px;</code></pre>
+<pre><code class="language-css">padding-right: 20px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">padding-right: 1ch;</code></pre>
+<pre><code class="language-css">padding-right: 1ch;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">padding-right: 0;</code></pre>
+<pre><code class="language-css">padding-right: 0;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/basic-box-model/padding-top.html
+++ b/live-examples/css-examples/basic-box-model/padding-top.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="padding-top">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">padding-top: 1em;</code></pre>
+<pre><code class="language-css">padding-top: 1em;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">padding-top: 10%;</code></pre>
+<pre><code class="language-css">padding-top: 10%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">padding-top: 20px;</code></pre>
+<pre><code class="language-css">padding-top: 20px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">padding-top: 1ch;</code></pre>
+<pre><code class="language-css">padding-top: 1ch;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">padding-top: 0;</code></pre>
+<pre><code class="language-css">padding-top: 0;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/basic-box-model/padding.html
+++ b/live-examples/css-examples/basic-box-model/padding.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="padding">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">padding: 1em;</code></pre>
+<pre><code class="language-css">padding: 1em;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">padding: 10% 0;</code></pre>
+<pre><code class="language-css">padding: 10% 0;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">padding: 10px 50px 20px;</code></pre>
+<pre><code class="language-css">padding: 10px 50px 20px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">padding: 10px 50px 30px 0;</code></pre>
+<pre><code class="language-css">padding: 10px 50px 30px 0;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">padding: 0;</code></pre>
+<pre><code class="language-css">padding: 0;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/basic-user-interface/box-sizing.html
+++ b/live-examples/css-examples/basic-user-interface/box-sizing.html
@@ -1,6 +1,6 @@
 <section id="example-choice-list" class="example-choice-list" data-property="boxSizing">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">box-sizing: content-box;
+<pre><code class="language-css">box-sizing: content-box;
 width: 100%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -8,7 +8,7 @@ width: 100%;</code></pre>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">box-sizing: content-box;
+<pre><code class="language-css">box-sizing: content-box;
 width: 100%;
 border: solid #5B6DCD 10px;
 padding: 5px;</code></pre>
@@ -18,7 +18,7 @@ padding: 5px;</code></pre>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">box-sizing: border-box;
+<pre><code class="language-css">box-sizing: border-box;
 width: 100%;
 border: solid #5B6DCD 10px;
 padding: 5px;</code></pre>

--- a/live-examples/css-examples/basic-user-interface/outline-color.html
+++ b/live-examples/css-examples/basic-user-interface/outline-color.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="outline-color">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">outline-color: red;</code></pre>
+        <pre><code class="language-css">outline-color: red;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">outline-color: #32a1ce;</code></pre>
+        <pre><code class="language-css">outline-color: #32a1ce;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">outline-color: rgba(170, 50, 220, .6);</code></pre>
+        <pre><code class="language-css">outline-color: rgba(170, 50, 220, .6);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">outline-color: hsla(60, 90%, 50%, .8);</code></pre>
+        <pre><code class="language-css">outline-color: hsla(60, 90%, 50%, .8);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">outline-color: currentcolor;</code></pre>
+        <pre><code class="language-css">outline-color: currentcolor;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/basic-user-interface/outline-offset.html
+++ b/live-examples/css-examples/basic-user-interface/outline-offset.html
@@ -1,21 +1,21 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="outline-offset">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">outline-offset: 4px;</code></pre>
+        <pre><code class="language-css">outline-offset: 4px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">outline-offset: .6rem;</code></pre>
+        <pre><code class="language-css">outline-offset: .6rem;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">outline-offset: 12px;
+        <pre><code class="language-css">outline-offset: 12px;
 outline: 5px dashed blue;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/basic-user-interface/outline-style.html
+++ b/live-examples/css-examples/basic-user-interface/outline-style.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="outline-style">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">outline-style: none;</code></pre>
+        <pre><code class="language-css">outline-style: none;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_two" class="language-css">outline-style: dotted;</code></pre>
+        <pre><code class="language-css">outline-style: dotted;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">outline-style: solid;</code></pre>
+        <pre><code class="language-css">outline-style: solid;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">outline-style: groove;</code></pre>
+        <pre><code class="language-css">outline-style: groove;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">outline-style: inset;</code></pre>
+        <pre><code class="language-css">outline-style: inset;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/basic-user-interface/outline-width.html
+++ b/live-examples/css-examples/basic-user-interface/outline-width.html
@@ -1,28 +1,28 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="outline-width">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">outline-width: 12px;</code></pre>
+        <pre><code class="language-css">outline-width: 12px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">outline-width: thin;</code></pre>
+        <pre><code class="language-css">outline-width: thin;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">outline-width: medium;</code></pre>
+        <pre><code class="language-css">outline-width: medium;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">outline-width: thick;</code></pre>
+        <pre><code class="language-css">outline-width: thick;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/basic-user-interface/outline.html
+++ b/live-examples/css-examples/basic-user-interface/outline.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="outline">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">outline: solid;</code></pre>
+        <pre><code class="language-css">outline: solid;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">outline: dashed red;</code></pre>
+        <pre><code class="language-css">outline: dashed red;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">outline: 1rem solid;</code></pre>
+        <pre><code class="language-css">outline: 1rem solid;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">outline: thick double #32a1ce;</code></pre>
+        <pre><code class="language-css">outline: thick double #32a1ce;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">outline: 8px ridge rgba(170, 50, 220, .6);
+        <pre><code class="language-css">outline: 8px ridge rgba(170, 50, 220, .6);
 border-radius: 2rem;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/basic-user-interface/text-overflow.html
+++ b/live-examples/css-examples/basic-user-interface/text-overflow.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textOverflow">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">text-overflow: clip;</code></pre>
+<pre><code class="language-css">text-overflow: clip;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">text-overflow: ellipsis;</code></pre>
+<pre><code class="language-css">text-overflow: ellipsis;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">text-overflow: "-";</code></pre>
+<pre><code class="language-css">text-overflow: "-";</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">text-overflow: "";</code></pre>
+<pre><code class="language-css">text-overflow: "";</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/color/color.html
+++ b/live-examples/css-examples/color/color.html
@@ -1,55 +1,55 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="color">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">color: currentcolor;</code></pre>
+<pre><code class="language-css">color: currentcolor;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">color: rebeccapurple;</code></pre>
+<pre><code class="language-css">color: rebeccapurple;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">color: #00ff00;</code></pre>
+<pre><code class="language-css">color: #00ff00;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">color: rgb(34, 12, 64);</code></pre>
+<pre><code class="language-css">color: rgb(34, 12, 64);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">color: rgba(34, 12, 64, 0.3);</code></pre>
+<pre><code class="language-css">color: rgba(34, 12, 64, 0.3);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">color: hsl(30, 100%, 50%);</code></pre>
+<pre><code class="language-css">color: hsl(30, 100%, 50%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_seven" class="language-css">color: hsla(30, 100%, 50%, 0.3);</code></pre>
+<pre><code class="language-css">color: hsla(30, 100%, 50%, 0.3);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_eight" class="language-css">color: initial;</code></pre>
+<pre><code class="language-css">color: initial;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/color/opacity.html
+++ b/live-examples/css-examples/color/opacity.html
@@ -1,19 +1,19 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="opacity">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">opacity: 0;</code></pre>
+        <pre><code class="language-css">opacity: 0;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_two" class="language-css">opacity: 0.33;</code></pre>
+        <pre><code class="language-css">opacity: 0.33;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">opacity: 1;</code></pre>
+        <pre><code class="language-css">opacity: 1;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/filter-effects/blur.html
+++ b/live-examples/css-examples/filter-effects/blur.html
@@ -1,20 +1,20 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="filter">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">filter: blur(0);</code></pre>
+<pre><code class="language-css">filter: blur(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">filter: blur(4px);</code></pre>
+<pre><code class="language-css">filter: blur(4px);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">filter: blur(1.5rem);</code></pre>
+<pre><code class="language-css">filter: blur(1.5rem);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/filter-effects/brightness.html
+++ b/live-examples/css-examples/filter-effects/brightness.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="filter">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">filter: brightness(1);</code></pre>
+<pre><code class="language-css">filter: brightness(1);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">filter: brightness(1.75);</code></pre>
+<pre><code class="language-css">filter: brightness(1.75);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">filter: brightness(50%);</code></pre>
+<pre><code class="language-css">filter: brightness(50%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">filter: brightness(0);</code></pre>
+<pre><code class="language-css">filter: brightness(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/filter-effects/contrast.html
+++ b/live-examples/css-examples/filter-effects/contrast.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="filter">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">filter: contrast(1);</code></pre>
+<pre><code class="language-css">filter: contrast(1);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">filter: contrast(1.75);</code></pre>
+<pre><code class="language-css">filter: contrast(1.75);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">filter: contrast(50%);</code></pre>
+<pre><code class="language-css">filter: contrast(50%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">filter: contrast(0);</code></pre>
+<pre><code class="language-css">filter: contrast(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/filter-effects/drop-shadow.html
+++ b/live-examples/css-examples/filter-effects/drop-shadow.html
@@ -1,20 +1,20 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="filter">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">filter: drop-shadow(30px 10px 4px #4444dd);</code></pre>
+<pre><code class="language-css">filter: drop-shadow(30px 10px 4px #4444dd);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">filter: drop-shadow(0 -6mm 4mm rgb(160, 0, 210));</code></pre>
+<pre><code class="language-css">filter: drop-shadow(0 -6mm 4mm rgb(160, 0, 210));</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">filter: drop-shadow(0 0 0.75rem crimson);</code></pre>
+<pre><code class="language-css">filter: drop-shadow(0 0 0.75rem crimson);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/filter-effects/filter.html
+++ b/live-examples/css-examples/filter-effects/filter.html
@@ -1,41 +1,41 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="filter">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">filter: url("../../media/examples/shadow.svg#element-id");</code></pre>
+<pre><code class="language-css">filter: url("../../media/examples/shadow.svg#element-id");</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">filter: blur(5px);</code></pre>
+<pre><code class="language-css">filter: blur(5px);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">filter: contrast(200%);</code></pre>
+<pre><code class="language-css">filter: contrast(200%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">filter: grayscale(80%);</code></pre>
+<pre><code class="language-css">filter: grayscale(80%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_five" class="language-css">filter: hue-rotate(90deg);</code></pre>
+<pre><code class="language-css">filter: hue-rotate(90deg);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">filter: drop-shadow(16px 16px 20px red) invert(75%);</code></pre>
+<pre><code class="language-css">filter: drop-shadow(16px 16px 20px red) invert(75%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/filter-effects/grayscale.html
+++ b/live-examples/css-examples/filter-effects/grayscale.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="filter">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">filter: grayscale(0);</code></pre>
+<pre><code class="language-css">filter: grayscale(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">filter: grayscale(0.20);</code></pre>
+<pre><code class="language-css">filter: grayscale(0.20);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">filter: grayscale(60%);</code></pre>
+<pre><code class="language-css">filter: grayscale(60%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">filter: grayscale(1);</code></pre>
+<pre><code class="language-css">filter: grayscale(1);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/filter-effects/hue-rotate.html
+++ b/live-examples/css-examples/filter-effects/hue-rotate.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="filter">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">filter: hue-rotate(0);</code></pre>
+<pre><code class="language-css">filter: hue-rotate(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">filter: hue-rotate(90deg);</code></pre>
+<pre><code class="language-css">filter: hue-rotate(90deg);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">filter: hue-rotate(-0.25turn);</code></pre>
+<pre><code class="language-css">filter: hue-rotate(-0.25turn);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">filter: hue-rotate(3.142rad);</code></pre>
+<pre><code class="language-css">filter: hue-rotate(3.142rad);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/filter-effects/invert.html
+++ b/live-examples/css-examples/filter-effects/invert.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="filter">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">filter: invert(0);</code></pre>
+<pre><code class="language-css">filter: invert(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">filter: invert(0.30);</code></pre>
+<pre><code class="language-css">filter: invert(0.30);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">filter: invert(50%);</code></pre>
+<pre><code class="language-css">filter: invert(50%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">filter: invert(70%);</code></pre>
+<pre><code class="language-css">filter: invert(70%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">filter: invert(1);</code></pre>
+<pre><code class="language-css">filter: invert(1);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/filter-effects/opacity.html
+++ b/live-examples/css-examples/filter-effects/opacity.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="filter">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">filter: opacity(1);</code></pre>
+<pre><code class="language-css">filter: opacity(1);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">filter: opacity(80%);</code></pre>
+<pre><code class="language-css">filter: opacity(80%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">filter: opacity(50%);</code></pre>
+<pre><code class="language-css">filter: opacity(50%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">filter: opacity(0.20);</code></pre>
+<pre><code class="language-css">filter: opacity(0.20);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">filter: opacity(0);</code></pre>
+<pre><code class="language-css">filter: opacity(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/filter-effects/saturate.html
+++ b/live-examples/css-examples/filter-effects/saturate.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="filter">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">filter: saturate(1);</code></pre>
+<pre><code class="language-css">filter: saturate(1);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">filter: saturate(4);</code></pre>
+<pre><code class="language-css">filter: saturate(4);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">filter: saturate(50%);</code></pre>
+<pre><code class="language-css">filter: saturate(50%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">filter: saturate(0);</code></pre>
+<pre><code class="language-css">filter: saturate(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/filter-effects/sepia.html
+++ b/live-examples/css-examples/filter-effects/sepia.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="filter">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">filter: sepia(0);</code></pre>
+<pre><code class="language-css">filter: sepia(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">filter: sepia(0.20);</code></pre>
+<pre><code class="language-css">filter: sepia(0.20);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">filter: sepia(60%);</code></pre>
+<pre><code class="language-css">filter: sepia(60%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">filter: sepia(1);</code></pre>
+<pre><code class="language-css">filter: sepia(1);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/flexbox/flex-wrap.html
+++ b/live-examples/css-examples/flexbox/flex-wrap.html
@@ -1,21 +1,21 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="flex-wrap">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">flex-wrap: nowrap;</code></pre>
+        <pre><code class="language-css">flex-wrap: nowrap;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">flex-wrap: wrap;</code></pre>
+        <pre><code class="language-css">flex-wrap: wrap;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">flex-wrap: wrap-reverse;</code></pre>
+        <pre><code class="language-css">flex-wrap: wrap-reverse;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/fonts/font-family.html
+++ b/live-examples/css-examples/fonts/font-family.html
@@ -1,41 +1,41 @@
 <section id="example-choice-list" class="example-choice-list" data-property="font-family">
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_one" class="language-css">font-family: Georgia, serif;</code></pre>
+<pre><code class="language-css">font-family: Georgia, serif;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">font-family: "Gill Sans", sans-serif;</code></pre>
+<pre><code class="language-css">font-family: "Gill Sans", sans-serif;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">font-family: sans-serif;</code></pre>
+<pre><code class="language-css">font-family: sans-serif;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">font-family: serif;</code></pre>
+<pre><code class="language-css">font-family: serif;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">font-family: cursive;</code></pre>
+<pre><code class="language-css">font-family: cursive;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">font-family: system-ui;</code></pre>
+<pre><code class="language-css">font-family: system-ui;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/fonts/font-style.html
+++ b/live-examples/css-examples/fonts/font-style.html
@@ -1,20 +1,20 @@
 <section id="example-choice-list" class="example-choice-list" data-property="fontStyle">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">font-style: normal;</code></pre>
+<pre><code class="language-css">font-style: normal;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">font-style: italic;</code></pre>
+<pre><code class="language-css">font-style: italic;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">font-style: oblique;</code></pre>
+<pre><code class="language-css">font-style: oblique;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/fonts/font-weight.html
+++ b/live-examples/css-examples/fonts/font-weight.html
@@ -1,41 +1,41 @@
 <section id="example-choice-list" class="example-choice-list" data-property="font-family">
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_one" class="language-css">font-weight: normal;</code></pre>
+<pre><code class="language-css">font-weight: normal;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">font-weight: bold;</code></pre>
+<pre><code class="language-css">font-weight: bold;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">font-weight: lighter;</code></pre>
+<pre><code class="language-css">font-weight: lighter;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">font-weight: bolder;</code></pre>
+<pre><code class="language-css">font-weight: bolder;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">font-weight: 100;</code></pre>
+<pre><code class="language-css">font-weight: 100;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">font-weight: 900;</code></pre>
+<pre><code class="language-css">font-weight: 900;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/fonts/font.html
+++ b/live-examples/css-examples/fonts/font.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list" data-property="font">
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_one" class="language-css">font: 1.2em "Fira Sans", sans-serif;</code></pre>
+<pre><code class="language-css">font: 1.2em "Fira Sans", sans-serif;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">font: italic 1.2em "Fira Sans", serif;</code></pre>
+<pre><code class="language-css">font: italic 1.2em "Fira Sans", serif;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">font: italic small-caps bold 16px/2 cursive;</code></pre>
+<pre><code class="language-css">font: italic small-caps bold 16px/2 cursive;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">font: small-caps bold 24px/1 sans-serif;</code></pre>
+<pre><code class="language-css">font: small-caps bold 24px/1 sans-serif;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">font: caption;</code></pre>
+<pre><code class="language-css">font: caption;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/fragmentation/box-decoration-break.html
+++ b/live-examples/css-examples/fragmentation/box-decoration-break.html
@@ -1,13 +1,13 @@
 <section id="example-choice-list" class="example-choice-list" data-property="boxDecorationBreak">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">box-decoration-break: slice;</code></pre>
+<pre><code class="language-css">box-decoration-break: slice;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">box-decoration-break: clone;</code></pre>
+<pre><code class="language-css">box-decoration-break: clone;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/generated-content/quotes.html
+++ b/live-examples/css-examples/generated-content/quotes.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list" data-property="quotes">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">quotes: none;</code></pre>
+<pre><code class="language-css">quotes: none;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">quotes: initial;</code></pre>
+<pre><code class="language-css">quotes: initial;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_three" class="language-css">quotes: "'" "'";</code></pre>
+<pre><code class="language-css">quotes: "'" "'";</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">quotes: "„" "“" "‚" "‘";</code></pre>
+<pre><code class="language-css">quotes: "„" "“" "‚" "‘";</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">quotes: "«" "»" "‹" "›";</code></pre>
+<pre><code class="language-css">quotes: "«" "»" "‹" "›";</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/images/object-fit.html
+++ b/live-examples/css-examples/images/object-fit.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list" data-property="objectFit">
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_one" class="language-css">object-fit: fill;</code></pre>
+<pre><code class="language-css">object-fit: fill;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">object-fit: contain;</code></pre>
+<pre><code class="language-css">object-fit: contain;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">object-fit: cover;</code></pre>
+<pre><code class="language-css">object-fit: cover;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">object-fit: none;</code></pre>
+<pre><code class="language-css">object-fit: none;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">object-fit: scale-down;</code></pre>
+<pre><code class="language-css">object-fit: scale-down;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/positioned-layout/position.html
+++ b/live-examples/css-examples/positioned-layout/position.html
@@ -1,14 +1,14 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="position">
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_one" class="language-css">position: static;</code></pre>
+<pre><code class="language-css">position: static;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">position: relative;
+<pre><code class="language-css">position: relative;
 top: 65px; left: 65px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -16,7 +16,7 @@ top: 65px; left: 65px;</code></pre>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">position: absolute;
+<pre><code class="language-css">position: absolute;
 top: 40px; left: 40px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -24,7 +24,7 @@ top: 40px; left: 40px;</code></pre>
 </div>
 
 <div id="choice-sticky" class="example-choice">
-<pre><code id="example_four" class="language-css">position: sticky;
+<pre><code class="language-css">position: sticky;
 top: 20px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/table/border-collapse.html
+++ b/live-examples/css-examples/table/border-collapse.html
@@ -1,14 +1,14 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-collapse">
 
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">border-collapse: collapse;</code></pre>
+<pre><code class="language-css">border-collapse: collapse;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">border-collapse: separate;</code></pre>
+<pre><code class="language-css">border-collapse: separate;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/table/border-spacing.html
+++ b/live-examples/css-examples/table/border-spacing.html
@@ -1,21 +1,21 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="border-spacing">
 
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">border-spacing: 0;</code></pre>
+<pre><code class="language-css">border-spacing: 0;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">border-spacing: 5px;</code></pre>
+<pre><code class="language-css">border-spacing: 5px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">border-spacing: 5px 1rem;</code></pre>
+<pre><code class="language-css">border-spacing: 5px 1rem;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/table/caption-side.html
+++ b/live-examples/css-examples/table/caption-side.html
@@ -1,14 +1,14 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="caption-side">
 
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">caption-side: top;</code></pre>
+<pre><code class="language-css">caption-side: top;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">caption-side: bottom;</code></pre>
+<pre><code class="language-css">caption-side: bottom;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/table/empty-cells.html
+++ b/live-examples/css-examples/table/empty-cells.html
@@ -1,14 +1,14 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="empty-cells">
 
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">empty-cells: show;</code></pre>
+<pre><code class="language-css">empty-cells: show;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">empty-cells: hide;</code></pre>
+<pre><code class="language-css">empty-cells: hide;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/table/table-layout.html
+++ b/live-examples/css-examples/table/table-layout.html
@@ -1,7 +1,7 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="table-layout">
 
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">table-layout: auto;
+<pre><code class="language-css">table-layout: auto;
 width: 150px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -9,7 +9,7 @@ width: 150px;</code></pre>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">table-layout: fixed;
+<pre><code class="language-css">table-layout: fixed;
 width: 150px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -17,7 +17,7 @@ width: 150px;</code></pre>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">table-layout: auto;
+<pre><code class="language-css">table-layout: auto;
 width: 100%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -25,7 +25,7 @@ width: 100%;</code></pre>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">table-layout: fixed;
+<pre><code class="language-css">table-layout: fixed;
 width: 100%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/text-decoration/text-decoration-color.html
+++ b/live-examples/css-examples/text-decoration/text-decoration-color.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textDecorationColor">
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_one" class="language-css">text-decoration-color: red;</code></pre>
+<pre><code class="language-css">text-decoration-color: red;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">text-decoration-color: #21ff21;</code></pre>
+<pre><code class="language-css">text-decoration-color: #21ff21;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">text-decoration-color: rgb(255, 90, 255);</code></pre>
+<pre><code class="language-css">text-decoration-color: rgb(255, 90, 255);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">text-decoration-color: hsl(70, 100%, 40%);</code></pre>
+<pre><code class="language-css">text-decoration-color: hsl(70, 100%, 40%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">text-decoration-color: currentcolor;</code></pre>
+<pre><code class="language-css">text-decoration-color: currentcolor;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/text-decoration/text-decoration-line.html
+++ b/live-examples/css-examples/text-decoration/text-decoration-line.html
@@ -1,41 +1,41 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textDecorationLine">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">text-decoration-line: none;</code></pre>
+<pre><code class="language-css">text-decoration-line: none;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">text-decoration-line: underline;</code></pre>
+<pre><code class="language-css">text-decoration-line: underline;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">text-decoration-line: overline;</code></pre>
+<pre><code class="language-css">text-decoration-line: overline;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">text-decoration-line: line-through;</code></pre>
+<pre><code class="language-css">text-decoration-line: line-through;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">text-decoration-line: underline overline;</code></pre>
+<pre><code class="language-css">text-decoration-line: underline overline;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">text-decoration-line: underline line-through;</code></pre>
+<pre><code class="language-css">text-decoration-line: underline line-through;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/text-decoration/text-decoration-skip-ink.html
+++ b/live-examples/css-examples/text-decoration/text-decoration-skip-ink.html
@@ -1,13 +1,13 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textDecorationSkipInk">
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_one" class="language-css">text-decoration-skip-ink: auto;</code></pre>
+<pre><code class="language-css">text-decoration-skip-ink: auto;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">text-decoration-skip-ink: none;</code></pre>
+<pre><code class="language-css">text-decoration-skip-ink: none;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/text-decoration/text-decoration-style.html
+++ b/live-examples/css-examples/text-decoration/text-decoration-style.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textDecorationStyle">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">text-decoration-style: solid;</code></pre>
+<pre><code class="language-css">text-decoration-style: solid;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">text-decoration-style: double;</code></pre>
+<pre><code class="language-css">text-decoration-style: double;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">text-decoration-style: dotted;</code></pre>
+<pre><code class="language-css">text-decoration-style: dotted;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">text-decoration-style: dashed;</code></pre>
+<pre><code class="language-css">text-decoration-style: dashed;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">text-decoration-style: wavy;</code></pre>
+<pre><code class="language-css">text-decoration-style: wavy;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/text-decoration/text-decoration.html
+++ b/live-examples/css-examples/text-decoration/text-decoration.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textDecoration">
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_one" class="language-css">text-decoration: underline;</code></pre>
+<pre><code class="language-css">text-decoration: underline;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">text-decoration: underline dotted;</code></pre>
+<pre><code class="language-css">text-decoration: underline dotted;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">text-decoration: underline dotted red;</code></pre>
+<pre><code class="language-css">text-decoration: underline dotted red;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">text-decoration: green wavy underline;</code></pre>
+<pre><code class="language-css">text-decoration: green wavy underline;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">text-decoration: underline overline #FF3028;</code></pre>
+<pre><code class="language-css">text-decoration: underline overline #FF3028;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/text-decoration/text-shadow.html
+++ b/live-examples/css-examples/text-decoration/text-shadow.html
@@ -1,41 +1,41 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textShadow">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">text-shadow: 1px 1px 2px pink;</code></pre>
+<pre><code class="language-css">text-shadow: 1px 1px 2px pink;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">text-shadow: #FC0 1px 0 10px;</code></pre>
+<pre><code class="language-css">text-shadow: #FC0 1px 0 10px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">text-shadow: 5px 5px #558ABB;</code></pre>
+<pre><code class="language-css">text-shadow: 5px 5px #558ABB;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">text-shadow: red 2px 5px;</code></pre>
+<pre><code class="language-css">text-shadow: red 2px 5px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">text-shadow: 5px 10px;</code></pre>
+<pre><code class="language-css">text-shadow: 5px 10px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">text-shadow: 1px 1px 2px red, 0 0 1em blue, 0 0 0.2em blue;</code></pre>
+<pre><code class="language-css">text-shadow: 1px 1px 2px red, 0 0 1em blue, 0 0 0.2em blue;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/text/hyphens.html
+++ b/live-examples/css-examples/text/hyphens.html
@@ -1,20 +1,20 @@
 <section id="example-choice-list" class="example-choice-list" data-property="hyphens">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">hyphens: none;</code></pre>
+<pre><code class="language-css">hyphens: none;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">hyphens: manual;</code></pre>
+<pre><code class="language-css">hyphens: manual;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_three" class="language-css">hyphens: auto;</code></pre>
+<pre><code class="language-css">hyphens: auto;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/text/letter-spacing.html
+++ b/live-examples/css-examples/text/letter-spacing.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list" data-property="letterSpacing">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">letter-spacing: normal;</code></pre>
+<pre><code class="language-css">letter-spacing: normal;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">letter-spacing: .2rem;</code></pre>
+<pre><code class="language-css">letter-spacing: .2rem;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">letter-spacing: 1px;</code></pre>
+<pre><code class="language-css">letter-spacing: 1px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">letter-spacing: -1px;</code></pre>
+<pre><code class="language-css">letter-spacing: -1px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/text/overflow-wrap.html
+++ b/live-examples/css-examples/text/overflow-wrap.html
@@ -1,14 +1,14 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="overflow-wrap">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">overflow-wrap: normal;</code></pre>
+        <pre><code class="language-css">overflow-wrap: normal;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_two" class="language-css">overflow-wrap: break-word;</code></pre>
+        <pre><code class="language-css">overflow-wrap: break-word;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/text/text-align.html
+++ b/live-examples/css-examples/text/text-align.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textAlign">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">text-align: left;</code></pre>
+<pre><code class="language-css">text-align: left;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">text-align: right;</code></pre>
+<pre><code class="language-css">text-align: right;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">text-align: center;</code></pre>
+<pre><code class="language-css">text-align: center;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">text-align: justify;</code></pre>
+<pre><code class="language-css">text-align: justify;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/text/text-transform.html
+++ b/live-examples/css-examples/text/text-transform.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="textTransform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">text-transform: capitalize;</code></pre>
+<pre><code class="language-css">text-transform: capitalize;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">text-transform: uppercase;</code></pre>
+<pre><code class="language-css">text-transform: uppercase;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">text-transform: lowercase;</code></pre>
+<pre><code class="language-css">text-transform: lowercase;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">text-transform: none;</code></pre>
+<pre><code class="language-css">text-transform: none;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">text-transform: full-width;</code></pre>
+<pre><code class="language-css">text-transform: full-width;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/text/white-space.html
+++ b/live-examples/css-examples/text/white-space.html
@@ -1,30 +1,30 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="whiteSpace">
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">white-space: normal;</code></pre>
+        <pre><code class="language-css">white-space: normal;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">white-space: nowrap;</code></pre>
+        <pre><code class="language-css">white-space: nowrap;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">white-space: pre;</code></pre>
+        <pre><code class="language-css">white-space: pre;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">white-space: pre-wrap;</code></pre>
+        <pre><code class="language-css">white-space: pre-wrap;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">white-space: pre-line;</code></pre>
+        <pre><code class="language-css">white-space: pre-line;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/text/word-break.html
+++ b/live-examples/css-examples/text/word-break.html
@@ -1,24 +1,24 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="wordBreak">
     <div class="example-choice" initial-choice="true">
-        <pre><code id="example_one" class="language-css">word-break: normal;</code></pre>
+        <pre><code class="language-css">word-break: normal;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">word-break: break-all;</code></pre>
+        <pre><code class="language-css">word-break: break-all;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">word-break: keep-all;</code></pre>
+        <pre><code class="language-css">word-break: keep-all;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">word-break: break-word;</code></pre>
+        <pre><code class="language-css">word-break: break-word;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/text/word-spacing.html
+++ b/live-examples/css-examples/text/word-spacing.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list" data-property="wordSpacing">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">word-spacing: normal;</code></pre>
+<pre><code class="language-css">word-spacing: normal;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">word-spacing: 1rem;</code></pre>
+<pre><code class="language-css">word-spacing: 1rem;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">word-spacing: 4px;</code></pre>
+<pre><code class="language-css">word-spacing: 4px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">word-spacing: 120%;</code></pre>
+<pre><code class="language-css">word-spacing: 120%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">word-spacing: -.4ch;</code></pre>
+<pre><code class="language-css">word-spacing: -.4ch;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/backface-visibility.html
+++ b/live-examples/css-examples/transforms/backface-visibility.html
@@ -1,14 +1,14 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="backface-visibility">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">backface-visibility: visible;</code></pre>
+        <pre><code class="language-css">backface-visibility: visible;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">backface-visibility: hidden;</code></pre>
+        <pre><code class="language-css">backface-visibility: hidden;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/transforms/perspective.html
+++ b/live-examples/css-examples/transforms/perspective.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: perspective(0);</code></pre>
+<pre><code class="language-css">transform: perspective(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: perspective(800px);</code></pre>
+<pre><code class="language-css">transform: perspective(800px);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: perspective(23rem);</code></pre>
+<pre><code class="language-css">transform: perspective(23rem);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: perspective(6.5cm);</code></pre>
+<pre><code class="language-css">transform: perspective(6.5cm);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/rotate.html
+++ b/live-examples/css-examples/transforms/rotate.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: rotate(0);</code></pre>
+<pre><code class="language-css">transform: rotate(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: rotate(90deg);</code></pre>
+<pre><code class="language-css">transform: rotate(90deg);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: rotate(-0.25turn);</code></pre>
+<pre><code class="language-css">transform: rotate(-0.25turn);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: rotate(3.142rad);</code></pre>
+<pre><code class="language-css">transform: rotate(3.142rad);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/rotate3d.html
+++ b/live-examples/css-examples/transforms/rotate3d.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: rotate3d(0);</code></pre>
+<pre><code class="language-css">transform: rotate3d(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: rotate3d(1, 1, 1, 45deg);</code></pre>
+<pre><code class="language-css">transform: rotate3d(1, 1, 1, 45deg);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: rotate3d(2, -1, -1, -0.2turn);</code></pre>
+<pre><code class="language-css">transform: rotate3d(2, -1, -1, -0.2turn);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: rotate3d(0, 1, 0.5, 3.142rad);</code></pre>
+<pre><code class="language-css">transform: rotate3d(0, 1, 0.5, 3.142rad);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/rotateX.html
+++ b/live-examples/css-examples/transforms/rotateX.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: rotateX(0);</code></pre>
+<pre><code class="language-css">transform: rotateX(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: rotateX(45deg);</code></pre>
+<pre><code class="language-css">transform: rotateX(45deg);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: rotateX(-0.2turn);</code></pre>
+<pre><code class="language-css">transform: rotateX(-0.2turn);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: rotateX(3.142rad);</code></pre>
+<pre><code class="language-css">transform: rotateX(3.142rad);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/rotateY.html
+++ b/live-examples/css-examples/transforms/rotateY.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: rotateY(0);</code></pre>
+<pre><code class="language-css">transform: rotateY(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: rotateY(45deg);</code></pre>
+<pre><code class="language-css">transform: rotateY(45deg);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: rotateY(-0.2turn);</code></pre>
+<pre><code class="language-css">transform: rotateY(-0.2turn);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: rotateY(3.142rad);</code></pre>
+<pre><code class="language-css">transform: rotateY(3.142rad);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/rotateZ.html
+++ b/live-examples/css-examples/transforms/rotateZ.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: rotateZ(0);</code></pre>
+<pre><code class="language-css">transform: rotateZ(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: rotateZ(90deg);</code></pre>
+<pre><code class="language-css">transform: rotateZ(90deg);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: rotateZ(-0.25turn);</code></pre>
+<pre><code class="language-css">transform: rotateZ(-0.25turn);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: rotateZ(3.142rad);</code></pre>
+<pre><code class="language-css">transform: rotateZ(3.142rad);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/scale.html
+++ b/live-examples/css-examples/transforms/scale.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: scale(1);</code></pre>
+<pre><code class="language-css">transform: scale(1);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: scale(0.7);</code></pre>
+<pre><code class="language-css">transform: scale(0.7);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: scale(1.3, 0.4);</code></pre>
+<pre><code class="language-css">transform: scale(1.3, 0.4);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: scale(-0.5, 1);</code></pre>
+<pre><code class="language-css">transform: scale(-0.5, 1);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/scale3d.html
+++ b/live-examples/css-examples/transforms/scale3d.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: scale3d(1, 1, 1);</code></pre>
+<pre><code class="language-css">transform: scale3d(1, 1, 1);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: scale3d(1.3, 1.3, 1.3);</code></pre>
+<pre><code class="language-css">transform: scale3d(1.3, 1.3, 1.3);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: scale3d(0.5, 1, 1.7);</code></pre>
+<pre><code class="language-css">transform: scale3d(0.5, 1, 1.7);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: scale3d(-1.4, 0.4, 0.7);</code></pre>
+<pre><code class="language-css">transform: scale3d(-1.4, 0.4, 0.7);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/scaleX.html
+++ b/live-examples/css-examples/transforms/scaleX.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: scaleX(1);</code></pre>
+<pre><code class="language-css">transform: scaleX(1);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: scaleX(0.7);</code></pre>
+<pre><code class="language-css">transform: scaleX(0.7);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: scaleX(1.3);</code></pre>
+<pre><code class="language-css">transform: scaleX(1.3);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: scaleX(-0.5);</code></pre>
+<pre><code class="language-css">transform: scaleX(-0.5);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/scaleY.html
+++ b/live-examples/css-examples/transforms/scaleY.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: scaleY(1);</code></pre>
+<pre><code class="language-css">transform: scaleY(1);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: scaleY(0.7);</code></pre>
+<pre><code class="language-css">transform: scaleY(0.7);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: scaleY(1.3);</code></pre>
+<pre><code class="language-css">transform: scaleY(1.3);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: scaleY(-0.5);</code></pre>
+<pre><code class="language-css">transform: scaleY(-0.5);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/scaleZ.html
+++ b/live-examples/css-examples/transforms/scaleZ.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: scaleZ(1);</code></pre>
+<pre><code class="language-css">transform: scaleZ(1);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: scaleZ(1.4);</code></pre>
+<pre><code class="language-css">transform: scaleZ(1.4);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: scaleZ(0.5);</code></pre>
+<pre><code class="language-css">transform: scaleZ(0.5);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: scaleZ(-1.4);</code></pre>
+<pre><code class="language-css">transform: scaleZ(-1.4);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/skew.html
+++ b/live-examples/css-examples/transforms/skew.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: skew(0);</code></pre>
+<pre><code class="language-css">transform: skew(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: skew(15deg, 15deg);</code></pre>
+<pre><code class="language-css">transform: skew(15deg, 15deg);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: skew(-0.06turn, 18deg);</code></pre>
+<pre><code class="language-css">transform: skew(-0.06turn, 18deg);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: skew(.312rad);</code></pre>
+<pre><code class="language-css">transform: skew(.312rad);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/skewX.html
+++ b/live-examples/css-examples/transforms/skewX.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: skewX(0);</code></pre>
+<pre><code class="language-css">transform: skewX(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: skewX(35deg);</code></pre>
+<pre><code class="language-css">transform: skewX(35deg);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: skewX(-0.06turn);</code></pre>
+<pre><code class="language-css">transform: skewX(-0.06turn);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: skewX(.352rad);</code></pre>
+<pre><code class="language-css">transform: skewX(.352rad);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/skewY.html
+++ b/live-examples/css-examples/transforms/skewY.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: skewY(0);</code></pre>
+<pre><code class="language-css">transform: skewY(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: skewY(35deg);</code></pre>
+<pre><code class="language-css">transform: skewY(35deg);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: skewY(-0.06turn);</code></pre>
+<pre><code class="language-css">transform: skewY(-0.06turn);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: skewY(.352rad);</code></pre>
+<pre><code class="language-css">transform: skewY(.352rad);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/transform.html
+++ b/live-examples/css-examples/transforms/transform.html
@@ -1,41 +1,41 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: matrix(1, 2, 3, 4, 5, 6);</code></pre>
+<pre><code class="language-css">transform: matrix(1, 2, 3, 4, 5, 6);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">transform: translate(120px, 50%);</code></pre>
+<pre><code class="language-css">transform: translate(120px, 50%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: scale(2, 0.5);</code></pre>
+<pre><code class="language-css">transform: scale(2, 0.5);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_four" class="language-css">transform: rotate(0.5turn);</code></pre>
+<pre><code class="language-css">transform: rotate(0.5turn);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">transform: skew(30deg, 20deg);</code></pre>
+<pre><code class="language-css">transform: skew(30deg, 20deg);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">transform: scale(0.5) translate(-100%, -100%);</code></pre>
+<pre><code class="language-css">transform: scale(0.5) translate(-100%, -100%);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/translate.html
+++ b/live-examples/css-examples/transforms/translate.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: translate(0);</code></pre>
+<pre><code class="language-css">transform: translate(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: translate(42px, 18px);</code></pre>
+<pre><code class="language-css">transform: translate(42px, 18px);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: translate(-2.1rem, -2ex);</code></pre>
+<pre><code class="language-css">transform: translate(-2.1rem, -2ex);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: translate(3ch, 3mm);</code></pre>
+<pre><code class="language-css">transform: translate(3ch, 3mm);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/translate3d.html
+++ b/live-examples/css-examples/transforms/translate3d.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: translate3d(0);</code></pre>
+<pre><code class="language-css">transform: translate3d(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: translate3d(42px, -62px, -135px);</code></pre>
+<pre><code class="language-css">transform: translate3d(42px, -62px, -135px);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: translate3d(-2.7rem, 0, 1rem);</code></pre>
+<pre><code class="language-css">transform: translate3d(-2.7rem, 0, 1rem);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: translate3d(5ch, 0.4in, 5em);</code></pre>
+<pre><code class="language-css">transform: translate3d(5ch, 0.4in, 5em);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/translateX.html
+++ b/live-examples/css-examples/transforms/translateX.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: translateX(0);</code></pre>
+<pre><code class="language-css">transform: translateX(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: translateX(42px);</code></pre>
+<pre><code class="language-css">transform: translateX(42px);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: translateX(-2.1rem);</code></pre>
+<pre><code class="language-css">transform: translateX(-2.1rem);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: translateX(3ch);</code></pre>
+<pre><code class="language-css">transform: translateX(3ch);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/translateY.html
+++ b/live-examples/css-examples/transforms/translateY.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: translateY(0);</code></pre>
+<pre><code class="language-css">transform: translateY(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: translateY(42px);</code></pre>
+<pre><code class="language-css">transform: translateY(42px);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: translateY(-2.1rem);</code></pre>
+<pre><code class="language-css">transform: translateY(-2.1rem);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: translateY(3ch);</code></pre>
+<pre><code class="language-css">transform: translateY(3ch);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transforms/translateZ.html
+++ b/live-examples/css-examples/transforms/translateZ.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transform: translateZ(0);</code></pre>
+<pre><code class="language-css">transform: translateZ(0);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice" initial-choice="true">
-<pre><code id="example_two" class="language-css">transform: translateZ(42px);</code></pre>
+<pre><code class="language-css">transform: translateZ(42px);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transform: translateZ(-9.7rem);</code></pre>
+<pre><code class="language-css">transform: translateZ(-9.7rem);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transform: translateZ(-3ch);</code></pre>
+<pre><code class="language-css">transform: translateZ(-3ch);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transitions/line-height.html
+++ b/live-examples/css-examples/transitions/line-height.html
@@ -1,34 +1,34 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="lineHeight">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">line-height: normal;</code></pre>
+<pre><code class="language-css">line-height: normal;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">line-height: 2.5;</code></pre>
+<pre><code class="language-css">line-height: 2.5;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">line-height: 3em;</code></pre>
+<pre><code class="language-css">line-height: 3em;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">line-height: 150%;</code></pre>
+<pre><code class="language-css">line-height: 150%;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">line-height: 32px;</code></pre>
+<pre><code class="language-css">line-height: 32px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transitions/transition-delay.html
+++ b/live-examples/css-examples/transitions/transition-delay.html
@@ -1,6 +1,6 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transition-delay">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transition-delay: 250ms;
+<pre><code class="language-css">transition-delay: 250ms;
 transition-property: margin-right;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -8,7 +8,7 @@ transition-property: margin-right;</code></pre>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">transition-delay: 1s;
+<pre><code class="language-css">transition-delay: 1s;
 transition-property: background-color;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -16,7 +16,7 @@ transition-property: background-color;</code></pre>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transition-delay: 1s;
+<pre><code class="language-css">transition-delay: 1s;
 transition-property: margin-right, color;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -24,7 +24,7 @@ transition-property: margin-right, color;</code></pre>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transition-delay: 1s, 250ms;
+<pre><code class="language-css">transition-delay: 1s, 250ms;
 transition-property: margin-right, color;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/transitions/transition-duration.html
+++ b/live-examples/css-examples/transitions/transition-duration.html
@@ -1,6 +1,6 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transition-duration">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transition-duration: 500ms;
+<pre><code class="language-css">transition-duration: 500ms;
 transition-property: margin-right;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -8,7 +8,7 @@ transition-property: margin-right;</code></pre>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">transition-duration: 2s;
+<pre><code class="language-css">transition-duration: 2s;
 transition-property: background-color;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -16,7 +16,7 @@ transition-property: background-color;</code></pre>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transition-duration: 2s;
+<pre><code class="language-css">transition-duration: 2s;
 transition-property: margin-right, color;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -24,7 +24,7 @@ transition-property: margin-right, color;</code></pre>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transition-duration: 3s, 1s;
+<pre><code class="language-css">transition-duration: 3s, 1s;
 transition-property: margin-right, color;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/transitions/transition-property.html
+++ b/live-examples/css-examples/transitions/transition-property.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transition-property">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transition-property: margin-right;</code></pre>
+<pre><code class="language-css">transition-property: margin-right;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">transition-property: margin-right, color;</code></pre>
+<pre><code class="language-css">transition-property: margin-right, color;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transition-property: all;</code></pre>
+<pre><code class="language-css">transition-property: all;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transition-property: none;</code></pre>
+<pre><code class="language-css">transition-property: none;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transitions/transition-timing-function.html
+++ b/live-examples/css-examples/transitions/transition-timing-function.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transition-timing-function">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transition-timing-function: linear;</code></pre>
+<pre><code class="language-css">transition-timing-function: linear;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">transition-timing-function: ease-in;</code></pre>
+<pre><code class="language-css">transition-timing-function: ease-in;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transition-timing-function: steps(6, end);</code></pre>
+<pre><code class="language-css">transition-timing-function: steps(6, end);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transition-timing-function: cubic-bezier(.29, 1.01, 1, -0.68);</code></pre>
+<pre><code class="language-css">transition-timing-function: cubic-bezier(.29, 1.01, 1, -0.68);</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transitions/transition.html
+++ b/live-examples/css-examples/transitions/transition.html
@@ -1,41 +1,41 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transition">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">transition: margin-right 2s;</code></pre>
+<pre><code class="language-css">transition: margin-right 2s;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">transition: margin-right 2s .5s;</code></pre>
+<pre><code class="language-css">transition: margin-right 2s .5s;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">transition: margin-right 2s ease-in-out;</code></pre>
+<pre><code class="language-css">transition: margin-right 2s ease-in-out;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">transition: margin-right 2s ease-in-out .5s;</code></pre>
+<pre><code class="language-css">transition: margin-right 2s ease-in-out .5s;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_five" class="language-css">transition: margin-right 2s, color 1s;</code></pre>
+<pre><code class="language-css">transition: margin-right 2s, color 1s;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_six" class="language-css">transition: all 1s ease-out;</code></pre>
+<pre><code class="language-css">transition: all 1s ease-out;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/transitions/z-index.html
+++ b/live-examples/css-examples/transitions/z-index.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list" data-property="zIndex">
 <div class="example-choice">
-<pre><code id="example_one" class="language-css">z-index: 1;</code></pre>
+<pre><code class="language-css">z-index: 1;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_two" class="language-css">z-index: 3;</code></pre>
+<pre><code class="language-css">z-index: 3;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_three" class="language-css">z-index: 5;</code></pre>
+<pre><code class="language-css">z-index: 5;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code id="example_four" class="language-css">z-index: 7;</code></pre>
+<pre><code class="language-css">z-index: 7;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/values-and-units/angle.html
+++ b/live-examples/css-examples/values-and-units/angle.html
@@ -1,28 +1,28 @@
 <section id="example-choice-list" class="example-choice-list large">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">transform: rotate(45deg);</code></pre>
+        <pre><code class="language-css">transform: rotate(45deg);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">transform: rotate(3.1416rad);</code></pre>
+        <pre><code class="language-css">transform: rotate(3.1416rad);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">transform: rotate(-50grad);</code></pre>
+        <pre><code class="language-css">transform: rotate(-50grad);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">transform: rotate(1.75turn);</code></pre>
+        <pre><code class="language-css">transform: rotate(1.75turn);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/values-and-units/basic-shape.html
+++ b/live-examples/css-examples/values-and-units/basic-shape.html
@@ -1,35 +1,35 @@
 <section id="example-choice-list" class="example-choice-list large">
 
     <div class="example-choice">
-        <pre><code id="example_one" class="language-css">clip-path: inset(22% 12% 15px 35px);</code></pre>
+        <pre><code class="language-css">clip-path: inset(22% 12% 15px 35px);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_two" class="language-css">clip-path: circle(6rem at 12rem 8rem);</code></pre>
+        <pre><code class="language-css">clip-path: circle(6rem at 12rem 8rem);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_three" class="language-css">clip-path: ellipse(115px 55px at 50% 40%);</code></pre>
+        <pre><code class="language-css">clip-path: ellipse(115px 55px at 50% 40%);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_four" class="language-css">clip-path: polygon(50% 20%, 90% 80%, 10% 80%);</code></pre>
+        <pre><code class="language-css">clip-path: polygon(50% 20%, 90% 80%, 10% 80%);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code id="example_five" class="language-css">clip-path: polygon(50% 2.4%, 34.5% 33.8%, 0% 38.8%, 25% 63.1%, 19.1% 97.6%, 50% 81.3%, 80.9% 97.6%, 75% 63.1%, 100% 38.8%, 65.5% 33.8%);</code></pre>
+        <pre><code class="language-css">clip-path: polygon(50% 2.4%, 34.5% 33.8%, 0% 38.8%, 25% 63.1%, 19.1% 97.6%, 50% 81.3%, 80.9% 97.6%, 75% 63.1%, 100% 38.8%, 65.5% 33.8%);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>


### PR DESCRIPTION
Removes from both examples and contributing docs.

Fixes #548

Doesn't affect PRs: #547, #549, #551, #553