### PR TITLE
Add example for text-align-last CSS property

### DIFF
--- a/live-examples/css-examples/text/meta.json
+++ b/live-examples/css-examples/text/meta.json
@@ -36,6 +36,15 @@
             "title": "CSS Demo: text-align",
             "type": "css"
         },
+        "textAlignLast": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/fonts/fonts-base.css",
+            "exampleCode": "live-examples/css-examples/text/text-align-last.html",
+            "fileName": "text-align-last.html",
+            "title": "CSS Demo: text-align-last",
+            "type": "css"
+        },
         "textTransform": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":

--- a/live-examples/css-examples/text/text-align-last.css
+++ b/live-examples/css-examples/text/text-align-last.css
@@ -1,0 +1,3 @@
+#example-element {
+    text-align: justify;
+}

--- a/live-examples/css-examples/text/text-align-last.css
+++ b/live-examples/css-examples/text/text-align-last.css
@@ -1,3 +1,0 @@
-#example-element {
-    text-align: justify;
-}

--- a/live-examples/css-examples/text/text-align-last.html
+++ b/live-examples/css-examples/text/text-align-last.html
@@ -1,0 +1,30 @@
+<section id="example-choice-list" class="example-choice-list" data-property="textAlign">
+    <div class="example-choice">
+        <pre><code class="language-css">text-align-last: right;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-align-last: center;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-align-last: left;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <div>
+            <p id="example-element" style="text-align: justify;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/text/text-align-last.html
+++ b/live-examples/css-examples/text/text-align-last.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list" data-property="textAlign">
+<section id="example-choice-list" class="example-choice-list" data-property="text-align-last">
     <div class="example-choice">
         <pre><code class="language-css">text-align-last: right;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">


### PR DESCRIPTION
This PR adds an example for [`text-align-last`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align-last). Let me know if you want to see any changes. Thanks!