### PR TITLE
Add examples for font-variant and font-variant-caps CSS property

### DIFF
--- a/live-examples/css-examples/fonts/font-variant-caps.css
+++ b/live-examples/css-examples/fonts/font-variant-caps.css
@@ -1,0 +1,13 @@
+@font-face{
+    font-family: 'Fira Sans';
+    src: local('FiraSans-Regular'),
+         url('../../../media/fonts/FiraSans-Regular.woff2') format('woff2');
+    font-weight: normal;
+    font-style: normal;
+}
+
+#output section {
+    font-family: 'Fira Sans', sans-serif;
+    margin-top: 10px;
+    font-size: 1.5em;
+}

--- a/live-examples/css-examples/fonts/font-variant-caps.css
+++ b/live-examples/css-examples/fonts/font-variant-caps.css
@@ -1,4 +1,4 @@
-@font-face{
+@font-face {
     font-family: 'Fira Sans';
     src: local('FiraSans-Regular'),
          url('../../../media/fonts/FiraSans-Regular.woff2') format('woff2');

--- a/live-examples/css-examples/fonts/font-variant-caps.html
+++ b/live-examples/css-examples/fonts/font-variant-caps.html
@@ -1,0 +1,30 @@
+<section id="example-choice-list" class="example-choice-list" data-property="font-variant">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">font-variant: normal;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-variant: small-caps;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-variant-caps: all-small-caps;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <div id="example-element">
+            <p>Difficult waffles</p>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/fonts/font-variant.css
+++ b/live-examples/css-examples/fonts/font-variant.css
@@ -1,0 +1,22 @@
+@font-face{
+    font-family: 'Fira Sans';
+    src: local('FiraSans-Regular'),
+         url('../../../media/fonts/FiraSans-Regular.woff2') format('woff2');
+    font-weight: normal;
+    font-style: normal;
+}
+
+#output section {
+    font-family: 'Fira Sans', sans-serif;
+    margin-top: 10px;
+    font-size: 1.5em;
+}
+
+#example-element table {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.tabular {
+    border: 1px solid black;
+}

--- a/live-examples/css-examples/fonts/font-variant.css
+++ b/live-examples/css-examples/fonts/font-variant.css
@@ -1,4 +1,4 @@
-@font-face{
+@font-face {
     font-family: 'Fira Sans';
     src: local('FiraSans-Regular'),
          url('../../../media/fonts/FiraSans-Regular.woff2') format('woff2');

--- a/live-examples/css-examples/fonts/font-variant.html
+++ b/live-examples/css-examples/fonts/font-variant.html
@@ -1,0 +1,48 @@
+<section id="example-choice-list" class="example-choice-list" data-property="font-variant">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">font-variant: normal;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-variant: no-common-ligatures proportional-nums;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-variant: common-ligatures tabular-nums;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-variant: small-caps slashed-zero;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <div id="example-element">
+            <p>Difficult waffles</p>
+            <table>
+                <tr>
+                    <td><span class="tabular">0O</span></td>
+                </tr>
+                <tr>
+                    <td><span class="tabular">3.14</span></td>
+                </tr>
+                <tr>
+                    <td><span class="tabular">2.71</span></td>
+                </tr>
+            </table>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/fonts/fonts.css
+++ b/live-examples/css-examples/fonts/fonts.css
@@ -1,4 +1,4 @@
-@font-face{
+@font-face {
     font-family: 'Fira Sans';
     src: local('FiraSans-Light'),
          url('../../../media/fonts/FiraSans-Light.woff2') format('woff2');
@@ -6,7 +6,7 @@
     font-style: normal;
 }
 
-@font-face{
+@font-face {
     font-family: 'Fira Sans';
     src: local('FiraSans-Regular'),
          url('../../../media/fonts/FiraSans-Regular.woff2') format('woff2');
@@ -14,7 +14,7 @@
     font-style: normal;
 }
 
-@font-face{
+@font-face {
     font-family: 'Fira Sans';
     src: local('FiraSans-Italic'),
          url('../../../media/fonts/FiraSans-Italic.woff2') format('woff2');
@@ -22,7 +22,7 @@
     font-style: italic;
 }
 
-@font-face{
+@font-face {
     font-family: 'Fira Sans';
     src: local('FiraSans-SemiBoldItalic'),
          url('../../../media/fonts/FiraSans-SemiBoldItalic.woff2') format('woff2');
@@ -30,7 +30,7 @@
     font-style: oblique;
 }
 
-@font-face{
+@font-face {
     font-family: 'Fira Sans';
     src: local('FiraSans-SemiBold'),
          url('../../../media/fonts/FiraSans-SemiBold.woff2') format('woff2');
@@ -38,7 +38,7 @@
     font-style: normal;
 }
 
-@font-face{
+@font-face {
     font-family: 'Fira Sans';
     src: local('FiraSans-Bold'),
          url('../../../media/fonts/FiraSans-Bold.woff2') format('woff2');
@@ -46,7 +46,7 @@
     font-style: normal;
 }
 
-@font-face{
+@font-face {
     font-family: 'Fira Sans';
     src: local('FiraSans-ExtraBold'),
          url('../../../media/fonts/FiraSans-ExtraBold.woff2') format('woff2');

--- a/live-examples/css-examples/fonts/meta.json
+++ b/live-examples/css-examples/fonts/meta.json
@@ -43,6 +43,15 @@
             "title": "CSS Demo: font-variant",
             "type": "css"
         },
+        "fontVariantCaps": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/fonts/font-variant-caps.css",
+            "exampleCode": "live-examples/css-examples/fonts/font-variant-caps.html",
+            "fileName": "font-variant-caps.html",
+            "title": "CSS Demo: font-variant-caps",
+            "type": "css"
+        },
         "fontWeight": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":

--- a/live-examples/css-examples/fonts/meta.json
+++ b/live-examples/css-examples/fonts/meta.json
@@ -34,6 +34,15 @@
             "title": "CSS Demo: font-style",
             "type": "css"
         },
+        "fontVariant": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/fonts/font-variant.css",
+            "exampleCode": "live-examples/css-examples/fonts/font-variant.html",
+            "fileName": "font-variant.html",
+            "title": "CSS Demo: font-variant",
+            "type": "css"
+        },
         "fontWeight": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":


### PR DESCRIPTION
This PR adds an example for [`font-variant`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant) and [`font-variant-caps`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps). Let me know if you want to see any changes. Thanks!