### PR TITLE
Reduce text size example; fix width

### DIFF
--- a/live-examples/css-examples/fonts/fonts-base.css
+++ b/live-examples/css-examples/fonts/fonts-base.css
@@ -4,3 +4,7 @@
     font-family: 'Fira Sans', sans-serif;
     font-size: 1.5em;
 }
+
+#default-example > div {
+  width: 250px;
+}

--- a/live-examples/css-examples/fonts/fonts-base.css
+++ b/live-examples/css-examples/fonts/fonts-base.css
@@ -6,5 +6,5 @@
 }
 
 #default-example > div {
-  width: 250px;
+    width: 250px;
 }

--- a/live-examples/css-examples/text/text-align-last.html
+++ b/live-examples/css-examples/text/text-align-last.html
@@ -24,7 +24,7 @@
 <div id="output" class="output hidden">
     <section id="default-example">
         <div>
-            <p id="example-element" style="text-align: justify;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+            <p id="example-element" style="text-align: justify;">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
         </div>
     </section>
 </div>


### PR DESCRIPTION
The [`text-align-last`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align-last) example can overflow vertically, cutting off the last line so the effect is not visible:

<img width="883" alt="screen shot 2018-03-07 at 3 57 17 pm" src="https://user-images.githubusercontent.com/432915/37125521-ebbe882c-2221-11e8-9db2-eba0cd7943ae.png">

This PR reduces the size of the text sample so that doesn't happen. It also fixes the width of the text `div`, so that we can make the effect more predictable (with a variable width output, the effect was more or less obvious depending on the browser window width). This change also affects [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align) since they share a CSS file, but also for the better I think.

<img width="883" alt="screen shot 2018-03-07 at 4 12 40 pm" src="https://user-images.githubusercontent.com/432915/37125639-67e2721a-2222-11e8-8fec-7892c4b33e79.png">
