### PR TITLE
Add example for font-language-override CSS property

### DIFF
--- a/live-examples/css-examples/fonts/font-language-override.css
+++ b/live-examples/css-examples/fonts/font-language-override.css
@@ -1,0 +1,17 @@
+@font-face {
+    font-family: 'Fira Sans';
+    src: local('FiraSans-Regular'),
+         url('../../../media/fonts/FiraSans-Regular.woff2') format('woff2');
+    font-weight: normal;
+    font-style: normal;
+}
+
+#output section {
+    font-family: 'Fira Sans', sans-serif;
+    margin-top: 10px;
+    font-size: 1.5em;
+}
+
+#output code {
+    font-size: .8em;
+}

--- a/live-examples/css-examples/fonts/font-language-override.html
+++ b/live-examples/css-examples/fonts/font-language-override.html
@@ -1,0 +1,31 @@
+<section id="example-choice-list" class="example-choice-list" data-property="font-language-override">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">font-language-override: normal;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-language-override: "ENG";</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-language-override: "TRK";</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <div id="example-element">
+            <p lang="tr"><code>lang="tr"</code> fi</p>
+            <p lang="en"><code>lang="en"</code> fi</p>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/fonts/meta.json
+++ b/live-examples/css-examples/fonts/meta.json
@@ -26,6 +26,15 @@
             "title": "CSS Demo: font-feature-settings",
             "type": "css"
         },
+        "fontLanguageOverride": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/fonts/font-language-override.css",
+            "exampleCode": "live-examples/css-examples/fonts/font-language-override.html",
+            "fileName": "font-language-override.html",
+            "title": "CSS Demo: font-language-override",
+            "type": "css"
+        },
         "fontKerning": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc": "../../live-examples/css-examples/fonts/font-kerning.css",


### PR DESCRIPTION
This PR adds an example for [`font-language-override`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-language-override). Let me know if you want to see any changes. Thanks!