### PR TITLE
Remove hard-coded 'height'

### DIFF
--- a/live-examples/css-examples/backgrounds-and-borders/box-shadow.css
+++ b/live-examples/css-examples/backgrounds-and-borders/box-shadow.css
@@ -4,6 +4,5 @@
     padding: 0;
     border: 2px solid #333;
     width: 80%;
-    height: 100px;
     text-align: center;
 }


### PR DESCRIPTION
Hard-coded 'height' is bad web design because they cause bugs like these:
https://bugzilla.mozilla.org/show_bug.cgi?id=1453903