### PR TITLE
Adds the groundwork for puppeteer tests and on test for the js editor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,9 @@ module.exports = {
         jest: true,
     },
     extends: 'eslint:recommended',
+    parserOptions: {
+        "ecmaVersion": 8
+    },
     rules: {
         'no-global-assign': 2,
         indent: [2, 4],
@@ -35,6 +38,7 @@ module.exports = {
         expect: true,
         exports: true,
         module: true,
+        page: true,
         Prism: true,
         require: true,
         test: true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+    tabWidth: 4,
+    singleQuote: true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ node_js:
 branches:
   only:
   - master
+before_script:
+  - npm run build
+  - sleep 3 # give build some time to complete
 deploy:
   provider: script
   script: ./travis-deploy-pages

--- a/__tests__/puppeteer-js-editor.test.js
+++ b/__tests__/puppeteer-js-editor.test.js
@@ -1,0 +1,18 @@
+describe('JS Editor', () => {
+    beforeAll(async () => {
+        await page.goto('http://127.0.0.1:4444/pages/js/array-concat.html');
+    });
+
+    it('renders expected output after clicking Run', async () => {
+        const expectedOutput = '> Array ["a", "b", "c", "d", "e", "f"]';
+        let outputContent;
+
+        await page.waitForSelector('#execute');
+        await page.click('#execute');
+
+        outputContent = await page.$eval('#output code', e =>
+            e.innerText.trim()
+        );
+        await expect(outputContent).toBe(expectedOutput);
+    });
+});

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    server: {
+        command: 'npm run start-server',
+        port: 4444
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,26 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0-beta.41",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.41.tgz",
+            "integrity": "sha512-omQT0n9EW38xfMCY7cCW/PAT55igUX9c9cMq6QN4EjxCcelcrocwMJ6H4JP4BGrQ+OHdJAQPM9/Eaa2Yce4Aug==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "7.0.0-beta.41"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0-beta.41",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.41.tgz",
+            "integrity": "sha512-5RURdqgHmXdg775Dr6GIFaVatHaPtaVgMF29jvWgkm8LP/B3MjZR/TOhkpbIBChqFzTn7uQKiBR3002pGjKY7Q==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.3.0",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+            }
+        },
         "JSONStream": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
@@ -27,12 +47,29 @@
             "dev": true
         },
         "acorn-globals": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-            "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+            "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
             "dev": true,
             "requires": {
-                "acorn": "4.0.13"
+                "acorn": "5.5.3"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.5.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+                    "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+                    "dev": true
+                }
+            }
+        },
+        "agent-base": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+            "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+            "dev": true,
+            "requires": {
+                "es6-promisify": "5.0.0"
             }
         },
         "ajv": {
@@ -120,9 +157,9 @@
             }
         },
         "argparse": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
                 "sprintf-js": "1.0.3"
@@ -141,6 +178,12 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "dev": true
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
             "dev": true
         },
         "array-equal": {
@@ -211,6 +254,12 @@
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
             "dev": true
         },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+            "dev": true
+        },
         "astral-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -241,10 +290,22 @@
             "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
             "dev": true
         },
+        "async-limiter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+            "dev": true
+        },
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "atob": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
+            "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
             "dev": true
         },
         "aws-sign2": {
@@ -329,7 +390,7 @@
             "dev": true,
             "requires": {
                 "babel-code-frame": "6.26.0",
-                "babel-generator": "6.26.0",
+                "babel-generator": "6.26.1",
                 "babel-helpers": "6.24.1",
                 "babel-messages": "6.23.0",
                 "babel-register": "6.26.0",
@@ -367,9 +428,9 @@
             }
         },
         "babel-generator": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-            "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+            "version": "6.26.1",
+            "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+            "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
             "dev": true,
             "requires": {
                 "babel-messages": "6.23.0",
@@ -393,13 +454,13 @@
             }
         },
         "babel-jest": {
-            "version": "21.2.0",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz",
-            "integrity": "sha512-O0W2qLoWu1QOoOGgxiR2JID4O6WSpxPiQanrkyi9SSlM0PJ60Ptzlck47lhtnr9YZO3zYOsxHwnyeWJ6AffoBQ==",
+            "version": "22.4.1",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.1.tgz",
+            "integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
             "dev": true,
             "requires": {
                 "babel-plugin-istanbul": "4.1.5",
-                "babel-preset-jest": "21.2.0"
+                "babel-preset-jest": "22.4.1"
             }
         },
         "babel-messages": {
@@ -418,14 +479,14 @@
             "dev": true,
             "requires": {
                 "find-up": "2.1.0",
-                "istanbul-lib-instrument": "1.9.1",
-                "test-exclude": "4.1.1"
+                "istanbul-lib-instrument": "1.10.1",
+                "test-exclude": "4.2.1"
             }
         },
         "babel-plugin-jest-hoist": {
-            "version": "21.2.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz",
-            "integrity": "sha512-yi5QuiVyyvhBUDLP4ButAnhYzkdrUwWDtvUJv71hjH3fclhnZg4HkDeqaitcR2dZZx/E67kGkRcPVjtVu+SJfQ==",
+            "version": "22.4.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.1.tgz",
+            "integrity": "sha512-gmj5FvFflXSnRapWmF/jDjx5Lof1kX0OwXibCxMOx38V3CFMOnTxLTUrAFfLkhCey3FJvv0ACvv/+h4nzFRxhg==",
             "dev": true
         },
         "babel-plugin-syntax-object-rest-spread": {
@@ -446,12 +507,12 @@
             }
         },
         "babel-preset-jest": {
-            "version": "21.2.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz",
-            "integrity": "sha512-hm9cBnr2h3J7yXoTtAVV0zg+3vg0Q/gT2GYuzlreTU0EPkJRtlNgKJJ3tBKEn0+VjAi3JykV6xCJkuUYttEEfA==",
+            "version": "22.4.1",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.1.tgz",
+            "integrity": "sha512-gW3+spyB8fkSAI9fX+41BQMwar5LjR+nyKa2QRvK22snxnI29+jJVAMfId+osucFJzJJvhlvzKWnfwX8Omodvg==",
             "dev": true,
             "requires": {
-                "babel-plugin-jest-hoist": "21.2.0",
+                "babel-plugin-jest-hoist": "22.4.1",
                 "babel-plugin-syntax-object-rest-spread": "6.13.0"
             }
         },
@@ -468,6 +529,17 @@
                 "lodash": "4.17.4",
                 "mkdirp": "0.5.1",
                 "source-map-support": "0.4.18"
+            },
+            "dependencies": {
+                "source-map-support": {
+                    "version": "0.4.18",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+                    "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+                    "dev": true,
+                    "requires": {
+                        "source-map": "0.5.7"
+                    }
+                }
             }
         },
         "babel-runtime": {
@@ -514,7 +586,7 @@
                 "babylon": "6.18.0",
                 "debug": "2.6.9",
                 "globals": "9.18.0",
-                "invariant": "2.2.2",
+                "invariant": "2.2.4",
                 "lodash": "4.17.4"
             },
             "dependencies": {
@@ -552,6 +624,38 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
+        },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "dev": true,
+            "requires": {
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "1.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
         },
         "base64-js": {
             "version": "1.2.1",
@@ -635,6 +739,12 @@
                 "through2": "2.0.3",
                 "umd": "3.0.1"
             }
+        },
+        "browser-process-hrtime": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+            "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+            "dev": true
         },
         "browser-resolve": {
             "version": "1.11.2",
@@ -839,6 +949,31 @@
             "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
             "dev": true
         },
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "dev": true,
+            "requires": {
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
         "cached-path-relative": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
@@ -899,6 +1034,7 @@
             "requires": {
                 "anymatch": "1.3.2",
                 "async-each": "1.0.1",
+                "fsevents": "1.1.3",
                 "glob-parent": "2.0.0",
                 "inherits": "2.0.3",
                 "is-binary-path": "1.0.1",
@@ -1016,6 +1152,92 @@
                 "safe-buffer": "5.1.1"
             }
         },
+        "class-utils": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "dev": true,
+            "requires": {
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
         "clean-css": {
             "version": "4.1.9",
             "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz",
@@ -1100,6 +1322,16 @@
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
             "dev": true
         },
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "dev": true,
+            "requires": {
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
+            }
+        },
         "color-convert": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
@@ -1146,6 +1378,18 @@
             "version": "2.12.2",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
             "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+            "dev": true
+        },
+        "compare-versions": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.1.0.tgz",
+            "integrity": "sha512-4hAxDSBypT/yp2ySFD346So6Ragw5xmBn/e/agIGl3bZr6DLUqnoRZPusxKrXdYRZpgexO9daejmIenlq/wrIQ==",
+            "dev": true
+        },
+        "component-emitter": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
             "dev": true
         },
         "concat": {
@@ -1221,6 +1465,12 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
             "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+            "dev": true
+        },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
         },
         "core-js": {
@@ -1342,6 +1592,16 @@
                 "cssom": "0.3.2"
             }
         },
+        "cwd": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
+            "integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
+            "dev": true,
+            "requires": {
+                "find-pkg": "0.1.2",
+                "fs-exists-sync": "0.1.0"
+            }
+        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -1370,6 +1630,12 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
         "deep-is": {
@@ -1406,6 +1672,24 @@
             "requires": {
                 "foreach": "2.0.5",
                 "object-keys": "1.0.11"
+            }
+        },
+        "define-property": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "dev": true,
+            "requires": {
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
             }
         },
         "defined": {
@@ -1451,6 +1735,12 @@
                 "repeating": "2.0.1"
             }
         },
+        "detect-newline": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+            "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+            "dev": true
+        },
         "detective": {
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.0.tgz",
@@ -1470,9 +1760,9 @@
             }
         },
         "diff": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-            "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
             "dev": true
         },
         "diffie-hellman": {
@@ -1491,6 +1781,15 @@
             "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
             "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
             "dev": true
+        },
+        "domexception": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+            "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+            "dev": true,
+            "requires": {
+                "webidl-conversions": "4.0.2"
+            }
         },
         "duplexer": {
             "version": "0.1.1",
@@ -1553,15 +1852,6 @@
                 "iconv-lite": "0.4.19"
             }
         },
-        "errno": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
-            "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
-            "dev": true,
-            "requires": {
-                "prr": "1.0.1"
-            }
-        },
         "error-ex": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
@@ -1595,6 +1885,21 @@
                 "is-symbol": "1.0.1"
             }
         },
+        "es6-promise": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+            "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+            "dev": true
+        },
+        "es6-promisify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "dev": true,
+            "requires": {
+                "es6-promise": "4.2.4"
+            }
+        },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1602,16 +1907,16 @@
             "dev": true
         },
         "escodegen": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-            "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+            "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
             "dev": true,
             "requires": {
                 "esprima": "3.1.3",
                 "estraverse": "4.2.0",
                 "esutils": "2.0.2",
                 "optionator": "0.8.2",
-                "source-map": "0.5.7"
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "esprima": {
@@ -1619,6 +1924,13 @@
                     "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
                     "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
                     "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -1701,6 +2013,12 @@
                 "strip-eof": "1.0.0"
             }
         },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
+        },
         "expand-brackets": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -1719,25 +2037,61 @@
                 "fill-range": "2.2.3"
             }
         },
+        "expand-tilde": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+            "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+            "dev": true,
+            "requires": {
+                "os-homedir": "1.0.2"
+            }
+        },
         "expect": {
-            "version": "21.2.1",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-21.2.1.tgz",
-            "integrity": "sha512-orfQQqFRTX0jH7znRIGi8ZMR8kTNpXklTTz8+HGTpmTKZo3Occ6JNB5FXMb8cRuiiC/GyDqsr30zUa66ACYlYw==",
+            "version": "22.4.0",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.0.tgz",
+            "integrity": "sha512-Fiy862jT3qc70hwIHwwCBNISmaqBrfWKKrtqyMJ6iwZr+6KXtcnHojZFtd63TPRvRl8EQTJ+YXYy2lK6/6u+Hw==",
             "dev": true,
             "requires": {
                 "ansi-styles": "3.2.0",
-                "jest-diff": "21.2.1",
-                "jest-get-type": "21.2.0",
-                "jest-matcher-utils": "21.2.1",
-                "jest-message-util": "21.2.1",
-                "jest-regex-util": "21.2.0"
+                "jest-diff": "22.4.0",
+                "jest-get-type": "22.1.0",
+                "jest-matcher-utils": "22.4.0",
+                "jest-message-util": "22.4.0",
+                "jest-regex-util": "22.1.0"
             }
+        },
+        "expect-puppeteer": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-2.0.1.tgz",
+            "integrity": "sha1-qcxTtQ1Qf96ldISJzgPbt2CzIdg=",
+            "dev": true
         },
         "extend": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
             "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
             "dev": true
+        },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "dev": true,
+            "requires": {
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "2.0.4"
+                    }
+                }
+            }
         },
         "external-editor": {
             "version": "2.1.0",
@@ -1757,6 +2111,55 @@
             "dev": true,
             "requires": {
                 "is-extglob": "1.0.0"
+            }
+        },
+        "extract-zip": {
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
+            "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
+            "dev": true,
+            "requires": {
+                "concat-stream": "1.6.0",
+                "debug": "2.6.9",
+                "mkdirp": "0.5.0",
+                "yauzl": "2.4.1"
+            },
+            "dependencies": {
+                "concat-stream": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+                    "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.3",
+                        "typedarray": "0.0.6"
+                    }
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                    "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                }
             }
         },
         "extsprintf": {
@@ -1790,6 +2193,15 @@
             "dev": true,
             "requires": {
                 "bser": "2.0.0"
+            }
+        },
+        "fd-slicer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "dev": true,
+            "requires": {
+                "pend": "1.2.0"
             }
         },
         "figures": {
@@ -1828,6 +2240,25 @@
                 "randomatic": "1.1.7",
                 "repeat-element": "1.1.2",
                 "repeat-string": "1.6.1"
+            }
+        },
+        "find-file-up": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
+            "integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
+            "dev": true,
+            "requires": {
+                "fs-exists-sync": "0.1.0",
+                "resolve-dir": "0.1.1"
+            }
+        },
+        "find-pkg": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
+            "integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
+            "dev": true,
+            "requires": {
+                "find-file-up": "0.1.3"
             }
         },
         "find-up": {
@@ -1886,10 +2317,25 @@
                 "mime-types": "2.1.17"
             }
         },
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "dev": true,
+            "requires": {
+                "map-cache": "0.2.2"
+            }
+        },
         "from": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
             "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+            "dev": true
+        },
+        "fs-exists-sync": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+            "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
             "dev": true
         },
         "fs-extra": {
@@ -1909,6 +2355,910 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
+        "fsevents": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+            "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "nan": "2.9.2",
+                "node-pre-gyp": "0.6.39"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ajv": {
+                    "version": "4.11.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aproba": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.2.9"
+                    }
+                },
+                "asn1": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "assert-plus": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "aws-sign2": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "aws4": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "balanced-match": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "block-stream": {
+                    "version": "0.0.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "boom": {
+                    "version": "2.10.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.7",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "buffer-shims": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "co": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "combined-stream": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "delayed-stream": "1.0.0"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cryptiles": {
+                    "version": "2.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1"
+                    }
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "detect-libc": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "extend": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "extsprintf": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "form-data": {
+                    "version": "2.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.15"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "fstream": {
+                    "version": "1.0.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.1"
+                    }
+                },
+                "fstream-ignore": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4"
+                    }
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aproba": "1.1.1",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
+                    }
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "bundled": true,
+                    "dev": true
+                },
+                "har-schema": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "har-validator": {
+                    "version": "4.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "hawk": {
+                    "version": "3.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1",
+                        "cryptiles": "2.0.5",
+                        "hoek": "2.16.3",
+                        "sntp": "1.0.9"
+                    }
+                },
+                "hoek": {
+                    "version": "2.16.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "http-signature": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.0",
+                        "sshpk": "1.13.0"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ini": {
+                    "version": "1.3.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jodid25519": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "json-stable-stringify": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsonify": "0.0.0"
+                    }
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jsonify": {
+                    "version": "0.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jsprim": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "mime-db": {
+                    "version": "1.27.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.15",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.27.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "node-pre-gyp": {
+                    "version": "0.6.39",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "1.0.2",
+                        "hawk": "3.1.3",
+                        "mkdirp": "0.5.1",
+                        "nopt": "4.0.1",
+                        "npmlog": "4.1.0",
+                        "rc": "1.2.1",
+                        "request": "2.81.0",
+                        "rimraf": "2.6.1",
+                        "semver": "5.3.0",
+                        "tar": "2.2.1",
+                        "tar-pack": "3.4.0"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1.1.0",
+                        "osenv": "0.1.4"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "performance-now": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "bundled": true,
+                    "dev": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "qs": {
+                    "version": "6.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "deep-extend": "0.4.2",
+                        "ini": "1.3.4",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.2.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "1.0.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "request": {
+                    "version": "2.81.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "4.2.1",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.15",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "0.2.0",
+                        "qs": "6.4.0",
+                        "safe-buffer": "5.0.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.2",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "sntp": {
+                    "version": "1.0.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "sshpk": {
+                    "version": "1.13.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "stringstream": {
+                    "version": "0.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "block-stream": "0.0.9",
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3"
+                    }
+                },
+                "tar-pack": {
+                    "version": "3.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "2.6.8",
+                        "fstream": "1.0.11",
+                        "fstream-ignore": "1.0.5",
+                        "once": "1.4.0",
+                        "readable-stream": "2.2.9",
+                        "rimraf": "2.6.1",
+                        "tar": "2.2.1",
+                        "uid-number": "0.0.6"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "punycode": "1.4.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "uid-number": {
+                    "version": "0.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "uuid": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "verror": {
+                    "version": "1.3.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "extsprintf": "1.0.2"
+                    }
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "string-width": "1.0.2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                }
+            }
+        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -1925,6 +3275,12 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
             "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+            "dev": true
+        },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
             "dev": true
         },
         "getpass": {
@@ -2005,6 +3361,28 @@
             "dev": true,
             "requires": {
                 "is-glob": "2.0.1"
+            }
+        },
+        "global-modules": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+            "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+            "dev": true,
+            "requires": {
+                "global-prefix": "0.1.5",
+                "is-windows": "0.2.0"
+            }
+        },
+        "global-prefix": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+            "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "1.0.1",
+                "ini": "1.3.5",
+                "is-windows": "0.2.0",
+                "which": "1.3.0"
             }
         },
         "globals": {
@@ -2179,6 +3557,66 @@
             "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
             "dev": true
         },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "dev": true,
+            "requires": {
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "dev": true,
+            "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
         "hash-base": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
@@ -2241,6 +3679,15 @@
             "requires": {
                 "os-homedir": "1.0.2",
                 "os-tmpdir": "1.0.2"
+            }
+        },
+        "homedir-polyfill": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+            "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+            "dev": true,
+            "requires": {
+                "parse-passwd": "1.0.0"
             }
         },
         "hosted-git-info": {
@@ -2307,6 +3754,16 @@
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
         },
+        "https-proxy-agent": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.0.tgz",
+            "integrity": "sha512-uUWcfXHvy/dwfM9bqa6AozvAjS32dZSTUYd/4SEpYKRg6LEcPLshksnQYRudM9AyNvUARMfAg5TLjUDyX/K4vA==",
+            "dev": true,
+            "requires": {
+                "agent-base": "4.2.0",
+                "debug": "3.1.0"
+            }
+        },
         "husky": {
             "version": "0.14.3",
             "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
@@ -2338,6 +3795,16 @@
             "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
             "dev": true
         },
+        "import-local": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+            "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+            "dev": true,
+            "requires": {
+                "pkg-dir": "2.0.0",
+                "resolve-cwd": "2.0.0"
+            }
+        },
         "imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2364,6 +3831,12 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
             "dev": true
         },
         "inline-source-map": {
@@ -2414,9 +3887,9 @@
             }
         },
         "invariant": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-            "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "dev": true,
             "requires": {
                 "loose-envify": "1.3.1"
@@ -2427,6 +3900,23 @@
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
             "dev": true
+        },
+        "is-accessor-descriptor": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+            "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+            "dev": true,
+            "requires": {
+                "kind-of": "6.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
         },
         "is-arrayish": {
             "version": "0.2.1",
@@ -2473,11 +3963,47 @@
                 "ci-info": "1.1.2"
             }
         },
+        "is-data-descriptor": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+            "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+            "dev": true,
+            "requires": {
+                "kind-of": "6.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
+        },
         "is-date-object": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
             "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
             "dev": true
+        },
+        "is-descriptor": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+            "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+            "dev": true,
+            "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
         },
         "is-dotfile": {
             "version": "1.0.3",
@@ -2521,6 +4047,12 @@
             "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
             "dev": true
         },
+        "is-generator-fn": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+            "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+            "dev": true
+        },
         "is-glob": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -2537,6 +4069,40 @@
             "dev": true,
             "requires": {
                 "kind-of": "3.2.2"
+            }
+        },
+        "is-odd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+            "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+            "dev": true,
+            "requires": {
+                "is-number": "4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
+            "requires": {
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
             }
         },
         "is-posix-bracket": {
@@ -2590,6 +4156,12 @@
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
             "dev": true
         },
+        "is-windows": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+            "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+            "dev": true
+        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -2618,61 +4190,77 @@
             "dev": true
         },
         "istanbul-api": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.1.tgz",
-            "integrity": "sha512-oFCwXvd65amgaPCzqrR+a2XjanS1MvpXN6l/MlMUTv6uiA1NOgGX+I0uyq8Lg3GDxsxPsaP1049krz3hIJ5+KA==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
+            "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
             "dev": true,
             "requires": {
                 "async": "2.6.0",
+                "compare-versions": "3.1.0",
                 "fileset": "2.0.3",
-                "istanbul-lib-coverage": "1.1.1",
-                "istanbul-lib-hook": "1.1.0",
-                "istanbul-lib-instrument": "1.9.1",
-                "istanbul-lib-report": "1.1.2",
-                "istanbul-lib-source-maps": "1.2.2",
-                "istanbul-reports": "1.1.3",
-                "js-yaml": "3.10.0",
+                "istanbul-lib-coverage": "1.2.0",
+                "istanbul-lib-hook": "1.2.0",
+                "istanbul-lib-instrument": "1.10.1",
+                "istanbul-lib-report": "1.1.4",
+                "istanbul-lib-source-maps": "1.2.4",
+                "istanbul-reports": "1.3.0",
+                "js-yaml": "3.11.0",
                 "mkdirp": "0.5.1",
                 "once": "1.4.0"
+            },
+            "dependencies": {
+                "istanbul-lib-source-maps": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz",
+                    "integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "3.1.0",
+                        "istanbul-lib-coverage": "1.2.0",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.2",
+                        "source-map": "0.5.7"
+                    }
+                }
             }
         },
         "istanbul-lib-coverage": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-            "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
+            "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
             "dev": true
         },
         "istanbul-lib-hook": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
-            "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz",
+            "integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
             "dev": true,
             "requires": {
                 "append-transform": "0.4.0"
             }
         },
         "istanbul-lib-instrument": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
-            "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
+            "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
             "dev": true,
             "requires": {
-                "babel-generator": "6.26.0",
+                "babel-generator": "6.26.1",
                 "babel-template": "6.26.0",
                 "babel-traverse": "6.26.0",
                 "babel-types": "6.26.0",
                 "babylon": "6.18.0",
-                "istanbul-lib-coverage": "1.1.1",
+                "istanbul-lib-coverage": "1.2.0",
                 "semver": "5.4.1"
             }
         },
         "istanbul-lib-report": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
-            "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
+            "integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
             "dev": true,
             "requires": {
-                "istanbul-lib-coverage": "1.1.1",
+                "istanbul-lib-coverage": "1.2.0",
                 "mkdirp": "0.5.1",
                 "path-parse": "1.0.5",
                 "supports-color": "3.2.3"
@@ -2696,303 +4284,332 @@
             }
         },
         "istanbul-lib-source-maps": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
-            "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
+            "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
             "dev": true,
             "requires": {
                 "debug": "3.1.0",
-                "istanbul-lib-coverage": "1.1.1",
+                "istanbul-lib-coverage": "1.2.0",
                 "mkdirp": "0.5.1",
                 "rimraf": "2.6.2",
                 "source-map": "0.5.7"
             }
         },
         "istanbul-reports": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
-            "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
+            "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
             "dev": true,
             "requires": {
                 "handlebars": "4.0.11"
             }
         },
         "jest": {
-            "version": "21.2.1",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-21.2.1.tgz",
-            "integrity": "sha512-mXN0ppPvWYoIcC+R+ctKxAJ28xkt/Z5Js875padm4GbgUn6baeR5N4Ng6LjatIRpUQDZVJABT7Y4gucFjPryfw==",
+            "version": "22.4.2",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-22.4.2.tgz",
+            "integrity": "sha512-wD7dXWtfaQAgbNVsjFqzmuhg6nzwGsTRVea3FpSJ7GURhG+J536fw4mdoLB01DgiEozDDeF1ZMR/UlUszTsCrg==",
             "dev": true,
             "requires": {
-                "jest-cli": "21.2.1"
+                "import-local": "1.0.0",
+                "jest-cli": "22.4.2"
             },
             "dependencies": {
                 "jest-cli": {
-                    "version": "21.2.1",
-                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-21.2.1.tgz",
-                    "integrity": "sha512-T1BzrbFxDIW/LLYQqVfo94y/hhaj1NzVQkZgBumAC+sxbjMROI7VkihOdxNR758iYbQykL2ZOWUBurFgkQrzdg==",
+                    "version": "22.4.2",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.2.tgz",
+                    "integrity": "sha512-ebo6ZWK2xDSs7LGnLvM16SZOIJ2dj0B6/oERmGcal32NHkks450nNfGrGTyOSPgJDgH8DFhVdBXgSamN7mtZ0Q==",
                     "dev": true,
                     "requires": {
                         "ansi-escapes": "3.0.0",
                         "chalk": "2.3.0",
+                        "exit": "0.1.2",
                         "glob": "7.1.2",
                         "graceful-fs": "4.1.11",
+                        "import-local": "1.0.0",
                         "is-ci": "1.0.10",
-                        "istanbul-api": "1.2.1",
-                        "istanbul-lib-coverage": "1.1.1",
-                        "istanbul-lib-instrument": "1.9.1",
-                        "istanbul-lib-source-maps": "1.2.2",
-                        "jest-changed-files": "21.2.0",
-                        "jest-config": "21.2.1",
-                        "jest-environment-jsdom": "21.2.1",
-                        "jest-haste-map": "21.2.0",
-                        "jest-message-util": "21.2.1",
-                        "jest-regex-util": "21.2.0",
-                        "jest-resolve-dependencies": "21.2.0",
-                        "jest-runner": "21.2.1",
-                        "jest-runtime": "21.2.1",
-                        "jest-snapshot": "21.2.1",
-                        "jest-util": "21.2.1",
+                        "istanbul-api": "1.3.1",
+                        "istanbul-lib-coverage": "1.2.0",
+                        "istanbul-lib-instrument": "1.10.1",
+                        "istanbul-lib-source-maps": "1.2.3",
+                        "jest-changed-files": "22.2.0",
+                        "jest-config": "22.4.2",
+                        "jest-environment-jsdom": "22.4.1",
+                        "jest-get-type": "22.1.0",
+                        "jest-haste-map": "22.4.2",
+                        "jest-message-util": "22.4.0",
+                        "jest-regex-util": "22.1.0",
+                        "jest-resolve-dependencies": "22.1.0",
+                        "jest-runner": "22.4.2",
+                        "jest-runtime": "22.4.2",
+                        "jest-snapshot": "22.4.0",
+                        "jest-util": "22.4.1",
+                        "jest-validate": "22.4.2",
+                        "jest-worker": "22.2.2",
                         "micromatch": "2.3.11",
-                        "node-notifier": "5.1.2",
-                        "pify": "3.0.0",
+                        "node-notifier": "5.2.1",
+                        "realpath-native": "1.0.0",
+                        "rimraf": "2.6.2",
                         "slash": "1.0.0",
                         "string-length": "2.0.0",
                         "strip-ansi": "4.0.0",
                         "which": "1.3.0",
-                        "worker-farm": "1.5.2",
-                        "yargs": "9.0.1"
-                    }
-                },
-                "yargs": {
-                    "version": "9.0.1",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-                    "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "4.1.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "2.1.0",
-                        "read-pkg-up": "2.0.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "7.0.0"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-                    "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "4.1.0"
+                        "yargs": "10.0.3"
                     }
                 }
             }
         },
         "jest-changed-files": {
-            "version": "21.2.0",
-            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-21.2.0.tgz",
-            "integrity": "sha512-+lCNP1IZLwN1NOIvBcV5zEL6GENK6TXrDj4UxWIeLvIsIDa+gf6J7hkqsW2qVVt/wvH65rVvcPwqXdps5eclTQ==",
+            "version": "22.2.0",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.2.0.tgz",
+            "integrity": "sha512-SzqOvoPMrXB0NPvDrSPeKETpoUNCtNDOsFbCzAGWxqWVvNyrIMLpUjVExT3u3LfdVrENlrNGCfh5YoFd8+ZeXg==",
             "dev": true,
             "requires": {
                 "throat": "4.1.0"
             }
         },
         "jest-config": {
-            "version": "21.2.1",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.2.1.tgz",
-            "integrity": "sha512-fJru5HtlD/5l2o25eY9xT0doK3t2dlglrqoGpbktduyoI0T5CwuB++2YfoNZCrgZipTwPuAGonYv0q7+8yDc/A==",
+            "version": "22.4.2",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.2.tgz",
+            "integrity": "sha512-oG31qYO73/3vj/Q8aM2RgzmHndTkz9nRk8ISybfuJqqbf0RW7OUjHVOZPLOUiwLWtz52Yq2HkjIblsyhbA7vrg==",
             "dev": true,
             "requires": {
                 "chalk": "2.3.0",
                 "glob": "7.1.2",
-                "jest-environment-jsdom": "21.2.1",
-                "jest-environment-node": "21.2.1",
-                "jest-get-type": "21.2.0",
-                "jest-jasmine2": "21.2.1",
-                "jest-regex-util": "21.2.0",
-                "jest-resolve": "21.2.0",
-                "jest-util": "21.2.1",
-                "jest-validate": "21.2.1",
-                "pretty-format": "21.2.1"
+                "jest-environment-jsdom": "22.4.1",
+                "jest-environment-node": "22.4.1",
+                "jest-get-type": "22.1.0",
+                "jest-jasmine2": "22.4.2",
+                "jest-regex-util": "22.1.0",
+                "jest-resolve": "22.4.2",
+                "jest-util": "22.4.1",
+                "jest-validate": "22.4.2",
+                "pretty-format": "22.4.0"
             }
         },
         "jest-diff": {
-            "version": "21.2.1",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz",
-            "integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
+            "version": "22.4.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.0.tgz",
+            "integrity": "sha512-+/t20WmnkOkB8MOaGaPziI8zWKxquMvYw4Ub+wOzi7AUhmpFXz43buWSxVoZo4J5RnCozpGbX3/FssjJ5KV9Nw==",
             "dev": true,
             "requires": {
                 "chalk": "2.3.0",
-                "diff": "3.4.0",
-                "jest-get-type": "21.2.0",
-                "pretty-format": "21.2.1"
+                "diff": "3.5.0",
+                "jest-get-type": "22.1.0",
+                "pretty-format": "22.4.0"
             }
         },
         "jest-docblock": {
-            "version": "21.2.0",
-            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-            "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-            "dev": true
-        },
-        "jest-environment-jsdom": {
-            "version": "21.2.1",
-            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz",
-            "integrity": "sha512-mecaeNh0eWmzNrUNMWARysc0E9R96UPBamNiOCYL28k7mksb1d0q6DD38WKP7ABffjnXyUWJPVaWRgUOivwXwg==",
+            "version": "22.4.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.0.tgz",
+            "integrity": "sha512-lDY7GZ+/CJb02oULYLBDj7Hs5shBhVpDYpIm8LUyqw9X2J22QRsM19gmGQwIFqGSJmpc/LRrSYudeSrG510xlQ==",
             "dev": true,
             "requires": {
-                "jest-mock": "21.2.0",
-                "jest-util": "21.2.1",
-                "jsdom": "9.12.0"
+                "detect-newline": "2.1.0"
+            }
+        },
+        "jest-environment-jsdom": {
+            "version": "22.4.1",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.1.tgz",
+            "integrity": "sha512-x/JzAoH+dWPBnIMv5OQKiIR0TYf6UvbRjsIuDZ11yDFXkHKGJZg6jNnLAsokAm3cq9kUa2hH5BPUC9XU4n1ELQ==",
+            "dev": true,
+            "requires": {
+                "jest-mock": "22.2.0",
+                "jest-util": "22.4.1",
+                "jsdom": "11.6.2"
             }
         },
         "jest-environment-node": {
-            "version": "21.2.1",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.2.1.tgz",
-            "integrity": "sha512-R211867wx9mVBVHzrjGRGTy5cd05K7eqzQl/WyZixR/VkJ4FayS8qkKXZyYnwZi6Rxo6WEV81cDbiUx/GfuLNw==",
+            "version": "22.4.1",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.1.tgz",
+            "integrity": "sha512-wj9+zzfRgnUbm5VwFOCGgG1QmbucUyrjPKBKUJdLW8K5Ss5zrNc1k+v6feZhFg6sS3ZGnjgtIyklaxEARxu+LQ==",
             "dev": true,
             "requires": {
-                "jest-mock": "21.2.0",
-                "jest-util": "21.2.1"
+                "jest-mock": "22.2.0",
+                "jest-util": "22.4.1"
+            }
+        },
+        "jest-environment-puppeteer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-2.0.0.tgz",
+            "integrity": "sha1-nfzS3yu6HY45cjYm9JMjti7CvfM=",
+            "dev": true,
+            "requires": {
+                "cwd": "0.10.0",
+                "lodash": "4.17.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "spawnd": "2.0.0",
+                "wait-port": "0.2.2"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.5",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+                    "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+                    "dev": true
+                }
             }
         },
         "jest-get-type": {
-            "version": "21.2.0",
-            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
-            "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+            "version": "22.1.0",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.1.0.tgz",
+            "integrity": "sha512-nD97IVOlNP6fjIN5i7j5XRH+hFsHL7VlauBbzRvueaaUe70uohrkz7pL/N8lx/IAwZRTJ//wOdVgh85OgM7g3w==",
             "dev": true
         },
         "jest-haste-map": {
-            "version": "21.2.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.2.0.tgz",
-            "integrity": "sha512-5LhsY/loPH7wwOFRMs+PT4aIAORJ2qwgbpMFlbWbxfN0bk3ZCwxJ530vrbSiTstMkYLao6JwBkLhCJ5XbY7ZHw==",
+            "version": "22.4.2",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.2.tgz",
+            "integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
             "dev": true,
             "requires": {
                 "fb-watchman": "2.0.0",
                 "graceful-fs": "4.1.11",
-                "jest-docblock": "21.2.0",
+                "jest-docblock": "22.4.0",
+                "jest-serializer": "22.4.0",
+                "jest-worker": "22.2.2",
                 "micromatch": "2.3.11",
-                "sane": "2.2.0",
-                "worker-farm": "1.5.2"
+                "sane": "2.4.1"
             }
         },
         "jest-jasmine2": {
-            "version": "21.2.1",
-            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz",
-            "integrity": "sha512-lw8FXXIEekD+jYNlStfgNsUHpfMWhWWCgHV7n0B7mA/vendH7vBFs8xybjQsDzJSduptBZJHqQX9SMssya9+3A==",
+            "version": "22.4.2",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.2.tgz",
+            "integrity": "sha512-KZaIHpXQ0AIlvQJFCU0uoXxtz5GG47X14r9upMe7VXE55UazoMZBFnQb9TX2HoYX2/AxJYnjHuvwKVCFqOrEtw==",
             "dev": true,
             "requires": {
                 "chalk": "2.3.0",
-                "expect": "21.2.1",
+                "co": "4.6.0",
+                "expect": "22.4.0",
                 "graceful-fs": "4.1.11",
-                "jest-diff": "21.2.1",
-                "jest-matcher-utils": "21.2.1",
-                "jest-message-util": "21.2.1",
-                "jest-snapshot": "21.2.1",
-                "p-cancelable": "0.3.0"
+                "is-generator-fn": "1.0.0",
+                "jest-diff": "22.4.0",
+                "jest-matcher-utils": "22.4.0",
+                "jest-message-util": "22.4.0",
+                "jest-snapshot": "22.4.0",
+                "jest-util": "22.4.1",
+                "source-map-support": "0.5.4"
+            }
+        },
+        "jest-leak-detector": {
+            "version": "22.4.0",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.0.tgz",
+            "integrity": "sha512-r3NEIVNh4X3fEeJtUIrKXWKhNokwUM2ILp5LD8w1KrEanPsFtZmYjmyZYjDTX2dXYr33TW65OvbRE3hWFAyq6g==",
+            "dev": true,
+            "requires": {
+                "pretty-format": "22.4.0"
             }
         },
         "jest-matcher-utils": {
-            "version": "21.2.1",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz",
-            "integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
+            "version": "22.4.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.0.tgz",
+            "integrity": "sha512-03m3issxUXpWMwDYTfmL8hRNewUB0yCRTeXPm+eq058rZxLHD9f5NtSSO98CWHqe4UyISIxd9Ao9iDVjHWd2qg==",
             "dev": true,
             "requires": {
                 "chalk": "2.3.0",
-                "jest-get-type": "21.2.0",
-                "pretty-format": "21.2.1"
+                "jest-get-type": "22.1.0",
+                "pretty-format": "22.4.0"
             }
         },
         "jest-message-util": {
-            "version": "21.2.1",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz",
-            "integrity": "sha512-EbC1X2n0t9IdeMECJn2BOg7buOGivCvVNjqKMXTzQOu7uIfLml+keUfCALDh8o4rbtndIeyGU8/BKfoTr/LVDQ==",
+            "version": "22.4.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.0.tgz",
+            "integrity": "sha512-eyCJB0T3hrlpFF2FqQoIB093OulP+1qvATQmD3IOgJgMGqPL6eYw8TbC5P/VCWPqKhGL51xvjIIhow5eZ2wHFw==",
             "dev": true,
             "requires": {
+                "@babel/code-frame": "7.0.0-beta.41",
                 "chalk": "2.3.0",
                 "micromatch": "2.3.11",
-                "slash": "1.0.0"
+                "slash": "1.0.0",
+                "stack-utils": "1.0.1"
             }
         },
         "jest-mock": {
-            "version": "21.2.0",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.2.0.tgz",
-            "integrity": "sha512-aZDfyVf0LEoABWiY6N0d+O963dUQSyUa4qgzurHR3TBDPen0YxKCJ6l2i7lQGh1tVdsuvdrCZ4qPj+A7PievCw==",
+            "version": "22.2.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.2.0.tgz",
+            "integrity": "sha512-eOfoUYLOB/JlxChOFkh/bzpWGqUXb9I+oOpkprHHs9L7nUNfL8Rk28h1ycWrqzWCEQ/jZBg/xIv7VdQkfAkOhw==",
             "dev": true
         },
+        "jest-puppeteer-preset": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/jest-puppeteer-preset/-/jest-puppeteer-preset-2.0.1.tgz",
+            "integrity": "sha1-cGdSWSKgMxeSJviHjrkntUzNlvY=",
+            "dev": true,
+            "requires": {
+                "expect-puppeteer": "2.0.1",
+                "jest-environment-puppeteer": "2.0.0"
+            }
+        },
         "jest-regex-util": {
-            "version": "21.2.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.2.0.tgz",
-            "integrity": "sha512-BKQ1F83EQy0d9Jen/mcVX7D+lUt2tthhK/2gDWRgLDJRNOdRgSp1iVqFxP8EN1ARuypvDflRfPzYT8fQnoBQFQ==",
+            "version": "22.1.0",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.1.0.tgz",
+            "integrity": "sha512-on0LqVS6Xeh69sw3d1RukVnur+lVOl3zkmb0Q54FHj9wHoq6dbtWqb3TSlnVUyx36hqjJhjgs/QLqs07Bzu72Q==",
             "dev": true
         },
         "jest-resolve": {
-            "version": "21.2.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.2.0.tgz",
-            "integrity": "sha512-vefQ/Lr+VdNvHUZFQXWtOqHX3HEdOc2MtSahBO89qXywEbUxGPB9ZLP9+BHinkxb60UT2Q/tTDOS6rYc6Mwigw==",
+            "version": "22.4.2",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.2.tgz",
+            "integrity": "sha512-P1hSfcc2HJYT5t+WPu/11OfFMa7m8pBb2Gf2vm6W9OVs7YTXQ5RCC3nDqaYZQaTqxEM1ZZaTcQGcE6U2xMOsqQ==",
             "dev": true,
             "requires": {
                 "browser-resolve": "1.11.2",
-                "chalk": "2.3.0",
-                "is-builtin-module": "1.0.0"
+                "chalk": "2.3.0"
             }
         },
         "jest-resolve-dependencies": {
-            "version": "21.2.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz",
-            "integrity": "sha512-ok8ybRFU5ScaAcfufIQrCbdNJSRZ85mkxJ1EhUp8Bhav1W1/jv/rl1Q6QoVQHObNxmKnbHVKrfLZbCbOsXQ+bQ==",
+            "version": "22.1.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.1.0.tgz",
+            "integrity": "sha512-76Ll61bD/Sus8wK8d+lw891EtiBJGJkWG8OuVDTEX0z3z2+jPujvQqSB2eQ+kCHyCsRwJ2PSjhn3UHqae/oEtA==",
             "dev": true,
             "requires": {
-                "jest-regex-util": "21.2.0"
+                "jest-regex-util": "22.1.0"
             }
         },
         "jest-runner": {
-            "version": "21.2.1",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-21.2.1.tgz",
-            "integrity": "sha512-Anb72BOQlHqF/zETqZ2K20dbYsnqW/nZO7jV8BYENl+3c44JhMrA8zd1lt52+N7ErnsQMd2HHKiVwN9GYSXmrg==",
+            "version": "22.4.2",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.2.tgz",
+            "integrity": "sha512-W4vwgiVQS0NyXt8hgpw7i0YUtsfoChiQcoHWBJeq2ocV4VF2osEZx8HYgpH5HfNe1Cb5LZeZWxX8Dr3hesbGFg==",
             "dev": true,
             "requires": {
-                "jest-config": "21.2.1",
-                "jest-docblock": "21.2.0",
-                "jest-haste-map": "21.2.0",
-                "jest-jasmine2": "21.2.1",
-                "jest-message-util": "21.2.1",
-                "jest-runtime": "21.2.1",
-                "jest-util": "21.2.1",
-                "pify": "3.0.0",
-                "throat": "4.1.0",
-                "worker-farm": "1.5.2"
+                "exit": "0.1.2",
+                "jest-config": "22.4.2",
+                "jest-docblock": "22.4.0",
+                "jest-haste-map": "22.4.2",
+                "jest-jasmine2": "22.4.2",
+                "jest-leak-detector": "22.4.0",
+                "jest-message-util": "22.4.0",
+                "jest-runtime": "22.4.2",
+                "jest-util": "22.4.1",
+                "jest-worker": "22.2.2",
+                "throat": "4.1.0"
             }
         },
         "jest-runtime": {
-            "version": "21.2.1",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.2.1.tgz",
-            "integrity": "sha512-6omlpA3+NSE+rHwD0PQjNEjZeb2z+oRmuehMfM1tWQVum+E0WV3pFt26Am0DUfQkkPyTABvxITRjCUclYgSOsA==",
+            "version": "22.4.2",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.2.tgz",
+            "integrity": "sha512-9/Fxbj99cqxI7o2nTNzevnI38eDBstkwve8ZeaAD/Kz0fbU3i3eRv2QPEmzbmyCyBvUWxCT7BzNLTzTqH1+pyA==",
             "dev": true,
             "requires": {
                 "babel-core": "6.26.0",
-                "babel-jest": "21.2.0",
+                "babel-jest": "22.4.1",
                 "babel-plugin-istanbul": "4.1.5",
                 "chalk": "2.3.0",
                 "convert-source-map": "1.5.1",
+                "exit": "0.1.2",
                 "graceful-fs": "4.1.11",
-                "jest-config": "21.2.1",
-                "jest-haste-map": "21.2.0",
-                "jest-regex-util": "21.2.0",
-                "jest-resolve": "21.2.0",
-                "jest-util": "21.2.1",
+                "jest-config": "22.4.2",
+                "jest-haste-map": "22.4.2",
+                "jest-regex-util": "22.1.0",
+                "jest-resolve": "22.4.2",
+                "jest-util": "22.4.1",
+                "jest-validate": "22.4.2",
                 "json-stable-stringify": "1.0.1",
                 "micromatch": "2.3.11",
+                "realpath-native": "1.0.0",
                 "slash": "1.0.0",
                 "strip-bom": "3.0.0",
                 "write-file-atomic": "2.3.0",
-                "yargs": "9.0.1"
+                "yargs": "10.0.3"
             },
             "dependencies": {
                 "convert-source-map": {
@@ -3009,78 +4626,72 @@
                     "requires": {
                         "jsonify": "0.0.0"
                     }
-                },
-                "yargs": {
-                    "version": "9.0.1",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-                    "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "4.1.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "2.1.0",
-                        "read-pkg-up": "2.0.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "7.0.0"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-                    "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "4.1.0"
-                    }
                 }
             }
         },
+        "jest-serializer": {
+            "version": "22.4.0",
+            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.0.tgz",
+            "integrity": "sha512-dnqde95MiYfdc1ZJpjEiHCRvRGGJHPsZQARJFucEGIaOzxqqS9/tt2WzD/OUSGT6kxaEGLQE92faVJGdoCu+Rw==",
+            "dev": true
+        },
         "jest-snapshot": {
-            "version": "21.2.1",
-            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz",
-            "integrity": "sha512-bpaeBnDpdqaRTzN8tWg0DqOTo2DvD3StOemxn67CUd1p1Po+BUpvePAp44jdJ7Pxcjfg+42o4NHw1SxdCA2rvg==",
+            "version": "22.4.0",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.0.tgz",
+            "integrity": "sha512-6Zz4F9G1Nbr93kfm5h3A2+OkE+WGpgJlskYE4iSNN2uYfoTL5b9W6aB9Orpx+ueReHyqmy7HET7Z3EmYlL3hKw==",
             "dev": true,
             "requires": {
                 "chalk": "2.3.0",
-                "jest-diff": "21.2.1",
-                "jest-matcher-utils": "21.2.1",
+                "jest-diff": "22.4.0",
+                "jest-matcher-utils": "22.4.0",
                 "mkdirp": "0.5.1",
                 "natural-compare": "1.4.0",
-                "pretty-format": "21.2.1"
+                "pretty-format": "22.4.0"
             }
         },
         "jest-util": {
-            "version": "21.2.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.2.1.tgz",
-            "integrity": "sha512-r20W91rmHY3fnCoO7aOAlyfC51x2yeV3xF+prGsJAUsYhKeV670ZB8NO88Lwm7ASu8SdH0S+U+eFf498kjhA4g==",
+            "version": "22.4.1",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.1.tgz",
+            "integrity": "sha512-9ySBdJY2qVWpg0OvZbGcFXE2NgwccpZVj384E9bx7brKFc7l5anpqah15mseWcz7FLDk7/N+LyYgqFme7Rez2Q==",
             "dev": true,
             "requires": {
                 "callsites": "2.0.0",
                 "chalk": "2.3.0",
                 "graceful-fs": "4.1.11",
-                "jest-message-util": "21.2.1",
-                "jest-mock": "21.2.0",
-                "jest-validate": "21.2.1",
-                "mkdirp": "0.5.1"
+                "is-ci": "1.0.10",
+                "jest-message-util": "22.4.0",
+                "mkdirp": "0.5.1",
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
             }
         },
         "jest-validate": {
-            "version": "21.2.1",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
-            "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+            "version": "22.4.2",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.2.tgz",
+            "integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
             "dev": true,
             "requires": {
                 "chalk": "2.3.0",
-                "jest-get-type": "21.2.0",
+                "jest-config": "22.4.2",
+                "jest-get-type": "22.1.0",
                 "leven": "2.1.0",
-                "pretty-format": "21.2.1"
+                "pretty-format": "22.4.0"
+            }
+        },
+        "jest-worker": {
+            "version": "22.2.2",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.2.2.tgz",
+            "integrity": "sha512-ZylDXjrFNt/OP6cUxwJFWwDgazP7hRjtCQbocFHyiwov+04Wm1x5PYzMGNJT53s4nwr0oo9ocYTImS09xOlUnw==",
+            "dev": true,
+            "requires": {
+                "merge-stream": "1.0.1"
             }
         },
         "js-tokens": {
@@ -3090,12 +4701,12 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-            "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+            "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.9",
+                "argparse": "1.0.10",
                 "esprima": "4.0.0"
             }
         },
@@ -3107,30 +4718,55 @@
             "optional": true
         },
         "jsdom": {
-            "version": "9.12.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
-            "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+            "version": "11.6.2",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
+            "integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
             "dev": true,
             "requires": {
                 "abab": "1.0.4",
-                "acorn": "4.0.13",
-                "acorn-globals": "3.1.0",
+                "acorn": "5.5.3",
+                "acorn-globals": "4.1.0",
                 "array-equal": "1.0.0",
+                "browser-process-hrtime": "0.1.2",
                 "content-type-parser": "1.0.2",
                 "cssom": "0.3.2",
                 "cssstyle": "0.2.37",
-                "escodegen": "1.9.0",
+                "domexception": "1.0.1",
+                "escodegen": "1.9.1",
                 "html-encoding-sniffer": "1.0.2",
+                "left-pad": "1.2.0",
                 "nwmatcher": "1.4.3",
-                "parse5": "1.5.1",
+                "parse5": "4.0.0",
+                "pn": "1.1.0",
                 "request": "2.83.0",
+                "request-promise-native": "1.0.5",
                 "sax": "1.2.4",
                 "symbol-tree": "3.2.2",
                 "tough-cookie": "2.3.3",
+                "w3c-hr-time": "1.0.1",
                 "webidl-conversions": "4.0.2",
                 "whatwg-encoding": "1.0.3",
-                "whatwg-url": "4.8.0",
-                "xml-name-validator": "2.0.1"
+                "whatwg-url": "6.4.0",
+                "ws": "4.1.0",
+                "xml-name-validator": "3.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.5.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+                    "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+                    "dev": true
+                },
+                "ws": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+                    "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+                    "dev": true,
+                    "requires": {
+                        "async-limiter": "1.0.0",
+                        "safe-buffer": "5.1.1"
+                    }
+                }
             }
         },
         "jsesc": {
@@ -3255,6 +4891,12 @@
                 "invert-kv": "1.0.0"
             }
         },
+        "left-pad": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+            "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+            "dev": true
+        },
         "leven": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -3322,6 +4964,12 @@
             "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
             "dev": true
         },
+        "lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+            "dev": true
+        },
         "longest": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -3356,11 +5004,26 @@
                 "tmpl": "1.0.4"
             }
         },
+        "map-cache": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+            "dev": true
+        },
         "map-stream": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
             "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
             "dev": true
+        },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "dev": true,
+            "requires": {
+                "object-visit": "1.0.1"
+            }
         },
         "md5.js": {
             "version": "1.3.4",
@@ -3404,6 +5067,15 @@
             "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
             "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
             "dev": true
+        },
+        "merge-stream": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3"
+            }
         },
         "micromatch": {
             "version": "2.3.11",
@@ -3490,6 +5162,27 @@
             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
             "dev": true
         },
+        "mixin-deep": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "dev": true,
+            "requires": {
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "2.0.4"
+                    }
+                }
+            }
+        },
         "mkdirp": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -3542,6 +5235,59 @@
             "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
             "dev": true
         },
+        "nan": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+            "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+            "dev": true,
+            "optional": true
+        },
+        "nanomatch": {
+            "version": "1.2.9",
+            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+            "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+            "dev": true,
+            "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-odd": "2.0.0",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "is-windows": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+                    "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
+        },
         "natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3574,9 +5320,9 @@
             "dev": true
         },
         "node-notifier": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
-            "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+            "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
             "dev": true,
             "requires": {
                 "growly": "1.3.0",
@@ -3700,11 +5446,97 @@
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
             "dev": true
         },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "dev": true,
+            "requires": {
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
         "object-keys": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
             "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
             "dev": true
+        },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "dev": true,
+            "requires": {
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.2",
+                "es-abstract": "1.10.0"
+            }
         },
         "object.omit": {
             "version": "2.0.1",
@@ -3714,6 +5546,23 @@
             "requires": {
                 "for-own": "0.1.5",
                 "is-extendable": "0.1.1"
+            }
+        },
+        "object.pick": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "dev": true,
+            "requires": {
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
             }
         },
         "once": {
@@ -3902,12 +5751,6 @@
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
-        "p-cancelable": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-            "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-            "dev": true
-        },
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -3978,10 +5821,22 @@
                 "error-ex": "1.3.1"
             }
         },
+        "parse-passwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+            "dev": true
+        },
         "parse5": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-            "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+            "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+            "dev": true
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
             "dev": true
         },
         "path-browserify": {
@@ -4059,6 +5914,12 @@
                 "sha.js": "2.4.9"
             }
         },
+        "pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+            "dev": true
+        },
         "performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -4085,6 +5946,21 @@
             "requires": {
                 "pinkie": "2.0.4"
             }
+        },
+        "pkg-dir": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+            "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+            "dev": true,
+            "requires": {
+                "find-up": "2.1.0"
+            }
+        },
+        "pn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+            "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+            "dev": true
         },
         "portfinder": {
             "version": "1.0.13",
@@ -4114,6 +5990,12 @@
                 }
             }
         },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+            "dev": true
+        },
         "prelude-ls": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -4127,9 +6009,9 @@
             "dev": true
         },
         "pretty-format": {
-            "version": "21.2.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
-            "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+            "version": "22.4.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.0.tgz",
+            "integrity": "sha512-pvCxP2iODIIk9adXlo4S3GRj0BrJiil68kByAa1PrgG97c1tClh9dLMgp3Z6cHFZrclaABt0UH8PIhwHuFLqYA==",
             "dev": true,
             "requires": {
                 "ansi-regex": "3.0.0",
@@ -4176,10 +6058,16 @@
             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
             "dev": true
         },
-        "prr": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+        "progress": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+            "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+            "dev": true
+        },
+        "proxy-from-env": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+            "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
             "dev": true
         },
         "ps-tree": {
@@ -4215,6 +6103,33 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
             "dev": true
+        },
+        "puppeteer": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.1.1.tgz",
+            "integrity": "sha1-rb8l5J9e8DRDwQq44JqVTKDHv+4=",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "extract-zip": "1.6.6",
+                "https-proxy-agent": "2.2.0",
+                "mime": "1.6.0",
+                "progress": "2.0.0",
+                "proxy-from-env": "1.0.0",
+                "rimraf": "2.6.2",
+                "ws": "3.3.3"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
         },
         "qs": {
             "version": "6.5.1",
@@ -4351,6 +6266,15 @@
                 "set-immediate-shim": "1.0.1"
             }
         },
+        "realpath-native": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
+            "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+            "dev": true,
+            "requires": {
+                "util.promisify": "1.0.0"
+            }
+        },
         "regenerator-runtime": {
             "version": "0.10.5",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
@@ -4364,6 +6288,16 @@
             "dev": true,
             "requires": {
                 "is-equal-shallow": "0.1.3"
+            }
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "remove-trailing-separator": {
@@ -4423,6 +6357,26 @@
                 "uuid": "3.1.0"
             }
         },
+        "request-promise-core": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+            "dev": true,
+            "requires": {
+                "lodash": "4.17.4"
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+            "dev": true,
+            "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.3.3"
+            }
+        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4450,6 +6404,37 @@
                 "path-parse": "1.0.5"
             }
         },
+        "resolve-cwd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+            "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+            "dev": true,
+            "requires": {
+                "resolve-from": "3.0.0"
+            }
+        },
+        "resolve-dir": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+            "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "1.2.2",
+                "global-modules": "0.2.3"
+            }
+        },
+        "resolve-from": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+            "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+            "dev": true
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+            "dev": true
+        },
         "restore-cursor": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -4459,6 +6444,12 @@
                 "onetime": "2.0.1",
                 "signal-exit": "3.0.2"
             }
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
         },
         "right-align": {
             "version": "0.1.3",
@@ -4525,15 +6516,25 @@
             "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
             "dev": true
         },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "dev": true,
+            "requires": {
+                "ret": "0.1.15"
+            }
+        },
         "sane": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/sane/-/sane-2.2.0.tgz",
-            "integrity": "sha512-OSJxhHO0CgPUw3lUm3GhfREAfza45smvEI9ozuFrxKG10GHVo0ryW9FK5VYlLvxj0SV7HVKHW0voYJIRu27GWg==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/sane/-/sane-2.4.1.tgz",
+            "integrity": "sha512-fW9svvNd81XzHDZyis9/tEY1bZikDGryy8Hi1BErPyNPYv47CdLseUN+tI5FBHWXEENRtj1SWtX/jBnggLaP0w==",
             "dev": true,
             "requires": {
                 "anymatch": "1.3.2",
                 "exec-sh": "0.2.1",
                 "fb-watchman": "2.0.0",
+                "fsevents": "1.1.3",
                 "minimatch": "3.0.4",
                 "minimist": "1.2.0",
                 "walker": "1.0.7",
@@ -4563,6 +6564,29 @@
             "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
             "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
             "dev": true
+        },
+        "set-value": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+            "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
         },
         "sha.js": {
             "version": "2.4.9",
@@ -4629,6 +6653,145 @@
             "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
             "dev": true
         },
+        "snapdragon": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "dev": true,
+            "requires": {
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.1",
+                "use": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "dev": true,
+            "requires": {
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "1.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            }
+        },
         "sntp": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
@@ -4644,13 +6807,52 @@
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
             "dev": true
         },
-        "source-map-support": {
-            "version": "0.4.18",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+        "source-map-resolve": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+            "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "atob": "2.0.3",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
+            }
+        },
+        "source-map-support": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
+            "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
+            "dev": true,
+            "requires": {
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "source-map-url": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+            "dev": true
+        },
+        "spawnd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-2.0.0.tgz",
+            "integrity": "sha1-0gIEA9xe9y7Kw/+rm0L6Fq6RdfU=",
+            "dev": true,
+            "requires": {
+                "exit": "0.1.2",
+                "signal-exit": "3.0.2",
+                "terminate": "2.1.0",
+                "wait-port": "0.2.2"
             }
         },
         "spdx-correct": {
@@ -4683,6 +6885,15 @@
                 "through": "2.3.8"
             }
         },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "3.0.2"
+            }
+        },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4704,6 +6915,96 @@
                 "jsbn": "0.1.1",
                 "tweetnacl": "0.14.5"
             }
+        },
+        "stack-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+            "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+            "dev": true
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "dev": true,
+            "requires": {
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true
         },
         "stream-browserify": {
             "version": "2.0.1",
@@ -4863,19 +7164,200 @@
                 "acorn": "4.0.13"
             }
         },
+        "terminate": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/terminate/-/terminate-2.1.0.tgz",
+            "integrity": "sha1-qH7kJL4BodKPLzAQRQQ6W81nmgU=",
+            "dev": true,
+            "requires": {
+                "ps-tree": "1.1.0"
+            }
+        },
         "test-exclude": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-            "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
+            "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
             "dev": true,
             "requires": {
                 "arrify": "1.0.1",
-                "micromatch": "2.3.11",
+                "micromatch": "3.1.9",
                 "object-assign": "4.1.1",
                 "read-pkg-up": "1.0.1",
                 "require-main-filename": "1.0.1"
             },
             "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+                    "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "1.1.0",
+                        "array-unique": "0.3.2",
+                        "define-property": "1.0.0",
+                        "extend-shallow": "2.0.1",
+                        "fill-range": "4.0.0",
+                        "isobject": "3.0.1",
+                        "kind-of": "6.0.2",
+                        "repeat-element": "1.1.2",
+                        "snapdragon": "0.8.2",
+                        "snapdragon-node": "2.1.1",
+                        "split-string": "3.1.0",
+                        "to-regex": "3.0.2"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "1.0.2"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "define-property": "0.2.5",
+                        "extend-shallow": "2.0.1",
+                        "posix-character-classes": "0.1.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "0.1.6"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "0.1.6",
+                                "is-data-descriptor": "0.1.4",
+                                "kind-of": "5.1.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
+                    "requires": {
+                        "array-unique": "0.3.2",
+                        "define-property": "1.0.0",
+                        "expand-brackets": "2.1.4",
+                        "extend-shallow": "2.0.1",
+                        "fragment-cache": "0.2.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "1.0.2"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "2.0.1",
+                        "is-number": "3.0.0",
+                        "repeat-string": "1.6.1",
+                        "to-regex-range": "2.1.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        }
+                    }
+                },
                 "find-up": {
                     "version": "1.1.2",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -4885,6 +7367,78 @@
                         "path-exists": "2.1.0",
                         "pinkie-promise": "2.0.1"
                     }
+                },
+                "is-accessor-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
                 },
                 "load-json-file": {
                     "version": "1.1.0",
@@ -4897,6 +7451,27 @@
                         "pify": "2.3.0",
                         "pinkie-promise": "2.0.1",
                         "strip-bom": "2.0.0"
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.9",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
+                    "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "4.0.0",
+                        "array-unique": "0.3.2",
+                        "braces": "2.3.1",
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "extglob": "2.0.4",
+                        "fragment-cache": "0.2.1",
+                        "kind-of": "6.0.2",
+                        "nanomatch": "1.2.9",
+                        "object.pick": "1.3.0",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     }
                 },
                 "path-exists": {
@@ -5015,6 +7590,48 @@
             "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
             "dev": true
         },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            }
+        },
+        "to-regex": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "dev": true,
+            "requires": {
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
+            }
+        },
+        "to-regex-range": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "dev": true,
+            "requires": {
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    }
+                }
+            }
+        },
         "tough-cookie": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
@@ -5025,10 +7642,21 @@
             }
         },
         "tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-            "dev": true
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+            "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+            "dev": true,
+            "requires": {
+                "punycode": "2.1.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+                    "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+                    "dev": true
+                }
+            }
         },
         "trim-right": {
             "version": "1.0.1",
@@ -5098,6 +7726,12 @@
             "dev": true,
             "optional": true
         },
+        "ultron": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+            "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+            "dev": true
+        },
         "umd": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
@@ -5121,10 +7755,97 @@
                 }
             }
         },
+        "union-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "dev": true,
+            "requires": {
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                },
+                "set-value": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "to-object-path": "0.3.0"
+                    }
+                }
+            }
+        },
         "universalify": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
             "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+            "dev": true
+        },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "dev": true,
+            "requires": {
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "dev": true,
+                    "requires": {
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "dev": true,
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+                    "dev": true
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "urix": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
             "dev": true
         },
         "url": {
@@ -5151,6 +7872,23 @@
             "integrity": "sha1-wHJ1aWetJLi1nldBVRyqx49QuLc=",
             "dev": true
         },
+        "use": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+            "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+            "dev": true,
+            "requires": {
+                "kind-of": "6.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
+        },
         "util": {
             "version": "0.10.3",
             "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -5173,6 +7911,16 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
+        },
+        "util.promisify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+            "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.2",
+                "object.getownpropertydescriptors": "2.0.3"
+            }
         },
         "uuid": {
             "version": "3.1.0",
@@ -5210,6 +7958,77 @@
                 "indexof": "0.0.1"
             }
         },
+        "w3c-hr-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+            "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+            "dev": true,
+            "requires": {
+                "browser-process-hrtime": "0.1.2"
+            }
+        },
+        "wait-port": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.2.tgz",
+            "integrity": "sha1-1RpJHkhKF791qUfnEaLwErTm8uM=",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "commander": "2.12.2",
+                "debug": "2.6.9"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
         "walker": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
@@ -5245,21 +8064,14 @@
             }
         },
         "whatwg-url": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
-            "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+            "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
             "dev": true,
             "requires": {
-                "tr46": "0.0.3",
-                "webidl-conversions": "3.0.1"
-            },
-            "dependencies": {
-                "webidl-conversions": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-                    "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-                    "dev": true
-                }
+                "lodash.sortby": "4.7.0",
+                "tr46": "1.0.1",
+                "webidl-conversions": "4.0.2"
             }
         },
         "which": {
@@ -5288,16 +8100,6 @@
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
             "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
             "dev": true
-        },
-        "worker-farm": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
-            "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
-            "dev": true,
-            "requires": {
-                "errno": "0.1.6",
-                "xtend": "4.0.1"
-            }
         },
         "wrap-ansi": {
             "version": "2.1.0",
@@ -5363,10 +8165,21 @@
                 "signal-exit": "3.0.2"
             }
         },
+        "ws": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+            "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+            "dev": true,
+            "requires": {
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "ultron": "1.1.1"
+            }
+        },
         "xml-name-validator": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-            "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
             "dev": true
         },
         "xtend": {
@@ -5414,6 +8227,15 @@
             "dev": true,
             "requires": {
                 "camelcase": "4.1.0"
+            }
+        },
+        "yauzl": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+            "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+            "dev": true,
+            "requires": {
+                "fd-slicer": "1.0.1"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -43,15 +43,18 @@
             "npm-run-all build-css-bundle build-js-bundle build-tabbed-js-bundle build-pages",
         "contributors:add": "all-contributors add",
         "contributors:generate": "all-contributors generate",
-        "start-server": "http-server ./docs",
+        "start-server": "http-server -p 4444 ./docs",
         "start-watch":
-            "chokidar '**/{*.js,*.css,*.html,*.json}' -i 'docs/**' -i 'node_modules/**' -i 'js/editor-*.js' -c 'npm run build' --initial --silent",
+            "chokidar '**/{*.js,*.css,*.html,*.json}' -i 'package.json' -i 'docs/**' -i 'node_modules/**' -i 'js/editor-*.js' -c 'npm run build' --initial --silent",
         "start": "npm-run-all --parallel start-watch start-server",
         "perf": "bundlesize",
-        "unit-tests": "jest",
-        "test": "npm-run-all unit-tests build perf",
+        "tests": "jest",
+        "test": "npm-run-all tests perf",
         "test:watch": "jest --watch",
         "precommit": "npm run test"
+    },
+    "jest": {
+        "preset": "jest-puppeteer-preset"
     },
     "keywords": [
         "javascript",
@@ -72,9 +75,11 @@
         "glob": "^7.1.2",
         "http-server": "^0.10.0",
         "husky": "^0.14.3",
-        "jest": "^21.2.1",
+        "jest": "^22.4.0",
+        "jest-puppeteer-preset": "^2.0.1",
         "node-dir": "^0.1.16",
         "npm-run-all": "^4.0.2",
+        "puppeteer": "^1.1.1",
         "uglify-es": "^3.0.3"
     }
 }


### PR DESCRIPTION
Run: `npm install` to get new dependencies, then
Run: `npm run unit-tests`

Note to Self: Change `unit-tests` to just be `test` as this now runs unit and functional tests