### PR TITLE
Rewrite the Object.create example.

### DIFF
--- a/live-examples/js-examples/object/object-create.html
+++ b/live-examples/js-examples/object/object-create.html
@@ -1,15 +1,17 @@
 <pre>
 <code id="static-js">const person = {
-  isHuman: true,
-  sayName: function () {
-    console.log(`My name is ${this.name}`);
+  isHuman: false,
+  printIntroduction: function () {
+    console.log(`My name is ${this.name}. Am I human? ${this.isHuman}`);
   }
 };
 
 const me = Object.create(person);
-me.name = "Matthew"; // name is now a property set on the me object, but not on the person object
 
-me.isHuman == true;
-me.sayName() // -> "My name is Matthew"
+me.name = "Matthew"; // "name" is a property set on "me", but not on "person"
+me.isHuman = true; // inherited properties can be overwritten
+
+me.printIntroduction();
+// expected output: "My name is Matthew"
 </code>
 </pre>

--- a/live-examples/js-examples/object/object-create.html
+++ b/live-examples/js-examples/object/object-create.html
@@ -12,6 +12,6 @@ me.name = "Matthew"; // "name" is a property set on "me", but not on "person"
 me.isHuman = true; // inherited properties can be overwritten
 
 me.printIntroduction();
-// expected output: "My name is Matthew"
+// expected output: "My name is Matthew. Am I human? true"
 </code>
 </pre>

--- a/live-examples/js-examples/object/object-create.html
+++ b/live-examples/js-examples/object/object-create.html
@@ -1,16 +1,15 @@
 <pre>
-<code id="static-js">function Shape() {
-  this.name = 'Shape 1';
-}
+<code id="static-js">const person = {
+  isHuman: true,
+  sayName: function () {
+    console.log(`My name is ${this.name}`);
+  }
+};
 
-function Rectangle() {
-  Shape.call(this);
-}
+const me = Object.create(person);
+me.name = "Matthew"; // name is now a property set on the me object, but not on the person object
 
-Rectangle.prototype = Object.create(Shape.prototype);
-const rect = new Rectangle();
-
-console.log(rect.name);
-// expected output: "Shape 1"
+me.isHuman == true;
+me.sayName() // -> "My name is Matthew"
 </code>
 </pre>


### PR DESCRIPTION
The previous version worked just the same even when deleting the line which had Object.create in it!
Also, this version seems simpler to me, as it does not assume knowledge of functions as constructors and the new keyword, etc.
This version however assumes (teaches?) knowledge about the context of inherited methods. It could of course be even simpler, if we just leave out the sayName method and focus on primitive inherited fields.