### PR TITLE
adding form element example

### DIFF
--- a/live-examples/html-examples/forms/css/form.css
+++ b/live-examples/html-examples/forms/css/form.css
@@ -1,0 +1,16 @@
+form.form-example {
+    display: table;
+}
+
+div.form-example {
+    display: table-row;
+}
+
+label, input {
+    display: table-cell;
+    margin-bottom: 10px;
+}
+
+label {
+    padding-right: 10px;
+}

--- a/live-examples/html-examples/forms/form.html
+++ b/live-examples/html-examples/forms/form.html
@@ -1,0 +1,13 @@
+<form action="" method="get" class="form-example">
+  <div class="form-example">
+    <label for="name">Enter your name: </label>
+    <input type="text" name="name" id="name" required>
+  </div>
+  <div class="form-example">
+    <label for="email">Enter your email: </label>
+    <input type="email" name="email" id="email" required>
+  </div>
+  <div class="form-example">
+    <input type="submit" value="Subscribe!">
+  </div>
+</form>

--- a/live-examples/html-examples/forms/meta.json
+++ b/live-examples/html-examples/forms/meta.json
@@ -21,7 +21,7 @@
             "exampleCode": "live-examples/html-examples/forms/form.html",
             "cssExampleSrc": "live-examples/html-examples/forms/css/form.css",
             "fileName": "form.html",
-            "title": "HTML Demo: <form>",
+            "title": "HTML Demo: &lt;form&gt;",
             "type": "tabbed"
         },
         "optgroup": {

--- a/live-examples/html-examples/forms/meta.json
+++ b/live-examples/html-examples/forms/meta.json
@@ -16,6 +16,14 @@
             "title": "HTML Demo: &lt;fieldset&gt;",
             "type": "tabbed"
         },
+        "form": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode": "live-examples/html-examples/forms/form.html",
+            "cssExampleSrc": "live-examples/html-examples/forms/css/form.css",
+            "fileName": "form.html",
+            "title": "HTML Demo: <form>",
+            "type": "tabbed"
+        },
         "optgroup": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode": "live-examples/html-examples/forms/optgroup.html",


### PR DESCRIPTION
as per https://github.com/mdn/interactive-examples/issues/746.

However, there are two problems with this example, one minor and one major:

* Minor: I had to add some extraneous classes to namespace the block elements in my example, otherwise my CSS was clashing with the styling of the editor UI, and messing things up. How I've got it now is not ideal, but it's working.
* Major: I think it must be because there's a form in the example, but whenever I click on the CSS, it seems to submit the form and therefore refresh the page, meaning you can't see or edit the CSS. I tried adding some preventDefault() code inline on the form element, but this didn't seem to work either. It makes me think that this is probably going to be a problem with any example that features a form element. Could you add a function of some kind that preventDefault()s all forms included in examples? 