### PR TITLE
reduce line-height for float and clear

### DIFF
--- a/live-examples/css-examples/basic-box-model/clear.css
+++ b/live-examples/css-examples/basic-box-model/clear.css
@@ -3,6 +3,7 @@
     border: .75em solid;
     padding: .75em;
     text-align: left;
+    line-height: normal;
 }
 
 .floated-left {

--- a/live-examples/css-examples/basic-box-model/float.css
+++ b/live-examples/css-examples/basic-box-model/float.css
@@ -4,6 +4,7 @@
     padding: .75em;
     text-align: left;
     width: 80%;
+    line-height: normal;
 }
 
 #example-element {


### PR DESCRIPTION
The examples for [`float`](https://developer.mozilla.org/en-US/docs/Web/CSS/float) and [`clear`](https://developer.mozilla.org/en-US/docs/Web/CSS/clear) overflow vertically quite easily. For example, here's what `float` looks like on my screen, full-width but with a sidebar open (tree-style tabs):

<img width="873" alt="screen shot 2018-02-24 at 10 59 50 pm" src="https://user-images.githubusercontent.com/432915/36639004-1f7b8408-19b7-11e8-8a7c-d34ca60f4d08.png">

This PR reduces line-height for these examples. Here's what `float` looks like at the same width, with this change:

<img width="874" alt="screen shot 2018-02-24 at 11 00 32 pm" src="https://user-images.githubusercontent.com/432915/36639009-3ee2bd02-19b7-11e8-9b0c-1653b04268c2.png">
