### PR TITLE
Add examples for text-emphasis CSS properties

### DIFF
--- a/live-examples/css-examples/text-decoration/meta.json
+++ b/live-examples/css-examples/text-decoration/meta.json
@@ -50,6 +50,16 @@
             "title": "CSS Demo: text-decoration-style",
             "type": "css"
         },
+        "textEmphasis": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/text-decoration/text-emphasis.css",
+            "exampleCode":
+                "live-examples/css-examples/text-decoration/text-emphasis.html",
+            "fileName": "text-emphasis.html",
+            "title": "CSS Demo: text-emphasis",
+            "type": "css"
+        },
         "textShadow": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":

--- a/live-examples/css-examples/text-decoration/meta.json
+++ b/live-examples/css-examples/text-decoration/meta.json
@@ -60,6 +60,16 @@
             "title": "CSS Demo: text-emphasis",
             "type": "css"
         },
+        "textEmphasisColor": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/text-decoration/text-emphasis-color.css",
+            "exampleCode":
+                "live-examples/css-examples/text-decoration/text-emphasis-color.html",
+            "fileName": "text-emphasis-color.html",
+            "title": "CSS Demo: text-emphasis-color",
+            "type": "css"
+        },
         "textShadow": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":

--- a/live-examples/css-examples/text-decoration/meta.json
+++ b/live-examples/css-examples/text-decoration/meta.json
@@ -70,6 +70,16 @@
             "title": "CSS Demo: text-emphasis-color",
             "type": "css"
         },
+        "textEmphasisStyle": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/text-decoration/text-emphasis-style.css",
+            "exampleCode":
+                "live-examples/css-examples/text-decoration/text-emphasis-style.html",
+            "fileName": "text-emphasis-style.html",
+            "title": "CSS Demo: text-emphasis-style",
+            "type": "css"
+        },
         "textShadow": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":

--- a/live-examples/css-examples/text-decoration/text-emphasis-color.css
+++ b/live-examples/css-examples/text-decoration/text-emphasis-color.css
@@ -1,0 +1,7 @@
+p {
+    font: 1.5em sans-serif;
+}
+
+#example-element {
+    text-emphasis: filled;
+}

--- a/live-examples/css-examples/text-decoration/text-emphasis-color.html
+++ b/live-examples/css-examples/text-decoration/text-emphasis-color.html
@@ -1,0 +1,28 @@
+<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis-color">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">text-emphasis-color: currentColor;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-emphasis-color: red;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-emphasis-color: rgba(90, 200, 160, 0.8);</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <p>I'd far rather be <span id="example-element" class="transition-all">happy than right</span> any day.</p>
+    </section>
+</div>

--- a/live-examples/css-examples/text-decoration/text-emphasis-style.css
+++ b/live-examples/css-examples/text-decoration/text-emphasis-style.css
@@ -1,0 +1,3 @@
+p {
+    font: 1.5em sans-serif;
+}

--- a/live-examples/css-examples/text-decoration/text-emphasis-style.html
+++ b/live-examples/css-examples/text-decoration/text-emphasis-style.html
@@ -1,0 +1,35 @@
+<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis-style">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">text-emphasis-style: none;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-emphasis-style: triangle;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-emphasis-style: 'x';</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-emphasis-style: filled double-circle;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <p>I'd far rather be <span id="example-element" class="transition-all">happy than right</span> any day.</p>
+    </section>
+</div>

--- a/live-examples/css-examples/text-decoration/text-emphasis.css
+++ b/live-examples/css-examples/text-decoration/text-emphasis.css
@@ -1,0 +1,3 @@
+p {
+    font: 1.5em sans-serif;
+}

--- a/live-examples/css-examples/text-decoration/text-emphasis.html
+++ b/live-examples/css-examples/text-decoration/text-emphasis.html
@@ -1,0 +1,35 @@
+<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">text-emphasis: none;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-emphasis: filled red;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-emphasis: 'x';</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-emphasis: filled double-circle blue;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <p>I'd far rather be <span id="example-element" class="transition-all">happy than right</span> any day.</p>
+    </section>
+</div>


### PR DESCRIPTION
This PR adds examples for:

* [`text-emphasis`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis)
* [`text-emphasis-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-color)
* [`text-emphasis-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-style)

I'm mostly satisfied with how these have turned out except for one thing: these emphasis marks aren't really intended for Latin script, but I don't really know any Japanese or Chinese text to use as an example. Open to suggestions there or on anything else. Thanks!