### PR TITLE
Add <input type="checkbox"> example

### DIFF
--- a/live-examples/html-examples/input/checkbox.html
+++ b/live-examples/html-examples/input/checkbox.html
@@ -1,0 +1,15 @@
+<fieldset>
+    <legend>Choose some monster features</legend>
+
+    <input type="checkbox"
+           id="scales" name="feature" value="scales" checked>
+    <label for="scales">Scales</label><br/>
+
+    <input type="checkbox"
+           id="horns" name="feature" value="horns">
+    <label for="horns">Horns</label><br/>
+
+    <input type="checkbox"
+           id="claws"  name="feature" value="claws">
+    <label for="claws">Claws</label><br/>
+</fieldset>

--- a/live-examples/html-examples/input/css/checkbox.css
+++ b/live-examples/html-examples/input/css/checkbox.css
@@ -1,0 +1,19 @@
+legend {
+  background-color: #000;
+  color: #fff;
+  padding: 3px 6px;
+}
+
+.output {
+    font: 1rem 'Fira Sans', sans-serif;
+}
+
+@font-face {
+    font-family: 'Fira Sans';
+    src: local('FiraSans-Regular'),
+    url('/media/fonts/FiraSans-Regular.woff2') format('woff2');
+}
+
+input {
+    margin: .4rem;
+}

--- a/live-examples/html-examples/input/meta.json
+++ b/live-examples/html-examples/input/meta.json
@@ -1,0 +1,12 @@
+{
+    "pages": {
+        "checkbox": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode": "live-examples/html-examples/input/checkbox.html",
+            "cssExampleSrc": "live-examples/html-examples/input/css/checkbox.css",
+            "fileName": "input-checkbox.html",
+            "title": "HTML Demo: <input type=\"checkbox\">",
+            "type": "tabbed"
+        }
+    }
+}


### PR DESCRIPTION
This is pretty much modeled on the existing [`<legend>`](https://interactive-examples.mdn.mozilla.net/pages/tabbed/legend.html) example.

I've tried to arrange line breaks in the source so it stays readable at reasonable window widths.

The input examples are a bit different from the others because they're not of course separate elements. So I'm proposing we give them titles like `<input type="checkbox">` (reflective of the page title) and a filename like "input-checkbox.html".

Thanks for your feedback!