### PR TITLE
Add <abbr> example

### DIFF
--- a/live-examples/html-examples/abbr.html
+++ b/live-examples/html-examples/abbr.html
@@ -1,0 +1,1 @@
+<p>You can use <abbr title="Cascading Style Sheets">CSS</abbr> to style your <abbr title="HyperText Markup Language">HTML</abbr>.</p>

--- a/live-examples/html-examples/css/abbr.css
+++ b/live-examples/html-examples/css/abbr.css
@@ -1,0 +1,3 @@
+abbr {
+    font-variant: all-small-caps;
+}

--- a/live-examples/html-examples/meta.json
+++ b/live-examples/html-examples/meta.json
@@ -1,5 +1,13 @@
 {
     "pages": {
+        "abbr": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode": "live-examples/html-examples/abbr.html",
+            "cssExampleSrc": "live-examples/html-examples/css/abbr.css",
+            "fileName": "abbr.html",
+            "title": "HTML Demo: <abbr>",
+            "type": "tabbed"
+        },
         "audio": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode": "live-examples/html-examples/audio.html",
@@ -7,7 +15,7 @@
             "fileName": "audio.html",
             "title": "HTML Demo: audio",
             "type": "tabbed"
-      },
+        },
         "datalist": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode": "live-examples/html-examples/datalist.html",


### PR DESCRIPTION
Add a simple example for [`<abbr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr). Feedback welcome!

I think we should wrap lines in the editor, what do you think?