### PR TITLE
Add example for text-orientation CSS property

### DIFF
--- a/live-examples/css-examples/writing-modes/meta.json
+++ b/live-examples/css-examples/writing-modes/meta.json
@@ -10,6 +10,14 @@
             "title": "CSS Demo: direction",
             "type": "css"
         },
+        "text-orientation": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "exampleCode":
+                "live-examples/css-examples/writing-modes/text-orientation.html",
+            "fileName": "text-orientation.html",
+            "title": "CSS Demo: text-orientation",
+            "type": "css"
+        },
         "writing-mode": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":

--- a/live-examples/css-examples/writing-modes/text-orientation.html
+++ b/live-examples/css-examples/writing-modes/text-orientation.html
@@ -1,0 +1,25 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="text-orientation">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">writing-mode: vertical-rl;
+text-orientation: mixed;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">writing-mode: vertical-rl;
+text-orientation: upright;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <div id="example-element" class="transition-all">
+            <p>In another moment down went Alice after it, never once considering how in the world she was to get out again.</p>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
This PR adds an example for [`text-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation). I think this one is OK, though there is one other value, `sideways-right` we could show, but that's only meaningful if there's a mix of vertical and horizontal characters (e.g., a mix of Latin and Japanese characters). Let me know if you want to see any changes. Thanks!