### PR TITLE
Reinstate caption in meta.json

### DIFF
--- a/live-examples/html-examples/table-content/meta.json
+++ b/live-examples/html-examples/table-content/meta.json
@@ -1,5 +1,15 @@
 {
     "pages": {
+        "caption": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode":
+              "live-examples/html-examples/table-content/caption.html",
+            "cssExampleSrc":
+                "live-examples/html-examples/table-content/css/caption.css",
+            "fileName": "caption.html",
+            "title": "HTML Demo: <caption>",
+            "type": "tabbed"
+        },
         "col": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode":


### PR DESCRIPTION
https://github.com/mdn/interactive-examples/pull/821 unintentionally removed the meta.json entry for `<caption>`. This PR puts it back.