### PR TITLE
Encode '<' and '>' in meta.json 'title' property

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -389,7 +389,7 @@ Add a property under `pages` describing your example. The example for `<td>` cou
     "exampleCode": "live-examples/html-examples/td.html",
     "cssExampleSrc": "live-examples/html-examples/css/td.css",
     "fileName": "td.html",
-    "title": "HTML Demo: <td>",
+    "title": "HTML Demo: &lt;td&gt;",
     "type": "tabbed"
 }
 ```

--- a/live-examples/html-examples/abbr.html
+++ b/live-examples/html-examples/abbr.html
@@ -1,0 +1,1 @@
+<p>You can use <abbr title="Cascading Style Sheets">CSS</abbr> to style your <abbr title="HyperText Markup Language">HTML</abbr>.</p>

--- a/live-examples/html-examples/css/abbr.css
+++ b/live-examples/html-examples/css/abbr.css
@@ -1,0 +1,3 @@
+abbr {
+    font-variant: all-small-caps;
+}

--- a/live-examples/html-examples/meta.json
+++ b/live-examples/html-examples/meta.json
@@ -1,5 +1,13 @@
 {
     "pages": {
+        "abbr": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode": "live-examples/html-examples/abbr.html",
+            "cssExampleSrc": "live-examples/html-examples/css/abbr.css",
+            "fileName": "abbr.html",
+            "title": "HTML Demo: <abbr>",
+            "type": "tabbed"
+        },
         "audio": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode": "live-examples/html-examples/audio.html",
@@ -7,7 +15,7 @@
             "fileName": "audio.html",
             "title": "HTML Demo: audio",
             "type": "tabbed"
-      },
+        },
         "datalist": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode": "live-examples/html-examples/datalist.html",

--- a/live-examples/html-examples/meta.json
+++ b/live-examples/html-examples/meta.json
@@ -5,7 +5,7 @@
             "exampleCode": "live-examples/html-examples/abbr.html",
             "cssExampleSrc": "live-examples/html-examples/css/abbr.css",
             "fileName": "abbr.html",
-            "title": "HTML Demo: <abbr>",
+            "title": "HTML Demo: &lt;abbr&gt;",
             "type": "tabbed"
         },
         "audio": {


### PR DESCRIPTION
It seems that we need to encode '<' and '>' in the `title` property in meta.json.