### PR TITLE
Give the editor a little more space

### DIFF
--- a/css/tabbed-editor.css
+++ b/css/tabbed-editor.css
@@ -24,7 +24,10 @@
 .output {
     font-size: .9rem;
     flex: none;
-    width: 50%;
+}
+
+.tabs {
+    width: 60%;
 }
 
 .output {


### PR DESCRIPTION
This gives the editor tabs 60% of the width, as they seem generally to need it more than the output ([60% is also the width given to the example-choice-list for the CSS examples](https://github.com/mdn/interactive-examples/blob/master/css/editable-css.css#L14)).