### PR TITLE
Apply code in code block instead of choice element

### DIFF
--- a/js/editor-libs/css-editor-utils.js
+++ b/js/editor-libs/css-editor-utils.js
@@ -39,7 +39,7 @@ module.exports = {
         codeBlock.setAttribute('spellcheck', false);
         codeBlock.focus();
 
-        module.exports.applyCode(choice.textContent, choice);
+        module.exports.applyCode(codeBlock.textContent, choice);
     },
     /**
      * Resets the default example to visible but, only if it is currently hidden


### PR DESCRIPTION
Reading the code, the previous behavior includes the text "Copy to clipboard" at `code` parameter of `applyCode` of `css-editor-utils.js`. 

So, for example, at [text-decoration-color example](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color), when switching to the option `text-decoration-color: #21ff21;`, the value of `code` parameter will be as follows

```
text-decoration-color: #21ff21;

Copy to clipboard
```

It doesn't cause any bug though, as somehow, `element.style.cssText` only applies the first line of `code` argument.

I submits this PR, because I think it is not the intended behavior. 😁 

Note: to see this "bug", you could put `console.log(code)` before `element.style.cssText = code;` line