### PR TITLE
Add <span> example

### DIFF
--- a/live-examples/html-examples/inline-text-semantics/css/span.css
+++ b/live-examples/html-examples/inline-text-semantics/css/span.css
@@ -1,0 +1,3 @@
+span.ingredient {
+    color: red;
+}

--- a/live-examples/html-examples/inline-text-semantics/meta.json
+++ b/live-examples/html-examples/inline-text-semantics/meta.json
@@ -128,6 +128,16 @@
             "title": "HTML Demo: <small>",
             "type": "tabbed"
         },
+        "span": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode":
+                "live-examples/html-examples/inline-text-semantics/span.html",
+            "cssExampleSrc":
+                "live-examples/html-examples/inline-text-semantics/css/span.css",
+            "fileName": "span.html",
+            "title": "HTML Demo: <span>",
+            "type": "tabbed"
+        },
         "strong": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode":

--- a/live-examples/html-examples/inline-text-semantics/span.html
+++ b/live-examples/html-examples/inline-text-semantics/span.html
@@ -1,0 +1,5 @@
+<ol>
+    <li>Add the <span class="ingredient">basil</span>, <span class="ingredient">pine nuts</span> and <span class="ingredient">garlic</span> to a blender and blend into a paste.</li>
+    <li>Gradually add the <span class="ingredient">olive oil</span> while running the blender slowly.</li>
+    <li>Mix in the <span class="ingredient">Parmesan</span>. Add <span class="ingredient">salt</span> to taste and plenty of <span class="ingredient">black pepper</span>.</li>
+ </ol>


### PR DESCRIPTION
Example for https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span

Not sure if this is a nice example, but the idea is that I want to show `<span>` as a re-usable, inline, styled element in text content. In this case it is something like a banner.

Fixes #788 