### PR TITLE
Add example for animation-name CSS property

### DIFF
--- a/live-examples/css-examples/animation/animation-name.css
+++ b/live-examples/css-examples/animation/animation-name.css
@@ -1,0 +1,66 @@
+#example-element {
+    animation-direction: alternate;
+    animation-duration: 1s;
+    animation-iteration-count: infinite;
+    animation-timing-function: ease-in;
+    background-color: #1766aa;
+    border-radius: 50%;
+    border: 5px solid #333;
+    color: white;
+    height: 150px;
+    margin-left: 0;
+    margin: auto;
+    width: 150px;
+}
+
+@-webkit-keyframes slide {
+    from {
+        background-color: orange;
+        color: black;
+        margin-left: 0;
+    }
+    to {
+        background-color: orange;
+        color: black;
+        margin-left: 80%;
+    }
+}
+
+@keyframes slide {
+    from {
+        background-color: orange;
+        color: black;
+        margin-left: 0;
+    }
+    to {
+        background-color: orange;
+        color: black;
+        margin-left: 80%;
+    }
+}
+
+@-webkit-keyframes bounce {
+    from {
+        background-color: orange;
+        color: black;
+        margin-bottom: 0;
+    }
+    to {
+        background-color: orange;
+        color: black;
+        margin-bottom: 40%;
+    }
+}
+
+@keyframes bounce {
+    from {
+        background-color: orange;
+        color: black;
+        margin-top: 0;
+    }
+    to {
+        background-color: orange;
+        color: black;
+        margin-top: 40%;
+    }
+}

--- a/live-examples/css-examples/animation/animation-name.html
+++ b/live-examples/css-examples/animation/animation-name.html
@@ -1,0 +1,28 @@
+<section id="example-choice-list" class="example-choice-list" data-property="animation-name">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">animation-name: none;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">animation-name: slide;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">animation-name: bounce;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example" class="flex-column">
+        <div id="example-element" class="animating"></div>
+    </section>
+</div>

--- a/live-examples/css-examples/animation/meta.json
+++ b/live-examples/css-examples/animation/meta.json
@@ -65,6 +65,16 @@
             "title": "CSS Demo: animation-iteration-count",
             "type": "css"
         },
+        "animationName": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/animation/animation-name.css",
+            "exampleCode":
+                "live-examples/css-examples/animation/animation-name.html",
+            "fileName": "animation-name.html",
+            "title": "CSS Demo: animation-name",
+            "type": "css"
+        },
         "animationPlayState": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":


### PR DESCRIPTION
This PR adds an example for [`animation-name`](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-name). Let me know if you want to see any changes. Thanks!