### PR TITLE
Tabbed editor wrap long lines

### DIFF
--- a/css/tabbed-editor.css
+++ b/css/tabbed-editor.css
@@ -32,7 +32,6 @@
     width: 40%;
     height: 302px;
     box-shadow: inset 1px 1px 5px #cccaca, inset 0 -1px 5px #969595;
-    overflow: scroll;
 }
 
 .output-label {

--- a/css/tabbed-editor.css
+++ b/css/tabbed-editor.css
@@ -32,6 +32,7 @@
     width: 40%;
     height: 302px;
     box-shadow: inset 1px 1px 5px #cccaca, inset 0 -1px 5px #969595;
+    overflow: scroll;
 }
 
 .output-label {

--- a/js/editor-libs/tabby.js
+++ b/js/editor-libs/tabby.js
@@ -80,6 +80,7 @@ module.exports = {
             code: htmlEditor,
             config: {
                 lineNumbers: true,
+                lineWrapping: true,
                 mode: 'htmlmixed',
                 value: staticHTMLCode.querySelector('code').textContent
             }


### PR DESCRIPTION
Wraps long lines in HTML editor. Fixes https://github.com/mdn/interactive-examples/issues/699