### PR TITLE
Add <data> example

### DIFF
--- a/live-examples/html-examples/inline-text-semantics/css/data.css
+++ b/live-examples/html-examples/inline-text-semantics/css/data.css
@@ -1,0 +1,4 @@
+data:hover::after {
+    content: ' (ID ' attr(value) ')';
+    font-size: .7em;
+}

--- a/live-examples/html-examples/inline-text-semantics/data.html
+++ b/live-examples/html-examples/inline-text-semantics/data.html
@@ -1,0 +1,6 @@
+<p>New Products:</p>
+<ul>
+    <li><data value="398">Mini Ketchup</data></li>
+    <li><data value="399">Jumbo Ketchup</data></li>
+    <li><data value="400">Mega Jumbo Ketchup</data></li>
+</ul>

--- a/live-examples/html-examples/inline-text-semantics/meta.json
+++ b/live-examples/html-examples/inline-text-semantics/meta.json
@@ -10,6 +10,14 @@
             "title": "HTML Demo: <abbr>",
             "type": "tabbed"
         },
+        "data": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode": "live-examples/html-examples/inline-text-semantics/data.html",
+            "cssExampleSrc": "live-examples/html-examples/inline-text-semantics/css/data.css",
+            "fileName": "data.html",
+            "title": "HTML Demo: <data>",
+            "type": "tabbed"
+        },
         "dfn": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode": "live-examples/html-examples/inline-text-semantics/dfn.html",


### PR DESCRIPTION
Example for https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data

This demo would work better with some JavaScript interaction (I think) as that seems to be the main use case for the `<data>` element. I did some CSS voodoo instead, let me know if that isn't suitable here.

Fixes #770