### PR TITLE
Add example for animation-iteration-count CSS property

### DIFF
--- a/live-examples/css-examples/animation/animation-iteration-count.css
+++ b/live-examples/css-examples/animation/animation-iteration-count.css
@@ -1,0 +1,50 @@
+#example-element {
+    align-items: center;
+    background-color: #1766aa;
+    border-radius: 50%;
+    border: 5px solid #333;
+    color: white;
+    display: flex;
+    flex-direction: column;
+    height: 150px;
+    justify-content: center;
+    margin-left: 0;
+    margin: auto;
+    width: 150px;
+}
+
+#playstatus {
+    font-weight: bold;
+}
+
+.animating {
+    animation-name: slide;
+    animation-duration: 3s;
+    animation-timing-function: ease-in;
+}
+
+@-webkit-keyframes slide {
+    from {
+        background-color: orange;
+        color: black;
+        margin-left: 0;
+    }
+    to {
+        background-color: orange;
+        color: black;
+        margin-left: 80%;
+    }
+}
+
+@keyframes slide {
+    from {
+        background-color: orange;
+        color: black;
+        margin-left: 0;
+    }
+    to {
+        background-color: orange;
+        color: black;
+        margin-left: 80%;
+    }
+}

--- a/live-examples/css-examples/animation/animation-iteration-count.html
+++ b/live-examples/css-examples/animation/animation-iteration-count.html
@@ -1,0 +1,30 @@
+<section id="example-choice-list" class="example-choice-list" data-property="animation-iteration-count">
+    <div class="example-choice">
+        <pre><code class="language-css" initial-choice="true">animation-iteration-count: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">animation-iteration-count: 2;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">animation-iteration-count: 1.5;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example" class="flex-column">
+        <div>Animation <span id="playstatus"></span></div>
+
+        <div id="example-element">Select a count to start!</div>
+    </section>
+</div>

--- a/live-examples/css-examples/animation/meta.json
+++ b/live-examples/css-examples/animation/meta.json
@@ -54,6 +54,17 @@
             "title": "CSS Demo: animation-fill-mode",
             "type": "css"
         },
+        "animationIterationCount": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/animation/animation-iteration-count.css",
+            "jsExampleSrc":
+                "../../live-examples/css-examples/animation/animation-state.js",
+            "exampleCode": "live-examples/css-examples/animation/animation-iteration-count.html",
+            "fileName": "animation-iteration-count.html",
+            "title": "CSS Demo: animation-iteration-count",
+            "type": "css"
+        },
         "animationPlayState": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":


### PR DESCRIPTION
This PR adds an example for [`animation-iteration-count`](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-iteration-count). Let me know if you want to see any changes. Thanks!