### PR TITLE
Fix: ArrayBuffer.byteLength() => byteLength

### DIFF
--- a/live-examples/js-examples/arraybuffer/meta.json
+++ b/live-examples/js-examples/arraybuffer/meta.json
@@ -13,7 +13,7 @@
             "exampleCode":
                 "live-examples/js-examples/arraybuffer/arraybuffer-bytelength.html",
             "fileName": "arraybuffer-bytelength.html",
-            "title": "JavaScript Demo: ArrayBuffer.byteLength()",
+            "title": "JavaScript Demo: ArrayBuffer.byteLength",
             "type": "js"
         },
         "arraybufferIsView": {


### PR DESCRIPTION
Remove the parens because it's not a function but a number.