### PR TITLE
Document publishing an example on a wiki page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -336,6 +336,19 @@ Point your browser to:
 
 Once satisfied with the example, [submit your pull request](https://help.github.com/articles/creating-a-pull-request/).
 
+## Publishing
+
+After your pull request is reviewed and merged, you can publish your example on MDN Web Docs. On the page that corresponds to the example, add the following to the page source (typically after the introductory paragraph):
+
+```
+<div>{{EmbedInteractiveExample("pages/TYPE/FILENAME")}}</div>
+
+<p class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
+```
+
+where `TYPE` is the kind of example (such as `js`, `css`, or `html`) and `FILENAME` is the name of the file that contains the example (like `margin.html` or `date-constructor.html`).
+
+
 ## Thank you!
 
 Thank you for your contribution ~ o/\o


### PR DESCRIPTION
This PR adds a section to the contributing guide on how to embed an example on a page. I figured it would be nice to have it spelled out somewhere.