### PR TITLE
Add example for scroll-behavior

### DIFF
--- a/live-examples/css-examples/cssom-view/meta.json
+++ b/live-examples/css-examples/cssom-view/meta.json
@@ -1,0 +1,12 @@
+{
+    "pages": {
+        "color": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc": "../../live-examples/css-examples/cssom-view/scroll-behavior.css",
+            "exampleCode": "live-examples/css-examples/cssom-view/scroll-behavior.html",
+            "fileName": "scroll-behavior.html",
+            "title": "CSS Demo: scroll-behavior",
+            "type": "css"
+        }
+    }
+}

--- a/live-examples/css-examples/cssom-view/scroll-behavior.css
+++ b/live-examples/css-examples/cssom-view/scroll-behavior.css
@@ -1,0 +1,19 @@
+.container {
+    flex-direction: column;
+}
+
+scroll-container {
+    border: 1px solid black;
+    display: block;
+    height: 200px;
+    overflow-y: scroll;
+    width: 200px;
+}
+
+scroll-page {
+    align-items: center;
+    display: flex;
+    font-size: 5em;
+    height: 100%;
+    justify-content: center;
+}

--- a/live-examples/css-examples/cssom-view/scroll-behavior.html
+++ b/live-examples/css-examples/cssom-view/scroll-behavior.html
@@ -1,0 +1,33 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-behavior">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">scroll-behavior: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-behavior: smooth;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example">
+        <div class="container">
+            <p class="nav">
+                Scroll to:
+                <a href="#pageA">A</a>
+                <a href="#pageB">B</a>
+                <a href="#pageC">C</a>
+            </p>
+            <scroll-container id="example-element">
+                <scroll-page id="pageA">A</scroll-page>
+                <scroll-page id="pageB">B</scroll-page>
+                <scroll-page id="pageC">C</scroll-page>
+            </scroll-container>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
This PR adds an example for [`scroll-behavior`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior). The only thing I was uncertain about here was the directory; the spec says it's likely to move to a different spec, so I'm not sure it actually deserves its own directory. Let me know if you want to see any changes. Thanks!