### PR TITLE
Add example for text-underline-position CSS property

### DIFF
--- a/live-examples/css-examples/text-decoration/meta.json
+++ b/live-examples/css-examples/text-decoration/meta.json
@@ -59,6 +59,16 @@
             "fileName": "text-shadow.html",
             "title": "CSS Demo: text-shadow",
             "type": "css"
+        },
+        "textUnderlinePosition": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/text-decoration/text-underline-position.css",
+            "exampleCode":
+                "live-examples/css-examples/text-decoration/text-underline-position.html",
+            "fileName": "text-underline-position.html",
+            "title": "CSS Demo: text-underline-position",
+            "type": "css"
         }
     }
 }

--- a/live-examples/css-examples/text-decoration/text-underline-position.css
+++ b/live-examples/css-examples/text-decoration/text-underline-position.css
@@ -3,5 +3,5 @@ p {
 }
 
 #example-element {
-	text-decoration-line: underline;
+    text-decoration-line: underline;
 }

--- a/live-examples/css-examples/text-decoration/text-underline-position.css
+++ b/live-examples/css-examples/text-decoration/text-underline-position.css
@@ -1,0 +1,7 @@
+p {
+    font: 1.5em sans-serif;
+}
+
+#example-element {
+	text-decoration-line: underline;
+}

--- a/live-examples/css-examples/text-decoration/text-underline-position.html
+++ b/live-examples/css-examples/text-decoration/text-underline-position.html
@@ -1,0 +1,21 @@
+<section id="example-choice-list" class="example-choice-list" data-property="text-underline-position">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">text-underline-position: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-underline-position: under;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <p><span id="example-element" class="transition-all">C<sub>8</sub>H<sub>10</sub>N<sub>4</sub>O<sub>2</sub></span> is the chemical formula for caffeine.</p>
+    </section>
+</div>


### PR DESCRIPTION
This PR adds an example for [`text-underline-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-underline-position). I got far along with this before realizing that the property is not particularly well-supported (works in Chrome, not so much elsewhere), but since it was finished I figured I should offer it up anyway. Let me know if you want to see any changes (but I'm also OK with not merging it too). Thanks!