### PR TITLE
Increase padding for code area

### DIFF
--- a/css/editable-css.css
+++ b/css/editable-css.css
@@ -70,7 +70,7 @@
 }
 
 .live .example-choice pre {
-    padding: 0 10px;
+    padding: 0 40px 0 10px;
 }
 
 .live .example-choice code {

--- a/css/editable-css.css
+++ b/css/editable-css.css
@@ -70,6 +70,10 @@
 }
 
 .live .example-choice pre {
+    padding: 0 10px;
+}
+
+.live .example-choice.selected pre {
     padding: 0 40px 0 10px;
 }
 


### PR DESCRIPTION
Sometimes CSS code examples overflow horizontally, When this happens, part of the code is covered by the copy button. For example, see https://developer.mozilla.org/en-US/docs/Web/CSS/background-image.

To fix this, this PR adds some more padding to the right side of the `<pre>` elements.