### PR TITLE
fix: issue #774, escape < in page titles

### DIFF
--- a/CONTRIBUTING-HTML.md
+++ b/CONTRIBUTING-HTML.md
@@ -10,23 +10,24 @@ The right-hand side contains the rendered HTML, styled according to any CSS that
 
 To write an interactive HTML example, you need to write the HTML and, if you need it, the CSS. You then need to update some metadata to tell the site builder about the new example.
 
-In this section we'll walk through creating an example for the  [`<td>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td) element.
+In this section we'll walk through creating an example for the [`<td>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td) element.
 
 ## Example structure
 
 HTML examples are all stored under "live-examples/html-examples". Under there, they are grouped into directories according the the categorization in the [HTML elements reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element):
 
-* main-root
-* document-metadata
-* sectioning-root
-* content-sectioning
-* text-content
-* ...and so on
+*   main-root
+*   document-metadata
+*   sectioning-root
+*   content-sectioning
+*   text-content
+*   ...and so on
 
 Each of these directories contains:
-* a file called "meta.json", which is a kind of manifest for all the examples in that directory.
-* an HTML file for each example, whose name is the name of the element, for example "td.html"
-* a directory called "css" that contains CSS files for each example,  whose name is the name of the element, for example "td.css".
+
+*   a file called "meta.json", which is a kind of manifest for all the examples in that directory.
+*   an HTML file for each example, whose name is the name of the element, for example "td.html"
+*   a directory called "css" that contains CSS files for each example, whose name is the name of the element, for example "td.css".
 
 ## Writing the example
 
@@ -46,10 +47,11 @@ touch td.html
 In this file we'll add the HTML fragment that will be displayed in the HTML editor. The fragment will need to include all the extra HTML needed to render the example, and should use good practices as far as possible. For example, in this case we'll include a complete `<table>` element.
 
 Some general guidelines for writing a good example:
-* Try to make the example engaging, good-looking, and interesting (the example presented here doesn't really manage this. The [datalist](https://developer.mozilla.org/en-US/docs/User:wbamberg/HTML_editor_user_test_pages/datalist) one is prettier).
-* Try to show some important attributes
-* Try to keep the HTML fragment to under 20 lines. If you have to go over, that's fine, but *really* try to keep it under 30.
-* Try to keep HTML fragment line length to under 64 characters. If you have to go over, that's fine, but the line will probably then wrap for most screen widths (be aware that the example gets less width when embedded in an MDN page than it does standalone)
+
+*   Try to make the example engaging, good-looking, and interesting (the example presented here doesn't really manage this. The [datalist](https://developer.mozilla.org/en-US/docs/User:wbamberg/HTML_editor_user_test_pages/datalist) one is prettier).
+*   Try to show some important attributes
+*   Try to keep the HTML fragment to under 20 lines. If you have to go over, that's fine, but _really_ try to keep it under 30.
+*   Try to keep HTML fragment line length to under 64 characters. If you have to go over, that's fine, but the line will probably then wrap for most screen widths (be aware that the example gets less width when embedded in an MDN page than it does standalone)
 
 In general, keep in mind that (hopefully) a lot of people will use the example for a long time. It's worth spending a bit of time getting it the way you want.
 
@@ -121,7 +123,7 @@ It contains a JSON object whose most interesting property is an object called `p
             "exampleCode": "live-examples/html-examples/table-content/table.html",
             "cssExampleSrc": "live-examples/html-examples/table-content/css/table.css",
             "fileName": "table.html",
-            "title": "HTML Demo: &lt;table&gt;",
+            "title": "HTML Demo: <table>",
             "type": "tabbed"
         }
     }
@@ -136,17 +138,17 @@ Add a property under `pages` describing your example. The example for `<td>` cou
     "exampleCode": "live-examples/html-examples/table-content/td.html",
     "cssExampleSrc": "live-examples/html-examples/table-content/css/td.css",
     "fileName": "td.html",
-    "title": "HTML Demo: &lt;td&gt;",
+    "title": "HTML Demo: <td>",
     "type": "tabbed"
 }
 ```
 
-* `"baseTmpl"` describes the basic template to use. All HTML examples use the "tmpl/live-tabbed-tmpl.html" template, which gives you the tabbed interface. JS and CSS examples use different templates.
-* `"exampleCode"` is the path to the file containing the example HTML.
-* `"cssExampleSrc"` is the path to the file containing the CSS for the example.
-* `"fileName"` is the filename of the final (output) page that will contain this HTML example.
-* `"title"` is the title to show in the example. For HTML element examples it should be `"HTML Demo: <{name}>"` where `{name}` is the name of the element.
-* `"type"` describes the type of example to create. All HTML examples should put "tabbed" here.
+*   `"baseTmpl"` describes the basic template to use. All HTML examples use the "tmpl/live-tabbed-tmpl.html" template, which gives you the tabbed interface. JS and CSS examples use different templates.
+*   `"exampleCode"` is the path to the file containing the example HTML.
+*   `"cssExampleSrc"` is the path to the file containing the CSS for the example.
+*   `"fileName"` is the filename of the final (output) page that will contain this HTML example.
+*   `"title"` is the title to show in the example. For HTML element examples it should be `"HTML Demo: <{name}>"` where `{name}` is the name of the element.
+*   `"type"` describes the type of example to create. All HTML examples should put "tabbed" here.
 
 Note that entries in `pages` are in alphabetical order, please preserve that when adding your page.
 

--- a/lib/pageBuilderUtils.js
+++ b/lib/pageBuilderUtils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const processor = require('./processor');
+
 module.exports = {
     /**
      * Sets the `<title>` and `<h4>` main page title
@@ -14,7 +16,10 @@ module.exports = {
 
         // replace all instances of `%title` with the `currentPage.title`
         while ((resultsArray = regex.exec(tmpl)) !== null) {
-            tmpl = tmpl.replace(resultsArray[0].trim(), currentPage.title);
+            tmpl = tmpl.replace(
+                resultsArray[0].trim(),
+                processor.preprocessHTML(currentPage.title)
+            );
         }
         return tmpl;
     }

--- a/live-examples/html-examples/content-sectioning/meta.json
+++ b/live-examples/html-examples/content-sectioning/meta.json
@@ -2,26 +2,32 @@
     "pages": {
         "address": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
-            "exampleCode": "live-examples/html-examples/content-sectioning/address.html",
-            "cssExampleSrc": "live-examples/html-examples/content-sectioning/css/address.css",
+            "exampleCode":
+                "live-examples/html-examples/content-sectioning/address.html",
+            "cssExampleSrc":
+                "live-examples/html-examples/content-sectioning/css/address.css",
             "fileName": "address.html",
-            "title": "HTML Demo: &lt;address&gt;",
+            "title": "HTML Demo: <address>",
             "type": "tabbed"
         },
         "article": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
-            "exampleCode": "live-examples/html-examples/content-sectioning/article.html",
-            "cssExampleSrc": "live-examples/html-examples/content-sectioning/css/article.css",
+            "exampleCode":
+                "live-examples/html-examples/content-sectioning/article.html",
+            "cssExampleSrc":
+                "live-examples/html-examples/content-sectioning/css/article.css",
             "fileName": "article.html",
-            "title": "HTML Demo: &lt;article&gt;",
+            "title": "HTML Demo: <article>",
             "type": "tabbed"
         },
         "aside": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
-            "exampleCode": "live-examples/html-examples/content-sectioning/aside.html",
-            "cssExampleSrc": "live-examples/html-examples/content-sectioning/css/aside.css",
+            "exampleCode":
+                "live-examples/html-examples/content-sectioning/aside.html",
+            "cssExampleSrc":
+                "live-examples/html-examples/content-sectioning/css/aside.css",
             "fileName": "aside.html",
-            "title": "HTML Demo: &lt;aside&gt;",
+            "title": "HTML Demo: <aside>",
             "type": "tabbed"
         }
     }

--- a/live-examples/html-examples/forms/meta.json
+++ b/live-examples/html-examples/forms/meta.json
@@ -3,25 +3,28 @@
         "datalist": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode": "live-examples/html-examples/forms/datalist.html",
-            "cssExampleSrc": "live-examples/html-examples/forms/css/datalist.css",
+            "cssExampleSrc":
+                "live-examples/html-examples/forms/css/datalist.css",
             "fileName": "datalist.html",
-            "title": "HTML Demo: &lt;datalist&gt;",
+            "title": "HTML Demo: <datalist>",
             "type": "tabbed"
         },
         "fieldset": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode": "live-examples/html-examples/forms/fieldset.html",
-            "cssExampleSrc": "live-examples/html-examples/forms/css/fieldset.css",
+            "cssExampleSrc":
+                "live-examples/html-examples/forms/css/fieldset.css",
             "fileName": "fieldset.html",
-            "title": "HTML Demo: &lt;fieldset&gt;",
+            "title": "HTML Demo: <fieldset>",
             "type": "tabbed"
         },
         "optgroup": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode": "live-examples/html-examples/forms/optgroup.html",
-            "cssExampleSrc": "live-examples/html-examples/forms/css/optgroup.css",
+            "cssExampleSrc":
+                "live-examples/html-examples/forms/css/optgroup.css",
             "fileName": "optgroup.html",
-            "title": "HTML Demo: &lt;optgroup&gt;",
+            "title": "HTML Demo: <optgroup>",
             "type": "tabbed"
         },
         "select": {
@@ -29,7 +32,7 @@
             "exampleCode": "live-examples/html-examples/forms/select.html",
             "cssExampleSrc": "live-examples/html-examples/forms/css/select.css",
             "fileName": "select.html",
-            "title": "HTML Demo: &lt;select&gt;",
+            "title": "HTML Demo: <select>",
             "type": "tabbed"
         }
     }

--- a/live-examples/html-examples/image-and-multimedia/meta.json
+++ b/live-examples/html-examples/image-and-multimedia/meta.json
@@ -1,11 +1,13 @@
 {
-    "pages": {           
+    "pages": {
         "audio": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
-            "exampleCode": "live-examples/html-examples/image-and-multimedia/audio.html",
-            "cssExampleSrc": "live-examples/html-examples/image-and-multimedia/css/audio.css",
+            "exampleCode":
+                "live-examples/html-examples/image-and-multimedia/audio.html",
+            "cssExampleSrc":
+                "live-examples/html-examples/image-and-multimedia/css/audio.css",
             "fileName": "audio.html",
-            "title": "HTML Demo: &lt;audio&gt;",
+            "title": "HTML Demo: <audio>",
             "type": "tabbed"
         }
     }

--- a/live-examples/html-examples/inline-text-semantics/meta.json
+++ b/live-examples/html-examples/inline-text-semantics/meta.json
@@ -15,7 +15,7 @@
             "exampleCode": "live-examples/html-examples/inline-text-semantics/kbd.html",
             "cssExampleSrc": "live-examples/html-examples/inline-text-semantics/css/kbd.css",
             "fileName": "kbd.html",
-            "title": "HTML Demo: &lt;kbd&gt;",
+            "title": "HTML Demo: <kbd>",
             "type": "tabbed"
         },
         "strong": {

--- a/live-examples/html-examples/inline-text-semantics/meta.json
+++ b/live-examples/html-examples/inline-text-semantics/meta.json
@@ -2,18 +2,22 @@
     "pages": {
         "abbr": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
-            "exampleCode": "live-examples/html-examples/inline-text-semantics/abbr.html",
-            "cssExampleSrc": "live-examples/html-examples/inline-text-semantics/css/abbr.css",
+            "exampleCode":
+                "live-examples/html-examples/inline-text-semantics/abbr.html",
+            "cssExampleSrc":
+                "live-examples/html-examples/inline-text-semantics/css/abbr.css",
             "fileName": "abbr.html",
-            "title": "HTML Demo: &lt;abbr&gt;",
+            "title": "HTML Demo: <abbr>",
             "type": "tabbed"
         },
         "strong": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
-            "exampleCode": "live-examples/html-examples/inline-text-semantics/strong.html",
-            "cssExampleSrc": "live-examples/html-examples/inline-text-semantics/css/strong.css",
+            "exampleCode":
+                "live-examples/html-examples/inline-text-semantics/strong.html",
+            "cssExampleSrc":
+                "live-examples/html-examples/inline-text-semantics/css/strong.css",
             "fileName": "strong.html",
-            "title": "HTML Demo: &lt;strong&gt;",
+            "title": "HTML Demo: <strong>",
             "type": "tabbed"
         }
     }

--- a/live-examples/html-examples/table-content/meta.json
+++ b/live-examples/html-examples/table-content/meta.json
@@ -2,10 +2,12 @@
     "pages": {
         "table": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
-            "exampleCode": "live-examples/html-examples/table-content/table.html",
-            "cssExampleSrc": "live-examples/html-examples/table-content/css/table.css",
+            "exampleCode":
+                "live-examples/html-examples/table-content/table.html",
+            "cssExampleSrc":
+                "live-examples/html-examples/table-content/css/table.css",
             "fileName": "table.html",
-            "title": "HTML Demo: &lt;table&gt;",
+            "title": "HTML Demo: <table>",
             "type": "tabbed"
         }
     }

--- a/live-examples/html-examples/text-content/meta.json
+++ b/live-examples/html-examples/text-content/meta.json
@@ -2,25 +2,28 @@
     "pages": {
         "blockquote": {
             "baseTmpl": "tmpl/live-html-tmpl.html",
-            "exampleCode": "live-examples/html-examples/text-content/blockquote.html",
+            "exampleCode":
+                "live-examples/html-examples/text-content/blockquote.html",
             "fileName": "blockquote.html",
-            "title": "HTML Demo: &lt;blockquote&gt;",
+            "title": "HTML Demo: <blockquote>",
             "type": "html"
         },
         "ol": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode": "live-examples/html-examples/text-content/ol.html",
-            "cssExampleSrc": "live-examples/html-examples/text-content/css/ol.css",
+            "cssExampleSrc":
+                "live-examples/html-examples/text-content/css/ol.css",
             "fileName": "ol.html",
-            "title": "HTML Demo: &lt;ol&gt;",
+            "title": "HTML Demo: <ol>",
             "type": "tabbed"
         },
         "pre": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode": "live-examples/html-examples/text-content/pre.html",
-            "cssExampleSrc": "live-examples/html-examples/text-content/css/pre.css",
+            "cssExampleSrc":
+                "live-examples/html-examples/text-content/css/pre.css",
             "fileName": "pre.html",
-            "title": "HTML Demo: &lt;pre&gt;",
+            "title": "HTML Demo: <pre>",
             "type": "tabbed"
         }
     }


### PR DESCRIPTION
It is no longer necessary to manually escape the `<` inside title in `meta.json`. This is no automatically done as part of the build. I also updated all the existing meta.json files as well as the documentation. 