### PR TITLE
Add examples for counter-reset and counter-increment

### DIFF
--- a/live-examples/css-examples/lists/counter-increment.css
+++ b/live-examples/css-examples/lists/counter-increment.css
@@ -1,0 +1,16 @@
+#default-example {
+    text-align: left;
+    counter-reset: chapter-count;
+}
+
+#example-element {
+    background-color: lightblue;
+}
+
+h2 {
+    font-size: 1em;
+}
+
+h2::before {
+    content: "Chapter " counter(chapter-count) ": ";
+}

--- a/live-examples/css-examples/lists/counter-increment.css
+++ b/live-examples/css-examples/lists/counter-increment.css
@@ -1,16 +1,8 @@
 #default-example {
     text-align: left;
-    counter-reset: chapter-count;
+    counter-reset: example-counter;
 }
 
-#example-element {
-    background-color: lightblue;
-}
-
-h2 {
-    font-size: 1em;
-}
-
-h2::before {
-    content: "Chapter " counter(chapter-count) ": ";
+#example-element::after {
+    content: counter(example-counter);
 }

--- a/live-examples/css-examples/lists/counter-increment.html
+++ b/live-examples/css-examples/lists/counter-increment.html
@@ -1,0 +1,41 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="list-style">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">counter-increment: chapter-count;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+                <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">counter-increment: chapter-count 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+                <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">counter-increment: chapter-count 5;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+                <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">counter-increment: chapter-count -5;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+                <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <div id="chapters" class="transition-all">
+            <h1>Alice's Adventures in Wonderland</h1>
+            <h2>Down the Rabbit-Hole</h2>
+            <h2 id="example-element">The Pool of Tears</h2>
+            <h2>A Caucus-Race and a Long Tale</h2>
+            <h2>The Rabbit Sends in a Little Bill</h2>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/lists/counter-increment.html
+++ b/live-examples/css-examples/lists/counter-increment.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="list-style">
+<section id="example-choice-list" class="example-choice-list large" data-property="counter-increment">
     <div class="example-choice" initial-choice="true">
         <pre><code class="language-css">counter-increment: example-counter;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">

--- a/live-examples/css-examples/lists/counter-increment.html
+++ b/live-examples/css-examples/lists/counter-increment.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="list-style">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">counter-increment: chapter-count;</code></pre>
+        <pre><code class="language-css">counter-increment: example-counter;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
                 <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">counter-increment: chapter-count 0;</code></pre>
+        <pre><code class="language-css">counter-increment: example-counter 0;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
                 <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">counter-increment: chapter-count 5;</code></pre>
+        <pre><code class="language-css">counter-increment: example-counter 5;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
                 <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">counter-increment: chapter-count -5;</code></pre>
+        <pre><code class="language-css">counter-increment: example-counter -5;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
                 <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -30,12 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
-        <div id="chapters" class="transition-all">
-            <h1>Alice's Adventures in Wonderland</h1>
-            <h2>Down the Rabbit-Hole</h2>
-            <h2 id="example-element">The Pool of Tears</h2>
-            <h2>A Caucus-Race and a Long Tale</h2>
-            <h2>The Rabbit Sends in a Little Bill</h2>
-        </div>
+        <div id="example-element" class="transition-all">Counter value: </div>
     </section>
 </div>

--- a/live-examples/css-examples/lists/counter-reset.css
+++ b/live-examples/css-examples/lists/counter-reset.css
@@ -1,0 +1,17 @@
+#default-example {
+    text-align: left;
+    counter-reset: chapter-count;
+}
+
+#example-element {
+    background-color: lightblue;
+}
+
+h2 {
+    counter-increment: chapter-count;
+    font-size: 1em;
+}
+
+h2::before {
+    content: "Chapter " counter(chapter-count) ": ";
+}

--- a/live-examples/css-examples/lists/counter-reset.html
+++ b/live-examples/css-examples/lists/counter-reset.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="list-style">
+<section id="example-choice-list" class="example-choice-list large" data-property="counter-reset">
     <div class="example-choice" initial-choice="true">
         <pre><code class="language-css">counter-reset: chapter-count 0;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">

--- a/live-examples/css-examples/lists/counter-reset.html
+++ b/live-examples/css-examples/lists/counter-reset.html
@@ -1,0 +1,41 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="list-style">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">counter-reset: chapter-count 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+                <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">counter-reset: chapter-count;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+                <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">counter-reset: chapter-count 5;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+                <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">counter-reset: chapter-count -5;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+                <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <div id="chapters" class="transition-all">
+            <h1>Alice's Adventures in Wonderland</h1>
+            <h2>Down the Rabbit-Hole</h2>
+            <h2 id="example-element">The Pool of Tears</h2>
+            <h2>A Caucus-Race and a Long Tale</h2>
+            <h2>The Rabbit Sends in a Little Bill</h2>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/lists/counter-reset.html
+++ b/live-examples/css-examples/lists/counter-reset.html
@@ -1,5 +1,12 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="counter-reset">
     <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">counter-reset: chapter-count none;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+                <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
         <pre><code class="language-css">counter-reset: chapter-count 0;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
                 <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/lists/meta.json
+++ b/live-examples/css-examples/lists/meta.json
@@ -10,6 +10,16 @@
             "title": "CSS Demo: counter-increment",
             "type": "css"
         },
+        "counterReset": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/lists/counter-reset.css",
+            "exampleCode":
+                "live-examples/css-examples/lists/counter-reset.html",
+            "fileName": "counter-reset.html",
+            "title": "CSS Demo: counter-reset",
+            "type": "css"
+        },
         "listStyle": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":

--- a/live-examples/css-examples/lists/meta.json
+++ b/live-examples/css-examples/lists/meta.json
@@ -1,5 +1,15 @@
 {
     "pages": {
+        "counterIncrement": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/lists/counter-increment.css",
+            "exampleCode":
+                "live-examples/css-examples/lists/counter-increment.html",
+            "fileName": "counter-increment.html",
+            "title": "CSS Demo: counter-increment",
+            "type": "css"
+        },
         "listStyle": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":


### PR DESCRIPTION
This PR adds examples for [`counter-reset`](https://developer.mozilla.org/en-US/docs/Web/CSS/counter-reset) and [`counter-increment`](https://developer.mozilla.org/en-US/docs/Web/CSS/counter-increment). Let me know if you want to see any changes. Thanks!