### PR TITLE
HTML editor: make editor width fixed

### DIFF
--- a/css/tabbed-editor.css
+++ b/css/tabbed-editor.css
@@ -23,13 +23,13 @@
 .tabs,
 .output {
     font-size: .9rem;
-    flex-basis: 50%;
+    flex: none;
+    width: 50%;
 }
 
 .output {
     padding: 50px 20px 20px;
     border-left: 0;
-    flex-shrink: 2;
 }
 
 .output-header {


### PR DESCRIPTION
In the current implementation the width of the editor can change when the user switches tabs:

![tabbed-width-switch](https://user-images.githubusercontent.com/432915/36654090-faa90746-1a6e-11e8-9272-af66d6bcdf71.gif)

I think this is distracting. This PR is supposed to make the width fixed, so editor and output each get 50%, no matter what:

![tabbed-width-switch-fixed](https://user-images.githubusercontent.com/432915/36654111-1c0c6522-1a6f-11e8-8b15-1ae4d084737d.gif)

This seems better to me, but I'm open to other ideas...