### PR TITLE
Allow more than one tabbed example

### DIFF
--- a/lib/pageBuilder.js
+++ b/lib/pageBuilder.js
@@ -41,42 +41,41 @@ function buildPages(pages) {
                 outputPath,
                 tabbedPageBuilder.buildTabbedExample(tmpl, currentPage)
             );
-            return;
-        }
-
-        // is there a linked CSS file
-        if (cssSource) {
-            // inject the link tag into the source
-            tmpl = processor.processInclude('css', tmpl, cssSource);
         } else {
-            // clear out the template string
-            tmpl = tmpl.replace('%example-css-src%', '');
+            // is there a linked CSS file
+            if (cssSource) {
+                // inject the link tag into the source
+                tmpl = processor.processInclude('css', tmpl, cssSource);
+            } else {
+                // clear out the template string
+                tmpl = tmpl.replace('%example-css-src%', '');
+            }
+
+            // is there a linked JS file
+            if (jsSource) {
+                // inject the script tag into the source
+                tmpl = processor.processInclude('js', tmpl, jsSource);
+            } else {
+                // clear out the template string
+                tmpl = tmpl.replace('%example-js-src%', '');
+            }
+
+            // set main title
+            tmpl = pageBuilderUtils.setMainTitle(currentPage, tmpl);
+
+            if (currentPage.type === 'html') {
+                let processedHTML = processor.preprocessHTML(exampleCode);
+                /* Note: Using String.prototype.replace's replacement function instead of
+                replacement string at 2nd argument because replacement string has weird
+                behavior to $ (dollar sign). More info:
+                https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter */
+                outputHTML = tmpl.replace('%example-code%', () => processedHTML);
+            } else {
+                outputHTML = tmpl.replace('%example-code%', () => exampleCode);
+            }
+
+            fse.outputFileSync(outputPath, outputHTML);
         }
-
-        // is there a linked JS file
-        if (jsSource) {
-            // inject the script tag into the source
-            tmpl = processor.processInclude('js', tmpl, jsSource);
-        } else {
-            // clear out the template string
-            tmpl = tmpl.replace('%example-js-src%', '');
-        }
-
-        // set main title
-        tmpl = pageBuilderUtils.setMainTitle(currentPage, tmpl);
-
-        if (currentPage.type === 'html') {
-            let processedHTML = processor.preprocessHTML(exampleCode);
-            /* Note: Using String.prototype.replace's replacement function instead of
-            replacement string at 2nd argument because replacement string has weird
-            behavior to $ (dollar sign). More info:
-            https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter */
-            outputHTML = tmpl.replace('%example-code%', () => processedHTML);
-        } else {
-            outputHTML = tmpl.replace('%example-code%', () => exampleCode);
-        }
-
-        fse.outputFileSync(outputPath, outputHTML);
     }
 }
 


### PR DESCRIPTION
Currently the page builder [returns after finding the first "tabbed" entry in meta.json](https://github.com/mdn/interactive-examples/blob/master/lib/pageBuilder.js#L44), meaning any entries after the first are ignored.

This PR changes that so we keep going, so if meta.json contains more than one tabbed example, they all get processed.

(I'm not sure if this is right, maybe there's some reason to only allow one? But anyway this change seems to work to allow us to have > 1.)