### PR TITLE
Add example for tab-size CSS property

### DIFF
--- a/live-examples/css-examples/text/meta.json
+++ b/live-examples/css-examples/text/meta.json
@@ -27,6 +27,15 @@
             "title": "CSS Demo: overflow-wrap",
             "type": "css"
         },
+        "tabSize": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/text/tab-size.css",
+            "exampleCode": "live-examples/css-examples/text/tab-size.html",
+            "fileName": "tab-size.html",
+            "title": "CSS Demo: tab-size",
+            "type": "css"
+        },
         "textAlign": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":

--- a/live-examples/css-examples/text/tab-size.css
+++ b/live-examples/css-examples/text/tab-size.css
@@ -1,0 +1,3 @@
+#example-element {
+    border: 1px solid red;
+}

--- a/live-examples/css-examples/text/tab-size.html
+++ b/live-examples/css-examples/text/tab-size.html
@@ -1,0 +1,37 @@
+<section id="example-choice-list" class="example-choice-list" data-property="tab-size">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css" initial-choice="true">tab-size: 8;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">tab-size: 4;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">tab-size: 30px;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">tab-size: 2em;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <div>
+            <pre id="example-element">#	123</pre>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
This PR adds an example for [`tab-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/tab-size). It's probably easiest to try this out in Chrome. Let me know if you want to see any changes. Thanks!