### PR TITLE
Add examples for font-variant-ligatures and font-variant-numeric

### DIFF
--- a/live-examples/css-examples/fonts/font-variant-ligatures.css
+++ b/live-examples/css-examples/fonts/font-variant-ligatures.css
@@ -1,0 +1,13 @@
+@font-face {
+    font-family: 'Fira Sans';
+    src: local('FiraSans-Regular'),
+         url('/media/fonts/FiraSans-Regular.woff2') format('woff2');
+    font-weight: normal;
+    font-style: normal;
+}
+
+#output section {
+    font-family: 'Fira Sans', sans-serif;
+    margin-top: 10px;
+    font-size: 1.5em;
+}

--- a/live-examples/css-examples/fonts/font-variant-ligatures.html
+++ b/live-examples/css-examples/fonts/font-variant-ligatures.html
@@ -1,0 +1,30 @@
+<section id="example-choice-list" class="example-choice-list" data-property="font-variant-ligatures">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">font-variant-ligatures: normal;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-variant-ligatures: no-common-ligatures;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-variant-ligatures: common-ligatures;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <div id="example-element">
+            <p>Difficult waffles</p>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/fonts/font-variant-numeric.css
+++ b/live-examples/css-examples/fonts/font-variant-numeric.css
@@ -1,0 +1,22 @@
+@font-face {
+    font-family: 'Fira Sans';
+    src: local('FiraSans-Regular'),
+         url('/media/fonts/FiraSans-Regular.woff2') format('woff2');
+    font-weight: normal;
+    font-style: normal;
+}
+
+#output section {
+    font-family: 'Fira Sans', sans-serif;
+    margin-top: 10px;
+    font-size: 1.5em;
+}
+
+#example-element table {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.tabular {
+    border: 1px solid black;
+}

--- a/live-examples/css-examples/fonts/font-variant-numeric.html
+++ b/live-examples/css-examples/fonts/font-variant-numeric.html
@@ -1,0 +1,47 @@
+<section id="example-choice-list" class="example-choice-list" data-property="font-variant-numeric">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">font-variant-numeric: normal;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-variant-numeric: slashed-zero;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-variant-numeric: tabular-nums;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">font-variant-numeric: oldstyle-nums;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <div id="example-element">
+            <table>
+                <tr>
+                    <td><span class="tabular">0</span></td>
+                </tr>
+                <tr>
+                    <td><span class="tabular">3.14</span></td>
+                </tr>
+                <tr>
+                    <td><span class="tabular">2.71</span></td>
+                </tr>
+            </table>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/fonts/meta.json
+++ b/live-examples/css-examples/fonts/meta.json
@@ -86,6 +86,15 @@
             "title": "CSS Demo: font-variant-caps",
             "type": "css"
         },
+        "fontVariantLigatures": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/fonts/font-variant-ligatures.css",
+            "exampleCode": "live-examples/css-examples/fonts/font-variant-ligatures.html",
+            "fileName": "font-variant-ligatures.html",
+            "title": "CSS Demo: font-variant-ligatures",
+            "type": "css"
+        },
         "fontWeight": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":

--- a/live-examples/css-examples/fonts/meta.json
+++ b/live-examples/css-examples/fonts/meta.json
@@ -95,6 +95,15 @@
             "title": "CSS Demo: font-variant-ligatures",
             "type": "css"
         },
+        "fontVariantNumeric": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "cssExampleSrc":
+                "../../live-examples/css-examples/fonts/font-variant-numeric.css",
+            "exampleCode": "live-examples/css-examples/fonts/font-variant-numeric.html",
+            "fileName": "font-variant-numeric.html",
+            "title": "CSS Demo: font-variant-numeric",
+            "type": "css"
+        },
         "fontWeight": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "cssExampleSrc":


### PR DESCRIPTION
This PR adds examples for [`font-variant-ligatures`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures) and [`font-variant-numeric`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric). Let me know if you want to see any changes. Thanks!