### PR TITLE
Fix issue #690, add output label to tabbed editor output pane

### DIFF
--- a/css/tabbed-editor.css
+++ b/css/tabbed-editor.css
@@ -36,6 +36,19 @@
     width: 40%;
 }
 
+.output-label {
+    position: absolute;
+    background-color: #333;
+    color: #83d0f2;
+    right: 0;
+    margin: 0;
+    padding: 3px 10px;
+    width: 70px;
+    height: 25px;
+    font-size: .9rem;
+    letter-spacing: .035rem;
+}
+
 .output-header {
     margin: 0;
     padding: 0 0 .5em 0;

--- a/tmpl/live-tabbed-tmpl.html
+++ b/tmpl/live-tabbed-tmpl.html
@@ -30,7 +30,7 @@
 <div id="css-editor"><pre><code>%example-css-src%</pre></code></div>
               </section>
           </section>
-          <h4 class="output-label">output</h4>
+          <h4 class="output-label">Output</h4>
           <div id="output" class="output"></div>
       </div>
 

--- a/tmpl/live-tabbed-tmpl.html
+++ b/tmpl/live-tabbed-tmpl.html
@@ -30,6 +30,7 @@
 <div id="css-editor"><pre><code>%example-css-src%</pre></code></div>
               </section>
           </section>
+          <h4 class="output-label">output</h4>
           <div id="output" class="output"></div>
       </div>
 


### PR DESCRIPTION
@wbamberg This is what it looks like in the context of a MDN page:

<img width="844" alt="screen shot 2018-04-02 at 16 56 22" src="https://user-images.githubusercontent.com/10350960/38245157-555840ae-373d-11e8-84f1-bd1e633d7c85.png">
