### PR TITLE
Add <ins> example

### DIFF
--- a/live-examples/html-examples/demarcating-edits/css/ins.css
+++ b/live-examples/html-examples/demarcating-edits/css/ins.css
@@ -1,0 +1,35 @@
+del,
+ins {
+    display: block;
+    text-decoration: none;
+    position: relative;
+}
+
+del {
+    background-color: #fbb;
+}
+
+ins {
+    background-color: #d4fcbc;
+}
+
+del::before,
+ins::before {
+    position: absolute;
+    left: .5rem;
+    font-family: monospace;
+}
+
+del::before {
+    content: '−';
+}
+
+ins::before {
+    content: '+';
+}
+
+p {
+    margin: 0 1.8rem 0;
+    font-family: Georgia, serif;
+    font-size: 1rem;
+}

--- a/live-examples/html-examples/demarcating-edits/ins.html
+++ b/live-examples/html-examples/demarcating-edits/ins.html
@@ -2,6 +2,6 @@
 <del>
     <p>&ldquo;I apologize for the delay.&rdquo;</p>
 </del>
-<ins>
+<ins cite="../howtobeawizard.html" datetime="TA-3001">
     <p>&ldquo;A wizard is never late &hellip;&rdquo;</p>
 </ins>

--- a/live-examples/html-examples/demarcating-edits/ins.html
+++ b/live-examples/html-examples/demarcating-edits/ins.html
@@ -1,0 +1,7 @@
+<p>&ldquo;You're late!&rdquo;</p>
+<del>
+    <p>&ldquo;I apologize for the delay.&rdquo;</p>
+</del>
+<ins>
+    <p>&ldquo;A wizard is never late &hellip;&rdquo;</p>
+</ins>

--- a/live-examples/html-examples/demarcating-edits/ins.html
+++ b/live-examples/html-examples/demarcating-edits/ins.html
@@ -2,6 +2,6 @@
 <del>
     <p>&ldquo;I apologize for the delay.&rdquo;</p>
 </del>
-<ins cite="../howtobeawizard.html" datetime="TA-3001">
+<ins cite="../howtobeawizard.html" datetime="2018-05">
     <p>&ldquo;A wizard is never late &hellip;&rdquo;</p>
 </ins>

--- a/live-examples/html-examples/demarcating-edits/meta.json
+++ b/live-examples/html-examples/demarcating-edits/meta.json
@@ -9,6 +9,16 @@
             "fileName": "del.html",
             "title": "HTML Demo: <del>",
             "type": "tabbed"
+        },
+        "ins": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode":
+                "live-examples/html-examples/demarcating-edits/ins.html",
+            "cssExampleSrc":
+                "live-examples/html-examples/demarcating-edits/css/ins.css",
+            "fileName": "ins.html",
+            "title": "HTML Demo: <ins>",
+            "type": "tabbed"
         }
     }
 }


### PR DESCRIPTION
Fixes #736.
CSS got a little longer (35 lines) mainly because of the `+/-` decoration. Previously, in the `<del>` example, I used them as inline level and here I want them to use as block level.
I could remove the  `+/-` prefixes (which uses 15 lines of css), but it won't look as nice as it is now. Let me know what do you think.