### PR TITLE
Add example for font-feature-settings CSS property

### DIFF
--- a/live-examples/css-examples/fonts/font-feature-settings.css
+++ b/live-examples/css-examples/fonts/font-feature-settings.css
@@ -1,7 +1,7 @@
 @font-face {
     font-family: 'Fira Sans';
     src: local('FiraSans-Regular'),
-         url('../../../media/fonts/FiraSans-Regular.woff2') format('woff2');
+         url('/media/fonts/FiraSans-Regular.woff2') format('woff2');
     font-weight: normal;
     font-style: normal;
 }

--- a/live-examples/css-examples/fonts/font-feature-settings.css
+++ b/live-examples/css-examples/fonts/font-feature-settings.css
@@ -1,0 +1,22 @@
+@font-face {
+    font-family: 'Fira Sans';
+    src: local('FiraSans-Regular'),
+         url('../../../media/fonts/FiraSans-Regular.woff2') format('woff2');
+    font-weight: normal;
+    font-style: normal;
+}
+
+#output section {
+    font-family: 'Fira Sans', sans-serif;
+    margin-top: 10px;
+    font-size: 1.5em;
+}
+
+#example-element table {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.tabular {
+    border: 1px solid black;
+}

--- a/live-examples/css-examples/fonts/font-feature-settings.html
+++ b/live-examples/css-examples/fonts/font-feature-settings.html
@@ -1,0 +1,48 @@
+<section id="example-choice-list" class="example-choice-list" data-property="font-feature-settings">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">font-feature-settings: normal;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-feature-settings: "liga" 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-feature-settings: "tnum";</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-feature-settings: "smcp", "zero";</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <div id="example-element">
+            <p>Difficult waffles</p>
+            <table>
+                <tr>
+                    <td><span class="tabular">0O</span></td>
+                </tr>
+                <tr>
+                    <td><span class="tabular">3.14</span></td>
+                </tr>
+                <tr>
+                    <td><span class="tabular">2.71</span></td>
+                </tr>
+            </table>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/fonts/meta.json
+++ b/live-examples/css-examples/fonts/meta.json
@@ -17,6 +17,15 @@
             "title": "CSS Demo: font-family",
             "type": "css"
         },
+        "fontFeatureSettings": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/fonts/font-feature-settings.css",
+            "exampleCode": "live-examples/css-examples/fonts/font-feature-settings.html",
+            "fileName": "font-feature-settings.html",
+            "title": "CSS Demo: font-feature-settings",
+            "type": "css"
+        },
         "fontSize": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc": "../../live-examples/css-examples/fonts/font-size.css",


### PR DESCRIPTION
This PR adds an example for [`font-feature-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings). If this looks like a clone of `font-variant` that's because it is—it does almost the exact same thing, with a different syntax. Let me know if you want to see any changes. Thanks!