### PR TITLE
Add <var> example

### DIFF
--- a/live-examples/html-examples/inline-text-semantics/css/var.css
+++ b/live-examples/html-examples/inline-text-semantics/css/var.css
@@ -1,0 +1,3 @@
+var {
+    font-weight: bold;
+}

--- a/live-examples/html-examples/inline-text-semantics/meta.json
+++ b/live-examples/html-examples/inline-text-semantics/meta.json
@@ -175,6 +175,14 @@
             "fileName": "q.html",
             "title": "HTML Demo: <q>",
             "type": "tabbed"
+        },
+        "var": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode": "live-examples/html-examples/inline-text-semantics/var.html",
+            "cssExampleSrc": "live-examples/html-examples/inline-text-semantics/css/var.css",
+            "fileName": "var.html",
+            "title": "HTML Demo: <var>",
+            "type": "tabbed"
         }
     }
 }

--- a/live-examples/html-examples/inline-text-semantics/var.html
+++ b/live-examples/html-examples/inline-text-semantics/var.html
@@ -1,0 +1,1 @@
+<p>The volume of a box is <var>l</var> × <var>w</var> × <var>h</var>, where <var>l</var> represents the length, <var>w</var> the width and <var>h</var> the height of the box.</p>


### PR DESCRIPTION
Example for https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var

Fixes #815 