### PR TITLE
Add example for isolation CSS property

### DIFF
--- a/live-examples/css-examples/compositing-and-blending/isolation.css
+++ b/live-examples/css-examples/compositing-and-blending/isolation.css
@@ -1,0 +1,14 @@
+.background-container {
+    background-color: #f4f460;
+    width: 250px;
+}
+
+#example-element {
+    border: 1px solid black;
+    margin: 2em;
+}
+
+#example-element * {
+    mix-blend-mode: multiply;
+    color: #8245a3;
+}

--- a/live-examples/css-examples/compositing-and-blending/isolation.html
+++ b/live-examples/css-examples/compositing-and-blending/isolation.html
@@ -1,0 +1,26 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="isolation">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">isolation: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">isolation: isolate;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <div class="background-container">
+            <div id="example-element">
+                <img src="../../media/examples/firefox-logo.svg">
+                <p><code>mix-blend-mode: multiply;</code></p>
+            </div>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/compositing-and-blending/meta.json
+++ b/live-examples/css-examples/compositing-and-blending/meta.json
@@ -10,6 +10,16 @@
             "title": "CSS Demo: background-blend-mode",
             "type": "css"
         },
+        "isolation": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/compositing-and-blending/isolation.css",
+            "exampleCode":
+                "live-examples/css-examples/compositing-and-blending/isolation.html",
+            "fileName": "isolation.html",
+            "title": "CSS Demo: isolation",
+            "type": "css"
+        },
         "mixBlendMode": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":


### PR DESCRIPTION
This PR adds an example for [`isolation`](https://developer.mozilla.org/en-US/docs/Web/CSS/isolation). Let me know if you want to see any changes. Thanks!