### PR TITLE
Add example for transform-style CSS property

### DIFF
--- a/live-examples/css-examples/transforms/meta.json
+++ b/live-examples/css-examples/transforms/meta.json
@@ -169,6 +169,16 @@
             "title": "CSS Demo: transform-origin",
             "type": "css"
         },
+        "transformStyle": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/transforms/transform-style.css",
+            "exampleCode":
+                "live-examples/css-examples/transforms/transform-style.html",
+            "fileName": "transform-style.html",
+            "title": "CSS Demo: transform-style",
+            "type": "css"
+        },
         "translate": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":

--- a/live-examples/css-examples/transforms/transform-style.css
+++ b/live-examples/css-examples/transforms/transform-style.css
@@ -1,23 +1,14 @@
 .layer {
+    background: #f69d3c;
+    border-radius: .75rem;
     transform: perspective(200px) rotateY(30deg);
-    background: rgba(0, 0, 255, 0.5);
-    border-radius: 1em;
-    width: 10em;
-    height: 10em;
 }
 
 .numeral {
+    background-color: #e66465;
+    border-radius: .2rem;
     color: black;
-    margin: 1em;
-    font-size: 3rem;
-    animation: slide 1.5s infinite alternate;
-}
-
-@keyframes slide {
-    from {
-        transform: translateZ(-75px) rotate(-15deg);
-    }
-    to {
-        transform: translateZ(75px) rotate(15deg);
-    }
+    margin: 1rem;
+    padding: .2rem;
+    transform: rotate3d(1, 1, 1, 45deg);
 }

--- a/live-examples/css-examples/transforms/transform-style.css
+++ b/live-examples/css-examples/transforms/transform-style.css
@@ -1,0 +1,23 @@
+.layer {
+    transform: perspective(200px) rotateY(30deg);
+    background: rgba(0, 0, 255, 0.5);
+    border-radius: 1em;
+    width: 10em;
+    height: 10em;
+}
+
+.numeral {
+    color: black;
+    margin: 1em;
+    font-size: 3rem;
+    animation: slide 1.5s infinite alternate;
+}
+
+@keyframes slide {
+    from {
+        transform: translateZ(-75px) rotate(-15deg);
+    }
+    to {
+        transform: translateZ(75px) rotate(15deg);
+    }
+}

--- a/live-examples/css-examples/transforms/transform-style.html
+++ b/live-examples/css-examples/transforms/transform-style.html
@@ -17,7 +17,8 @@
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
         <div id="example-element" class="transition-all layer">
-            <div class="numeral">3D</div>
+            <p>Parent</p>
+            <div class="numeral"><code>rotate3d(1, 1, 1, 45deg)</code></div>
         </div>
     </section>
 </div>

--- a/live-examples/css-examples/transforms/transform-style.html
+++ b/live-examples/css-examples/transforms/transform-style.html
@@ -1,0 +1,23 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="transform-style">
+    <div class="example-choice">
+        <pre><code class="language-css" initial-choice="true">transform-style: flat;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">transform-style: preserve-3d;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <div id="example-element" class="transition-all layer">
+            <div class="numeral">3D</div>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
This PR adds an example for [`transform-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-style). This is kinda a tough one to illustrate. Let me know if you want to see any changes. Thanks!