### PR TITLE
Add example for (-moz-) appearance CSS property

### DIFF
--- a/live-examples/css-examples/basic-user-interface/appearance.html
+++ b/live-examples/css-examples/basic-user-interface/appearance.html
@@ -1,0 +1,39 @@
+<section id="example-choice-list" class="example-choice-list">
+  <div class="example-choice">
+    <pre><code class="language-css">-moz-appearance: none;
+appearance: none;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">-moz-appearance: button;
+apperance: button;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">-moz-appearance: checkbox;
+apperance: checkbox;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">-moz-appearance: radio;
+appearance: radio;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+</section>
+
+<div id="output" class="output hidden large">
+  <section id="default-example">
+    <div id="example-element">element</div>
+  </section>
+</div>

--- a/live-examples/css-examples/basic-user-interface/appearance.html
+++ b/live-examples/css-examples/basic-user-interface/appearance.html
@@ -1,7 +1,7 @@
 <section id="example-choice-list" class="example-choice-list">
   <div class="example-choice">
     <pre><code class="language-css">-moz-appearance: none;
-appearance: none;</code></pre>
+-webkit-appearance: none;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
@@ -9,7 +9,7 @@ appearance: none;</code></pre>
 
   <div class="example-choice">
     <pre><code class="language-css">-moz-appearance: button;
-apperance: button;</code></pre>
+-webkit-appearance: button;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
@@ -17,7 +17,7 @@ apperance: button;</code></pre>
 
   <div class="example-choice">
     <pre><code class="language-css">-moz-appearance: checkbox;
-apperance: checkbox;</code></pre>
+-webkit-appearance: checkbox;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
@@ -25,7 +25,7 @@ apperance: checkbox;</code></pre>
 
   <div class="example-choice">
     <pre><code class="language-css">-moz-appearance: radio;
-appearance: radio;</code></pre>
+-webkit-appearance: radio;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>

--- a/live-examples/css-examples/basic-user-interface/meta.json
+++ b/live-examples/css-examples/basic-user-interface/meta.json
@@ -1,5 +1,13 @@
 {
     "pages": {
+        "appearance": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "exampleCode":
+                "live-examples/css-examples/basic-user-interface/appearance.html",
+            "fileName": "appearance.html",
+            "title": "CSS Demo: appearance",
+            "type": "css"
+        },
         "boxSizing": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":


### PR DESCRIPTION
This PR adds [`-moz-appearance`](https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-appearance). This one's experimental and not-well supported yet, but it was on the to-do list so I did a pretty minimal example here. Let me know if you want to see any changes. Thanks!