### PR TITLE
Add resize example

### DIFF
--- a/live-examples/css-examples/basic-user-interface/meta.json
+++ b/live-examples/css-examples/basic-user-interface/meta.json
@@ -60,6 +60,14 @@
             "title": "CSS Demo: outline-width",
             "type": "css"
         },
+        "resize": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc": "../../live-examples/css-examples/basic-user-interface/resize.css",
+            "exampleCode": "live-examples/css-examples/basic-user-interface/resize.html",
+            "fileName": "resize.html",
+            "title": "CSS Demo: resize",
+            "type": "css"
+        },
         "textOverflow": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":

--- a/live-examples/css-examples/basic-user-interface/resize.css
+++ b/live-examples/css-examples/basic-user-interface/resize.css
@@ -1,0 +1,13 @@
+#example-element {
+  background: linear-gradient(135deg, #0ff 0%,#0ff 94%,#fff 95%);
+  border: 3px solid #000;
+  overflow: auto;
+  width: 250px;
+  height: 250px;
+  font-weight: bold;
+  color: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+}

--- a/live-examples/css-examples/basic-user-interface/resize.html
+++ b/live-examples/css-examples/basic-user-interface/resize.html
@@ -1,0 +1,37 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="resize">
+
+  <div class="example-choice" initial-choice="true">
+    <pre><code class="language-css">resize: both;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+        <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">resize: horizontal;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+        <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">resize: vertical;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+        <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">resize: none;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+        <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+</section>
+
+<div id="output" class="output large hidden">
+  <section id="default-example" class="default-example">
+    <div id="example-element">Try resizing this element.</div>
+  </section>
+</div>


### PR DESCRIPTION
https://github.com/mdn/interactive-examples/issues/581

Added examples for `both`, `horizontal`, `vertical`, and `none` values.

---

![image](https://user-images.githubusercontent.com/5430077/36136034-7209cef0-105c-11e8-8057-842fb827c1b9.png)
