### PR TITLE
Add example for image-rendering CSS property

### DIFF
--- a/live-examples/css-examples/images/image-rendering.css
+++ b/live-examples/css-examples/images/image-rendering.css
@@ -1,0 +1,5 @@
+#example-element {
+    height: 500px;
+    object-fit: cover;
+    border: 1px solid red;
+}

--- a/live-examples/css-examples/images/image-rendering.css
+++ b/live-examples/css-examples/images/image-rendering.css
@@ -1,5 +1,4 @@
 #example-element {
-    height: 500px;
+    height: 480px;
     object-fit: cover;
-    border: 1px solid red;
 }

--- a/live-examples/css-examples/images/image-rendering.html
+++ b/live-examples/css-examples/images/image-rendering.html
@@ -1,0 +1,28 @@
+<section id="example-choice-list" class="example-choice-list" data-property="image-rendering">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">image-rendering: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">image-rendering: crisp-edges;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">image-rendering: pixelated;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <img id="example-element" src="../../media/examples/lizard.png" class="transition-all" />
+    </section>
+</div>

--- a/live-examples/css-examples/images/meta.json
+++ b/live-examples/css-examples/images/meta.json
@@ -1,5 +1,14 @@
 {
     "pages": {
+        "imageRendering": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/images/image-rendering.css",
+            "exampleCode": "live-examples/css-examples/images/image-rendering.html",
+            "fileName": "image-rendering.html",
+            "title": "CSS Demo: image-rendering",
+            "type": "css"
+        },
         "linearGradient": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":


### PR DESCRIPTION
This PR adds an example for [`image-rendering`](https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering), though I think it might still be a work in progress. The main issue here is that it's hard to show this property in action without using vendor prefixes on the values, but I think that would really complicated the example. Any advice on how to improve this one would be appreciated. Thanks!