### PR TITLE
Add example for object-position CSS property

### DIFF
--- a/live-examples/css-examples/images/meta.json
+++ b/live-examples/css-examples/images/meta.json
@@ -44,6 +44,15 @@
             "fileName": "object-fit.html",
             "title": "CSS Demo: object-fit",
             "type": "css"
+        },
+        "objectPosition": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/images/object-position.css",
+            "exampleCode": "live-examples/css-examples/images/object-position.html",
+            "fileName": "object-position.html",
+            "title": "CSS Demo: object-position",
+            "type": "css"
         }
     }
 }

--- a/live-examples/css-examples/images/object-position.css
+++ b/live-examples/css-examples/images/object-position.css
@@ -1,0 +1,6 @@
+#example-element {
+    height: 250px;
+    width: 250px;
+    object-fit: none;
+    border: 1px solid red;
+}

--- a/live-examples/css-examples/images/object-position.html
+++ b/live-examples/css-examples/images/object-position.html
@@ -21,7 +21,7 @@
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">object-position: 250px 125px</code></pre>
+        <pre><code class="language-css">object-position: 250px 125px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/images/object-position.html
+++ b/live-examples/css-examples/images/object-position.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list" data-property="objectFit">
+<section id="example-choice-list" class="example-choice-list" data-property="object-position">
     <div class="example-choice" initial-choice="true">
         <pre><code class="language-css">object-position: 50% 50%;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">

--- a/live-examples/css-examples/images/object-position.html
+++ b/live-examples/css-examples/images/object-position.html
@@ -1,0 +1,35 @@
+<section id="example-choice-list" class="example-choice-list" data-property="objectFit">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">object-position: 50% 50%;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">object-position: right top;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">object-position: left bottom;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">object-position: 250px 125px</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <img id="example-element" src="../../media/examples/moon.jpg" class="transition-all" />
+    </section>
+</div>


### PR DESCRIPTION
This PR adds an example for [`object-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position). Let me know if you want to see any changes. Thanks!