### PR TITLE
Clean up appearance of list-style-type example

### DIFF
--- a/live-examples/css-examples/lists/list-style-type.html
+++ b/live-examples/css-examples/lists/list-style-type.html
@@ -42,14 +42,6 @@
 
         <hr>
 
-        <div class="note">
-            <pre><code>@counter-style space-counter {
-    symbols: "\1F680"
-             "\1F6F8"
-             "\1F6F0"
-             "\1F52D";
-    suffix: " "
-}</code></pre>
-        </div>
+        <div class="note"><p><code>space-counter</code> is defined with <a href="https://developer.mozilla.org/docs/Web/CSS/%40counter-style"><code>@counter-style</code></a></p>
     </section>
 </div>

--- a/live-examples/css-examples/lists/list-style-type.html
+++ b/live-examples/css-examples/lists/list-style-type.html
@@ -42,6 +42,6 @@
 
         <hr>
 
-        <div class="note"><p><code>space-counter</code> is defined with <a href="https://developer.mozilla.org/docs/Web/CSS/%40counter-style"><code>@counter-style</code></a></p>
+        <div class="note"><p><code>space-counter</code> is defined with <a href="//developer.mozilla.org/docs/Web/CSS/@counter-style" target="_parent"><code>@counter-style</code></a></p>
     </section>
 </div>

--- a/live-examples/css-examples/lists/list-style.css
+++ b/live-examples/css-examples/lists/list-style.css
@@ -6,10 +6,6 @@
     width: 100%;
 }
 
-.output * {
-    margin: 0 auto 0 auto;
-}
-
 .output section {
     text-align: left;
     flex-direction: column;


### PR DESCRIPTION
Following up from the conversation on #594, this removes the complicated description of `@counter-style` in the `list-style-type` example.