### PR TITLE
Add background color for output

### DIFF
--- a/css/tabbed-editor.css
+++ b/css/tabbed-editor.css
@@ -12,6 +12,8 @@
 
 .output {
     border-left: 0;
+    background-color: white;
+    margin: 0 1em;
 }
 
 .CodeMirror {


### PR DESCRIPTION
When they're embedded in MDN pages, the editors get a gray background. With the HTML editor, the output isn't given its own background, so it's not clear that the output is a distinct section:

<img width="852" alt="screen shot 2018-02-23 at 11 23 18 pm" src="https://user-images.githubusercontent.com/432915/36626960-e6366b2a-18f0-11e8-8a87-5d5c41d30169.png">

This PR adds a white background-color, and a bit of margin, to the output, so it should look like:

<img width="943" alt="screen shot 2018-02-23 at 11 26 52 pm" src="https://user-images.githubusercontent.com/432915/36626986-364c8392-18f1-11e8-95cb-a9992b4c7758.png">

It could probably use some refinement :) but should be an improvement. Let me know what you think!