### PR TITLE
Add 'taller' to taller JS examples

### DIFF
--- a/live-examples/js-examples/classes/classes-extends.html
+++ b/live-examples/js-examples/classes/classes-extends.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">class formatDate extends Date {
+<code id="static-js" data-height="taller">class formatDate extends Date {
   constructor(dateStr) {
     super(dateStr);
   }

--- a/live-examples/js-examples/function/function-bind.html
+++ b/live-examples/js-examples/function/function-bind.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var module = {
+<code id="static-js" data-height="taller">var module = {
   x: 42,
   getX: function() {
     return this.x;

--- a/live-examples/js-examples/number/number-isnan.html
+++ b/live-examples/js-examples/number/number-isnan.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">function typeOfNaN(x) {
+<code id="static-js" data-height="taller">function typeOfNaN(x) {
   if (Number.isNaN(x)) {
     return 'Number NaN';
   }

--- a/live-examples/js-examples/proxyhandler/proxyhandler-apply.html
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-apply.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">function sum(a, b) {
+<code id="static-js" data-height="taller">function sum(a, b) {
   return a + b;
 }
 

--- a/live-examples/js-examples/proxyhandler/proxyhandler-construct.html
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-construct.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">function monster1(disposition) {
+<code id="static-js" data-height="taller">function monster1(disposition) {
   this.disposition = disposition;
 }
 

--- a/live-examples/js-examples/proxyhandler/proxyhandler-defineproperty.html
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-defineproperty.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">const handler1 = {
+<code id="static-js" data-height="taller">const handler1 = {
   defineProperty(target, key, descriptor) {
     invariant(key, 'define');
     return true;

--- a/live-examples/js-examples/proxyhandler/proxyhandler-get.html
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-get.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">const monster1 = {
+<code id="static-js" data-height="taller">const monster1 = {
   secret: 'easily scared',
   eyeCount: 4
 };

--- a/live-examples/js-examples/proxyhandler/proxyhandler-getownpropertydescriptor.html
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-getownpropertydescriptor.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">const monster1 = {
+<code id="static-js" data-height="taller">const monster1 = {
   eyeCount: 4
 };
 

--- a/live-examples/js-examples/proxyhandler/proxyhandler-getprototypeof.html
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-getprototypeof.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">const monster1 = {
+<code id="static-js" data-height="taller">const monster1 = {
   eyeCount: 4
 };
 

--- a/live-examples/js-examples/proxyhandler/proxyhandler-has.html
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-has.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">const handler1 = {
+<code id="static-js" data-height="taller">const handler1 = {
   has (target, key) {
     if (key[0] === '_') {
       return false;

--- a/live-examples/js-examples/proxyhandler/proxyhandler-isextensible.html
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-isextensible.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">const monster1 = {
+<code id="static-js" data-height="taller">const monster1 = {
   canEvolve: true
 };
 

--- a/live-examples/js-examples/proxyhandler/proxyhandler-ownkeys.html
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-ownkeys.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">const monster1 = {
+<code id="static-js" data-height="taller">const monster1 = {
   _age: 111,
   [Symbol('secret')]: 'I am scared!',
   eyeCount: 4

--- a/live-examples/js-examples/proxyhandler/proxyhandler-preventextensions.html
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-preventextensions.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">const monster1 = {
+<code id="static-js" data-height="taller">const monster1 = {
   canEvolve: true
 };
 

--- a/live-examples/js-examples/proxyhandler/proxyhandler-set.html
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-set.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">function Monster() {
+<code id="static-js" data-height="taller">function Monster() {
   this.eyeCount = 4;
 }
 

--- a/live-examples/js-examples/reflect/reflect-deleteproperty.html
+++ b/live-examples/js-examples/reflect/reflect-deleteproperty.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">const object1 = {
+<code id="static-js" data-height="taller">const object1 = {
   property1: 42
 };
 

--- a/live-examples/js-examples/reflect/reflect-isextensible.html
+++ b/live-examples/js-examples/reflect/reflect-isextensible.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">const object1 = {};
+<code id="static-js" data-height="taller">const object1 = {};
 
 console.log(Reflect.isExtensible(object1));
 // expected output: true

--- a/live-examples/js-examples/regexp/regexp-prototype-multiline.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-multiline.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var regex1 = new RegExp('^football');
+<code id="static-js" data-height="taller">var regex1 = new RegExp('^football');
 var regex2 = new RegExp('^football', 'm');
 
 console.log(regex1.multiline);

--- a/live-examples/js-examples/regexp/regexp-prototype-test.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-test.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var regex1 = RegExp('foo*');
+<code id="static-js" data-height="taller">var regex1 = RegExp('foo*');
 var regex2 = RegExp('foo*','g');
 var str1 = 'table football';
 

--- a/live-examples/js-examples/regexp/regexp-prototype-tostring.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-tostring.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">console.log(new RegExp('a+b+c'));
+<code id="static-js" data-height="taller">console.log(new RegExp('a+b+c'));
 // expected output: /a+b+c/
 
 console.log(new RegExp('a+b+c').toString());

--- a/live-examples/js-examples/regexp/regexp-prototype-unicode.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-unicode.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var regex1 = new RegExp('\u{61}');
+<code id="static-js" data-height="taller">var regex1 = new RegExp('\u{61}');
 var regex2 = new RegExp('\u{61}', 'u');
 
 console.log(regex1.unicode);

--- a/live-examples/js-examples/weakset/weakset-prototype-add.html
+++ b/live-examples/js-examples/weakset/weakset-prototype-add.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">const weakset1 = new WeakSet();
+<code id="static-js" data-height="taller">const weakset1 = new WeakSet();
 const object1 = {};
 
 weakset1.add(object1);


### PR DESCRIPTION
Fixes https://github.com/mdn/interactive-examples/issues/464.

This should add `data-height="taller"` to all the examples listed in https://github.com/mdn/interactive-examples/issues/464#issuecomment-360625731, except for these three examples, that already have it:

```
proxyhandler-setprototypeof
proxyhandler-deleteproperty
statement-async
```