### PR TITLE
Add example for text-indent CSS property

### DIFF
--- a/live-examples/css-examples/text/meta.json
+++ b/live-examples/css-examples/text/meta.json
@@ -45,6 +45,15 @@
             "title": "CSS Demo: text-align-last",
             "type": "css"
         },
+        "textIndent": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/text/text-indent.css",
+            "exampleCode": "live-examples/css-examples/text/text-indent.html",
+            "fileName": "text-indent.html",
+            "title": "CSS Demo: text-indent",
+            "type": "css"
+        },
         "textTransform": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":

--- a/live-examples/css-examples/text/text-indent.css
+++ b/live-examples/css-examples/text/text-indent.css
@@ -1,0 +1,11 @@
+@import '../fonts/fonts.css';
+
+#output section {
+    font-family: 'Fira Sans', sans-serif;
+    font-size: 1.5em;
+}
+
+#example-element {
+    text-align: left;
+    margin-left: 3em;
+}

--- a/live-examples/css-examples/text/text-indent.html
+++ b/live-examples/css-examples/text/text-indent.html
@@ -1,0 +1,30 @@
+<section id="example-choice-list" class="example-choice-list" data-property="text-indent">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">text-indent: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-indent: 30%;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-indent: -3em;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <div>
+            <p id="example-element">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt.</p>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
This PR adds an example for [`text-indent`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-indent). Let me know if you want to see any changes. Thanks!