### PR TITLE
Add example for list-style-type CSS property

### DIFF
--- a/live-examples/css-examples/lists/list-style-type.html
+++ b/live-examples/css-examples/lists/list-style-type.html
@@ -1,5 +1,12 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="list-style">
     <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">list-style-type: space-counter;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+                <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
         <pre><code class="language-css">list-style-type: disc;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
                 <span class="visually-hidden">Copy to Clipboard</span>
@@ -15,13 +22,6 @@
 
     <div class="example-choice">
         <pre><code class="language-css">list-style-type: "\1F44D"; // thumbs up sign</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-                <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">list-style-type: space-counter;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
                 <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/lists/list-style-type.html
+++ b/live-examples/css-examples/lists/list-style-type.html
@@ -36,22 +36,18 @@
                 <li>Apollo</li>
                 <li>Hubble</li>
                 <li>Chandra</li>
-                <li>Cassini-Huygens</li>
-                <li>Spitzer</li>
             </ul>
         </div>
 
+        <hr>
+
         <div class="note">
-            <p><code>space-counter</code> is defined as:</p>
             <pre><code>@counter-style space-counter {
-    system: cyclic;
     symbols: "\1F680"
-             "\1F6F8"
              "\1F6F0"
-             "\1F52D";
+             "\1F6F8";
     suffix: " "
-}
-</code></pre>
+}</code></pre>
         </div>
     </section>
 </div>

--- a/live-examples/css-examples/lists/list-style-type.html
+++ b/live-examples/css-examples/lists/list-style-type.html
@@ -1,0 +1,57 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="list-style">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">list-style-type: disc;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+                <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">list-style-type: circle;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+                <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">list-style-type: "\1F44D"; // thumbs up sign</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+                <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">list-style-type: space-counter;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+                <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <div>
+            <p>NASA Notable Missions</p>
+            <ul id="example-element" class="transition-all">
+                <li>Apollo</li>
+                <li>Hubble</li>
+                <li>Chandra</li>
+                <li>Cassini-Huygens</li>
+                <li>Spitzer</li>
+            </ul>
+        </div>
+
+        <div class="note">
+            <p><code>space-counter</code> is defined as:</p>
+            <pre><code>@counter-style space-counter {
+    system: cyclic;
+    symbols: "\1F680"
+             "\1F6F8"
+             "\1F6F0"
+             "\1F52D";
+    suffix: " "
+}
+</code></pre>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/lists/list-style-type.html
+++ b/live-examples/css-examples/lists/list-style-type.html
@@ -32,10 +32,11 @@
     <section id="default-example" class="default-example">
         <div>
             <p>NASA Notable Missions</p>
-            <ul id="example-element" class="transition-all">
+            <ul id="example-element" class="transition-all list-style-type">
                 <li>Apollo</li>
                 <li>Hubble</li>
                 <li>Chandra</li>
+                <li>Cassini-Huygens</li>
             </ul>
         </div>
 
@@ -44,8 +45,9 @@
         <div class="note">
             <pre><code>@counter-style space-counter {
     symbols: "\1F680"
+             "\1F6F8"
              "\1F6F0"
-             "\1F6F8";
+             "\1F52D";
     suffix: " "
 }</code></pre>
         </div>

--- a/live-examples/css-examples/lists/list-style.css
+++ b/live-examples/css-examples/lists/list-style.css
@@ -13,3 +13,15 @@
 .output section li {
     background: #f1f8ff;
 }
+
+.output .note {
+    max-width: 50%;
+    margin: 1em auto auto 1em;
+    font-size: .8rem;
+}
+
+@counter-style space-counter {
+    system: cyclic;
+    symbols: "\1F680" "\1F6F8" "\1F6F0" "\1F52D";
+    suffix: " "
+}

--- a/live-examples/css-examples/lists/list-style.css
+++ b/live-examples/css-examples/lists/list-style.css
@@ -1,5 +1,5 @@
 .default-example {
-    font-size: 1.3rem;
+    font-size: 1.2rem;
 }
 
 #example-element {
@@ -19,6 +19,10 @@
     background: #f1f8ff;
 }
 
+.output section ul.list-style-type>li {
+    background: white;
+}
+
 .output hr {
     width: 50%;
     color: lightgray;
@@ -30,6 +34,6 @@
 }
 
 @counter-style space-counter {
-    symbols: "\1F680" "\1F6F0" "\1F52D";
+    symbols: "\1F680" "\1F6F8" "\1F6F0" "\1F52D";
     suffix: " "
 }

--- a/live-examples/css-examples/lists/list-style.css
+++ b/live-examples/css-examples/lists/list-style.css
@@ -6,22 +6,30 @@
     width: 100%;
 }
 
+.output * {
+    margin: 0 auto 0 auto;
+}
+
 .output section {
     text-align: left;
+    flex-direction: column;
 }
 
 .output section li {
     background: #f1f8ff;
 }
 
+.output hr {
+    width: 50%;
+    color: lightgray;
+    margin: .5em;
+}
+
 .output .note {
-    max-width: 50%;
-    margin: 1em auto auto 1em;
-    font-size: .8rem;
+    font-size: .8rem; */
 }
 
 @counter-style space-counter {
-    system: cyclic;
-    symbols: "\1F680" "\1F6F8" "\1F6F0" "\1F52D";
+    symbols: "\1F680" "\1F6F0" "\1F52D";
     suffix: " "
 }

--- a/live-examples/css-examples/lists/meta.json
+++ b/live-examples/css-examples/lists/meta.json
@@ -19,6 +19,16 @@
             "fileName": "list-style-position.html",
             "title": "CSS Demo: list-style-position",
             "type": "css"
+        },
+        "listStyleType": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/lists/list-style.css",
+            "exampleCode":
+                "live-examples/css-examples/lists/list-style-type.html",
+            "fileName": "list-style-type.html",
+            "title": "CSS Demo: list-style-type",
+            "type": "css"
         }
     }
 }


### PR DESCRIPTION
This PR adds an example for the [`list-style-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type) CSS property. This is my first attempt at an example (🎉) so I'm open to any and all input on this. One area in particular I'm concerned about is the appearance of the `@counter-style` definition.

This ought to fix #483 (which looked unclaimed to me, at the moment).