### PR TITLE
Add <wbr> example

### DIFF
--- a/live-examples/html-examples/inline-text-semantics/css/wbr.css
+++ b/live-examples/html-examples/inline-text-semantics/css/wbr.css
@@ -1,0 +1,10 @@
+.output {
+    background-color: gray;
+}
+
+#example-paragraphs {
+    background-color: white;
+    overflow: hidden;
+    resize: horizontal;
+    width: 7rem;
+}

--- a/live-examples/html-examples/inline-text-semantics/meta.json
+++ b/live-examples/html-examples/inline-text-semantics/meta.json
@@ -183,6 +183,14 @@
             "fileName": "var.html",
             "title": "HTML Demo: <var>",
             "type": "tabbed"
+        },
+        "wbr": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode": "live-examples/html-examples/inline-text-semantics/wbr.html",
+            "cssExampleSrc": "live-examples/html-examples/inline-text-semantics/css/wbr.css",
+            "fileName": "wbr.html",
+            "title": "HTML Demo: <wbr>",
+            "type": "tabbed"
         }
     }
 }

--- a/live-examples/html-examples/inline-text-semantics/wbr.html
+++ b/live-examples/html-examples/inline-text-semantics/wbr.html
@@ -1,0 +1,5 @@
+<div id="example-paragraphs">
+    <p>Fernstraßenbauprivatfinanzierungsgesetz</p>
+    <p>Fernstraßen<wbr>bau<wbr>privat<wbr>finanzierungs<wbr>gesetz</p>
+    <p>Fernstraßen&shy;bau&shy;privat&shy;finanzierungs&shy;gesetz</p>
+</div>


### PR DESCRIPTION
Example for https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr

`&shy;` isn't shown in the source view as is, but displayed as a red dot for me. I thought it would be nice to compare it, though. Another idea was to compare to `<br>` but I thought that might be too obvious.

I believe a `wbr { }` CSS selector isn't needed here.

Fixes #816 