### PR TITLE
More illustrative example for `Proxy.apply`

### DIFF
--- a/live-examples/js-examples/proxyhandler/proxyhandler-apply.html
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-apply.html
@@ -8,13 +8,15 @@ const handler = {
     console.log(`Calculate sum: ${argumentsList}`);
     // expected output: "Calculate sum: 1,2"
 
-    return argumentsList[0] + argumentsList[1];
+    return target(argumentsList[0], argumentsList[1]) * 10;
   }
 };
 
 var proxy1 = new Proxy(sum, handler);
 
-console.log(proxy1(1, 2));
+console.log(sum(1, 2)); 
 // expected output: 3
+console.log(proxy1(1, 2));
+// expected output: 30
 </code>
 </pre>


### PR DESCRIPTION
IMO, the original example is somewhat lackluster.

In the existing example, the proxied `proxy1` function returns the same result as the original `sum` function; both return the sum of `arguments[0]` and `arguments[1]`. Th me, this seems pointless and does not do a proper job of showing how useful `Proxy` can be.

I think it would be best to show how `Proxy.apply` can be used to intercept and modify the return value and/or parameters passed to the target function.

Interested in everybody's thoughts. Thanks.