### PR TITLE
Add interactive example for dl element

### DIFF
--- a/live-examples/html-examples/text-content/css/dl.css
+++ b/live-examples/html-examples/text-content/css/dl.css
@@ -1,0 +1,14 @@
+@font-face {
+    font-family: "Fira Sans";
+    src: local("FiraSans-Regular"),
+    url("/media/fonts/FiraSans-Regular.woff2") format("woff2");
+}
+
+p, dl {
+    font: 1rem "Fira Sans", sans-serif;
+}
+
+dl > dt {
+    font-weight: bold;
+    text-decoration: underline;
+}

--- a/live-examples/html-examples/text-content/css/dl.css
+++ b/live-examples/html-examples/text-content/css/dl.css
@@ -1,11 +1,12 @@
 @font-face {
-    font-family: "Fira Sans";
-    src: local("FiraSans-Regular"),
-    url("/media/fonts/FiraSans-Regular.woff2") format("woff2");
+    font-family: 'Fira Sans';
+    src: local('FiraSans-Regular'),
+    url('/media/fonts/FiraSans-Regular.woff2')
+    /* format("woff2"); */
 }
 
 p, dl {
-    font: 1rem "Fira Sans", sans-serif;
+    font: 1rem 'Fira Sans', sans-serif;
 }
 
 dl > dt {

--- a/live-examples/html-examples/text-content/css/dl.css
+++ b/live-examples/html-examples/text-content/css/dl.css
@@ -2,7 +2,6 @@
     font-family: 'Fira Sans';
     src: local('FiraSans-Regular'),
     url('/media/fonts/FiraSans-Regular.woff2')
-    /* format("woff2"); */
 }
 
 p, dl {

--- a/live-examples/html-examples/text-content/dl.html
+++ b/live-examples/html-examples/text-content/dl.html
@@ -1,0 +1,10 @@
+<p>Web developers use these languages when they create a site:</p>
+
+<dl>
+    <dt>HTML</dt>
+    <dd><em>HyperText Markup Language</em> describes the structure of the page and its contents.</dd>
+    <dt>CSS</dt>
+    <dd><em>Cascading Style Sheets</em> describes how a site looks and even to some extent how it responds to certain events.</dd>
+    <dt>JavaScript</dt>
+    <dd>JavaScript is the programming language used to define the logic and function of a site beyond simple look and feel. Any computation or "thinking" is done using JavaScript.</dd>
+</dl>

--- a/live-examples/html-examples/text-content/meta.json
+++ b/live-examples/html-examples/text-content/meta.json
@@ -8,6 +8,16 @@
             "title": "HTML Demo: <blockquote>",
             "type": "html"
         },
+        "dl": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode":
+                "live-examples/html-examples/text-content/dl.html",
+            "cssExampleSrc":
+                "live-examples/html-examples/text-content/css/dl.css",
+            "fileName": "dl.html",
+            "title": "HTML Demo: <dl>",
+            "type": "tabbed"
+        },
         "ol": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode": "live-examples/html-examples/text-content/ol.html",


### PR DESCRIPTION
Simple interactive example for `<dl>`.  Probably will use modifications of this same code for `<dt>` and `<dd>` -- but not the exact same example, because that can mess up SEO.