### PR TITLE
Update <footer> example CSS

### DIFF
--- a/live-examples/html-examples/content-sectioning/css/footer.css
+++ b/live-examples/html-examples/content-sectioning/css/footer.css
@@ -19,5 +19,6 @@ footer ul {
     display: flex;
     justify-content: space-around;
     margin: 0;
+    padding-left: 0;
     list-style: none;
 }


### PR DESCRIPTION
Forgot to remove the left padding of the `ul` element in the footer, which now will allow (by 40px) a narrower output window before breaking it into a new line. 

Fixes #728, improves #804.