### PR TITLE
Add example for CSS pointer-events property

### DIFF
--- a/live-examples/css-examples/svg/meta.json
+++ b/live-examples/css-examples/svg/meta.json
@@ -1,0 +1,14 @@
+{
+    "pages": {
+        "pointEvents": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/svg/pointer-events.css",
+            "exampleCode":
+                "live-examples/css-examples/svg/pointer-events.html",
+            "fileName": "pointer-events.html",
+            "title": "CSS Demo: pointer-events",
+            "type": "css"
+        }
+    }
+}

--- a/live-examples/css-examples/svg/pointer-events.css
+++ b/live-examples/css-examples/svg/pointer-events.css
@@ -1,0 +1,8 @@
+#example-element {
+    font-weight: bold;
+}
+
+#example-element svg {
+    width: 10em;
+    height: 10em;
+}

--- a/live-examples/css-examples/svg/pointer-events.html
+++ b/live-examples/css-examples/svg/pointer-events.html
@@ -1,0 +1,48 @@
+<section id="example-choice-list" class="example-choice-list" data-property="animation">
+    <div class="example-choice">
+        <pre><code class="language-css">pointer-events: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">pointer-events: none;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">pointer-events: stroke; /* SVG-only */</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">pointer-events: fill; /* SVG-only */</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example" class="flex-column">
+        <div id="example-element">
+            <p>
+                <a href="#">example link</a>
+            </p>
+
+            <p>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                    <a xlink:href="#">
+                        <circle cx="50" cy="50" r="40" stroke="orange" stroke-width="5" fill="lightblue"/>
+                        <text x="50" y="55" text-anchor="middle" stroke="black">SVG</text>
+                    </a>
+                </svg>
+            </p>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/svg/pointer-events.html
+++ b/live-examples/css-examples/svg/pointer-events.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list" data-property="animation">
+<section id="example-choice-list" class="example-choice-list" data-property="pointer-events">
     <div class="example-choice">
         <pre><code class="language-css">pointer-events: auto;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">


### PR DESCRIPTION
This PR adds an example for [`pointer-events`](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events). Let me know if you want to see any changes. Thanks!