### PR TITLE
Add example for animation-fill-mode CSS property

### DIFF
--- a/live-examples/css-examples/animation/animation-fill-mode.css
+++ b/live-examples/css-examples/animation/animation-fill-mode.css
@@ -1,6 +1,7 @@
 #example-element {
     background-color: #1766aa;
-    margin: 20px;
+    margin: auto;
+    margin-left: 0;
     border: 5px solid #333;
     width: 150px;
     height: 150px;

--- a/live-examples/css-examples/animation/animation-fill-mode.css
+++ b/live-examples/css-examples/animation/animation-fill-mode.css
@@ -1,5 +1,6 @@
 #example-element {
     background-color: #1766aa;
+    color: white;
     margin: auto;
     margin-left: 0;
     border: 5px solid #333;
@@ -24,10 +25,12 @@
 @-webkit-keyframes slide {
     from {
         background-color: orange;
+        color: black;
         margin-left: 0;
     }
     to {
         background-color: orange;
+        color: black;
         margin-left: 80%;
     }
 }
@@ -35,10 +38,12 @@
 @keyframes slide {
     from {
         background-color: orange;
+        color: black;
         margin-left: 0;
     }
     to {
         background-color: orange;
+        color: black;
         margin-left: 80%;
     }
 }

--- a/live-examples/css-examples/animation/animation-fill-mode.css
+++ b/live-examples/css-examples/animation/animation-fill-mode.css
@@ -1,18 +1,43 @@
 #example-element {
+    background-color: #1766aa;
+    margin: 20px;
+    border: 5px solid #333;
+    width: 150px;
+    height: 150px;
+    border-radius: 50%;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+}
+
+#playstatus {
+    font-weight: bold;
 }
 
 .animating {
-    animation: spin 1s ease-in .25s 1;
+    animation: slide 1s ease-in 1;
 }
 
-@-webkit-keyframes spin {
+@-webkit-keyframes slide {
+    from {
+        background-color: orange;
+        margin-left: 0;
+    }
     to {
-        transform: rotate(.75turn);
+        background-color: orange;
+        margin-left: 80%;
     }
 }
 
-@keyframes spin {
+@keyframes slide {
+    from {
+        background-color: orange;
+        margin-left: 0;
+    }
     to {
-        transform: rotate(.75turn);
+        background-color: orange;
+        margin-left: 80%;
     }
 }

--- a/live-examples/css-examples/animation/animation-fill-mode.css
+++ b/live-examples/css-examples/animation/animation-fill-mode.css
@@ -1,0 +1,18 @@
+#example-element {
+}
+
+.animating {
+    animation: spin 1s ease-in .25s 1;
+}
+
+@-webkit-keyframes spin {
+    to {
+        transform: rotate(.75turn);
+    }
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(.75turn);
+    }
+}

--- a/live-examples/css-examples/animation/animation-fill-mode.html
+++ b/live-examples/css-examples/animation/animation-fill-mode.html
@@ -1,7 +1,7 @@
 <section id="example-choice-list" class="example-choice-list" data-property="animation">
     <div class="example-choice">
         <pre><code class="language-css">animation-fill-mode: none;
-animation-delay: 2s;</code></pre>
+animation-delay: 1s;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -9,7 +9,7 @@ animation-delay: 2s;</code></pre>
 
     <div class="example-choice">
         <pre><code class="language-css">animation-fill-mode: forwards;
-animation-delay: 2s;</code></pre>
+animation-delay: 1s;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -17,7 +17,7 @@ animation-delay: 2s;</code></pre>
 
     <div class="example-choice">
         <pre><code class="language-css">animation-fill-mode: backwards;
-animation-delay: 2s;</code></pre>
+animation-delay: 1s;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -25,7 +25,7 @@ animation-delay: 2s;</code></pre>
 
     <div class="example-choice">
         <pre><code class="language-css">animation-fill-mode: both;
-animation-delay: 2s;</code></pre>
+animation-delay: 1s;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/animation/animation-fill-mode.html
+++ b/live-examples/css-examples/animation/animation-fill-mode.html
@@ -1,0 +1,21 @@
+<section id="example-choice-list" class="example-choice-list" data-property="animation">
+    <div class="example-choice">
+        <pre><code class="language-css">animation-fill-mode: none;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">animation-fill-mode: forwards;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example" class="flex-column">
+        <div id="example-element">Select a mode to spin!</div>
+    </section>
+</div>

--- a/live-examples/css-examples/animation/animation-fill-mode.html
+++ b/live-examples/css-examples/animation/animation-fill-mode.html
@@ -1,13 +1,31 @@
 <section id="example-choice-list" class="example-choice-list" data-property="animation">
     <div class="example-choice">
-        <pre><code class="language-css">animation-fill-mode: none;</code></pre>
+        <pre><code class="language-css">animation-fill-mode: none;
+animation-delay: 2s;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">animation-fill-mode: forwards;</code></pre>
+        <pre><code class="language-css">animation-fill-mode: forwards;
+animation-delay: 2s;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">animation-fill-mode: backwards;
+animation-delay: 2s;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">animation-fill-mode: both;
+animation-delay: 2s;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -16,6 +34,8 @@
 
 <div id="output" class="output hidden">
     <section id="default-example" class="flex-column">
-        <div id="example-element">Select a mode to spin!</div>
+        <div>Animation <span id="playstatus"></span></div>
+
+        <div id="example-element">Select a mode to start!</div>
     </section>
 </div>

--- a/live-examples/css-examples/animation/animation-fill-mode.js
+++ b/live-examples/css-examples/animation/animation-fill-mode.js
@@ -1,0 +1,25 @@
+'use strict';
+
+window.addEventListener('load', function() {
+    function update() {
+        el.className = '';
+        window.requestAnimationFrame(function() {
+            window.requestAnimationFrame(function() {
+                el.className = 'animating';
+            });
+        });
+    }
+
+    var el = document.getElementById('example-element');
+
+    var observer = new MutationObserver(function(mutations) {
+        update(mutations);
+    });
+
+    observer.observe(el, {
+        attributes: true,
+        attributeFilter: ['style']
+    });
+
+    update();
+});

--- a/live-examples/css-examples/animation/animation-fill-mode.js
+++ b/live-examples/css-examples/animation/animation-fill-mode.js
@@ -1,7 +1,11 @@
 'use strict';
 
 window.addEventListener('load', function() {
+    var el = document.getElementById('example-element');
+    var status = document.getElementById('playstatus');
+
     function update() {
+        status.textContent = 'delaying';
         el.className = '';
         window.requestAnimationFrame(function() {
             window.requestAnimationFrame(function() {
@@ -10,7 +14,15 @@ window.addEventListener('load', function() {
         });
     }
 
-    var el = document.getElementById('example-element');
+    el.addEventListener('animationstart', function(){
+        console.log('animationstart event');
+        status.textContent = 'playing';
+    });
+
+    el.addEventListener('animationend', function(){
+        console.log('animationend event');
+        status.textContent = 'finished';
+    });
 
     var observer = new MutationObserver(function(mutations) {
         update(mutations);

--- a/live-examples/css-examples/animation/meta.json
+++ b/live-examples/css-examples/animation/meta.json
@@ -8,6 +8,18 @@
             "fileName": "animation.html",
             "title": "CSS Demo: animation",
             "type": "css"
+        },
+        "animation-fill-mode": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/animation/animation-fill-mode.css",
+            "jsExampleSrc":
+                "../../live-examples/css-examples/animation/animation-fill-mode.js",
+            "exampleCode":
+                "live-examples/css-examples/animation/animation-fill-mode.html",
+            "fileName": "animation-fill-mode.html",
+            "title": "CSS Demo: animation-fill-mode",
+            "type": "css"
         }
     }
 }


### PR DESCRIPTION
This PR adds an example for [`animation-fill-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-fill-mode).

I think this might still be a work in progress. It's quite difficult to show the relationship between the mode and the animation without a lot of context for the animation itself (particularly the animation delay). I'm open to ideas on how to improve this. Let me know if you have any suggestions. Thanks!