### PR TITLE
Add example for CSS caret-color property

### DIFF
--- a/live-examples/css-examples/basic-user-interface/caret-color.css
+++ b/live-examples/css-examples/basic-user-interface/caret-color.css
@@ -1,0 +1,3 @@
+#example-element {
+    font-size: 1.2rem;
+}

--- a/live-examples/css-examples/basic-user-interface/caret-color.html
+++ b/live-examples/css-examples/basic-user-interface/caret-color.html
@@ -1,0 +1,31 @@
+<section id="example-choice-list" class="example-choice-list" data-property="cursor">
+  <div class="example-choice">
+    <pre><code class="language-css">caret-color: red;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">caret-color: auto;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">caret-color: transparent;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+</section>
+
+<div id="output" class="output hidden large">
+  <section id="default-example" class="default-example container">
+    <div>
+        <p>Enter text in the field to see the caret:</p>
+        <p><input type="text" id="example-element"></p>
+    </div>
+  </section>
+</div>

--- a/live-examples/css-examples/basic-user-interface/meta.json
+++ b/live-examples/css-examples/basic-user-interface/meta.json
@@ -10,6 +10,16 @@
             "title": "CSS Demo: box-sizing",
             "type": "css"
         },
+        "caretColor": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/basic-user-interface/caret-color.css",
+            "exampleCode":
+                "live-examples/css-examples/basic-user-interface/caret-color.html",
+            "fileName": "caret-color.html",
+            "title": "CSS Demo: caret-color",
+            "type": "css"
+        },
         "cursor": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":


### PR DESCRIPTION
This PR adds an example for [`caret-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/caret-color). Let me know if you want to see any changes. Thanks!