### PR TITLE
Add example for text-justify CSS property

### DIFF
--- a/live-examples/css-examples/text/meta.json
+++ b/live-examples/css-examples/text/meta.json
@@ -72,6 +72,15 @@
             "title": "CSS Demo: text-indent",
             "type": "css"
         },
+        "textJustify": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/text/text-justify.css",
+            "exampleCode": "live-examples/css-examples/text/text-justify.html",
+            "fileName": "text-justify.html",
+            "title": "CSS Demo: text-justify",
+            "type": "css"
+        },
         "textTransform": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":

--- a/live-examples/css-examples/text/text-justify.css
+++ b/live-examples/css-examples/text/text-justify.css
@@ -1,0 +1,3 @@
+#example-element {
+    text-align: justify;
+}

--- a/live-examples/css-examples/text/text-justify.html
+++ b/live-examples/css-examples/text/text-justify.html
@@ -1,0 +1,35 @@
+<section id="example-choice-list" class="example-choice-list" data-property="text-justify">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">text-justify: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-justify: none;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-justify: inter-word;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-justify: inter-character;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+  <section id="default-example">
+      <p id="example-element">As much mud in the streets as if the waters had but newly retired from the face of the earth, and it would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine lizard up Holborn Hill.</p>
+  </section>
+</div>


### PR DESCRIPTION
This PR adds an example for [`text-justify`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-justify). I think this one works pretty well for now, though like #651, I think it might benefit from some added CJK text to show the inter-character spacing option a bit better (though that could come in a later PR). Let me know if you want to see any changes. Thanks!