### PR TITLE
fix: scroll output when content overflows

### DIFF
--- a/css/tabbed-editor.css
+++ b/css/tabbed-editor.css
@@ -32,6 +32,7 @@
     width: 40%;
     height: 302px;
     box-shadow: inset 1px 1px 5px #cccaca, inset 0 -1px 5px #969595;
+    overflow: scroll;
 }
 
 .output-label {


### PR DESCRIPTION
Scrolls output container when content overflows.