### PR TITLE
Use console.error() method to display errors

### DIFF
--- a/live-examples/js-examples/statement/statement-trycatch.html
+++ b/live-examples/js-examples/statement/statement-trycatch.html
@@ -3,7 +3,7 @@
   eval('alert("Hello world)');
 }
 catch(error) {
-  console.log(error);
+  console.error(error);
   // expected output: SyntaxError: unterminated string literal
   // Note - error messages will vary depending on browser
 }


### PR DESCRIPTION
Errors should be displayed using the console.error() method.