### PR TITLE
Add <li> example

### DIFF
--- a/live-examples/html-examples/text-content/css/li.css
+++ b/live-examples/html-examples/text-content/css/li.css
@@ -1,0 +1,7 @@
+ol li {
+    font-weight: bold;
+}
+
+ul li {
+    font-weight: normal;
+}

--- a/live-examples/html-examples/text-content/li.html
+++ b/live-examples/html-examples/text-content/li.html
@@ -1,0 +1,19 @@
+<ol>
+    <li>Apollo 11
+        <ul>
+            <li>Neil Armstrong</li>
+        </ul>
+    </li>
+    <li>Apollo 12
+        <ul>
+            <li>Alan Bean</li>
+            <li>Peter Conrad</li>
+        </ul>
+    </li>
+    <li>Apollo 14
+        <ul>
+            <li>Edgar Mitchell</li>
+            <li>Alan Shepard</li>
+        </ul>
+    </li>
+</ol>

--- a/live-examples/html-examples/text-content/meta.json
+++ b/live-examples/html-examples/text-content/meta.json
@@ -48,6 +48,16 @@
             "title": "HTML Demo: <hr>",
             "type": "tabbed"
         },
+        "li": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode":
+                "live-examples/html-examples/text-content/li.html",
+            "cssExampleSrc":
+                "live-examples/html-examples/text-content/css/li.css",
+            "fileName": "li.html",
+            "title": "HTML Demo: <li>",
+            "type": "tabbed"
+        },
         "ol": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode": "live-examples/html-examples/text-content/ol.html",


### PR DESCRIPTION
Example for https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li

I thought it would be nice to show `<li>` with both `<ol>` and `<ul>`. So this is nested again. It's a little uncreative when comes to the CSS, let me know if I should try harder to make it more fancy. 