### PR TITLE
Fix mismatched data-property values

### DIFF
--- a/live-examples/css-examples/animation/animation-fill-mode.html
+++ b/live-examples/css-examples/animation/animation-fill-mode.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list" data-property="animation">
+<section id="example-choice-list" class="example-choice-list" data-property="animation-fill-mode">
     <div class="example-choice">
         <pre><code class="language-css">animation-fill-mode: none;
 animation-delay: 1s;</code></pre>

--- a/live-examples/css-examples/basic-user-interface/caret-color.html
+++ b/live-examples/css-examples/basic-user-interface/caret-color.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list" data-property="cursor">
+<section id="example-choice-list" class="example-choice-list" data-property="caret-color">
   <div class="example-choice">
     <pre><code class="language-css">caret-color: red;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">

--- a/live-examples/css-examples/fonts/font-weight.html
+++ b/live-examples/css-examples/fonts/font-weight.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list" data-property="font-family">
+<section id="example-choice-list" class="example-choice-list" data-property="font-weight">
 <div class="example-choice" initial-choice="true">
 <pre><code class="language-css">font-weight: normal;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">

--- a/live-examples/css-examples/lists/list-style-image.html
+++ b/live-examples/css-examples/lists/list-style-image.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="list-style-position">
+<section id="example-choice-list" class="example-choice-list large" data-property="list-style-image">
 
     <div class="example-choice" initial-choice="true">
         <pre><code class="language-css">list-style-image: url("../../media/examples/rocket.svg");</code></pre>

--- a/live-examples/css-examples/lists/list-style-type.html
+++ b/live-examples/css-examples/lists/list-style-type.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="list-style">
+<section id="example-choice-list" class="example-choice-list large" data-property="list-style-type">
     <div class="example-choice" initial-choice="true">
         <pre><code class="language-css">list-style-type: space-counter;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">


### PR DESCRIPTION
This fixes the CSS examples which have `data-property` set to something that's not the name of the property being demonstrated, or the camel case form of the same name (e.g., for `animation-fill-mode` I would've left either value `animation-fill-mode` or `animationFillMode`, but `animation` was wrong).