### PR TITLE
Scroll snapping

### DIFF
--- a/live-examples/css-examples/scroll-snap/meta.json
+++ b/live-examples/css-examples/scroll-snap/meta.json
@@ -1,0 +1,14 @@
+{
+    "pages": {
+        "scrollSnap": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/scroll-snap/scroll-snap-type.css",
+            "exampleCode":
+                "live-examples/css-examples/scroll-snap/scroll-snap-type.html",
+            "fileName": "scroll-snap-type.html",
+            "title": "CSS Demo: scroll-snap-type",
+            "type": "css"
+        }
+    }
+}

--- a/live-examples/css-examples/scroll-snap/scroll-snap-type.css
+++ b/live-examples/css-examples/scroll-snap/scroll-snap-type.css
@@ -1,0 +1,26 @@
+#example-element {
+    text-align: left;
+    width: 250px;
+    height: 250px;
+    overflow-x: scroll;
+    display: flex;
+    box-sizing: border-box;
+    border: 1px solid black;
+}
+
+#example-element > div {
+    flex: 0 0 250px;
+    width: 250px;
+    background-color: rebeccapurple;
+    color: #fff;
+    font-size: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    scroll-snap-align: center none;
+}
+
+#example-element > div:nth-child(even) {
+    background-color: #fff;
+    color: rebeccapurple;
+}

--- a/live-examples/css-examples/scroll-snap/scroll-snap-type.html
+++ b/live-examples/css-examples/scroll-snap/scroll-snap-type.html
@@ -1,0 +1,32 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <div id="example-element">            
+            <div>1</div>
+            <div>2</div>
+            <div>3</div>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
Here is an example for scroll-snap-type. For the new spec so only works in Safari. Building this highlights various issues in the MDN docs for scroll-snapping.

We have all the properties now removed from the spec (but supported by Firefox), we don't have scroll-snap-align. The current example on the scroll-snap-type page is incorrect now as to the updated spec, although uses the properties as supported by Firefox. It looks like the browser information is incorrect too.

Quite difficult to know what to do with these specs which have a bit of implementation but then change in a major way. 