### PR TITLE
Better example for `sort` use case

### DIFF
--- a/live-examples/js-examples/intl/intl-collator.html
+++ b/live-examples/js-examples/intl/intl-collator.html
@@ -1,6 +1,6 @@
 <pre>
 <code id="static-js">function letterSort(lang, letters) {
-  letters.sort((a, b) => new Intl.Collator(lang).compare(a, b));
+  letters.sort(new Intl.Collator(lang).compare);
   return letters;
 }
 


### PR DESCRIPTION
Other examples show raw comparison, with explicit calling of the method `compare`.
This example however uses `sort`. It's more optimal to create the Collator object only once. Moreover, the example shows, that the `compare` function is already bound to the Collator object.