### PR TITLE
Fix broken fonts in font-variant and font-variant-caps examples

### DIFF
--- a/live-examples/css-examples/fonts/font-variant-caps.css
+++ b/live-examples/css-examples/fonts/font-variant-caps.css
@@ -1,7 +1,7 @@
 @font-face {
     font-family: 'Fira Sans';
     src: local('FiraSans-Regular'),
-         url('../../../media/fonts/FiraSans-Regular.woff2') format('woff2');
+         url('/media/fonts/FiraSans-Regular.woff2') format('woff2');
     font-weight: normal;
     font-style: normal;
 }

--- a/live-examples/css-examples/fonts/font-variant.css
+++ b/live-examples/css-examples/fonts/font-variant.css
@@ -1,7 +1,7 @@
 @font-face {
     font-family: 'Fira Sans';
     src: local('FiraSans-Regular'),
-         url('../../../media/fonts/FiraSans-Regular.woff2') format('woff2');
+         url('/media/fonts/FiraSans-Regular.woff2') format('woff2');
     font-weight: normal;
     font-style: normal;
 }


### PR DESCRIPTION
The fonts aren't loading on these new examples. It seems that the paths specified in the CSS work for the local dev server, but not as deployed. This PR should fix that. Let me know if you want to see any changes! Thanks!