### PR TITLE
Add example for CSS font-kerning property

### DIFF
--- a/live-examples/css-examples/fonts/font-kerning.css
+++ b/live-examples/css-examples/fonts/font-kerning.css
@@ -1,0 +1,3 @@
+#output section {
+    font-family: serif;
+}

--- a/live-examples/css-examples/fonts/font-kerning.html
+++ b/live-examples/css-examples/fonts/font-kerning.html
@@ -1,0 +1,30 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="font-kerning">
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-kerning: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">font-kerning: normal;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-kerning: none;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+      <div id="example-element" class="transition-all">“We took Tracy to see ‘THE WATERFALL’ in W. Virginia.”</div>
+    </section>
+</div>

--- a/live-examples/css-examples/fonts/meta.json
+++ b/live-examples/css-examples/fonts/meta.json
@@ -26,6 +26,14 @@
             "title": "CSS Demo: font-feature-settings",
             "type": "css"
         },
+        "fontKerning": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc": "../../live-examples/css-examples/fonts/font-kerning.css",
+            "exampleCode": "live-examples/css-examples/fonts/font-kerning.html",
+            "fileName": "font-kerning.html",
+            "title": "CSS Demo: font-kerning",
+            "type": "css"
+        },
         "fontSize": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc": "../../live-examples/css-examples/fonts/font-size.css",


### PR DESCRIPTION
Trying this again. There seems to be some odd line endings in `css-examples/fonts/meta.json`; I've ignored them for now but you may want to check that out. 