### PR TITLE
Add <style> example

### DIFF
--- a/live-examples/html-examples/document-metadata/css/style.css
+++ b/live-examples/html-examples/document-metadata/css/style.css
@@ -1,0 +1,3 @@
+p {
+    color: red;
+}

--- a/live-examples/html-examples/document-metadata/meta.json
+++ b/live-examples/html-examples/document-metadata/meta.json
@@ -1,0 +1,14 @@
+{
+    "pages": {
+        "style": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode":
+                "live-examples/html-examples/document-metadata/style.html",
+            "cssExampleSrc":
+                "live-examples/html-examples/document-metadata/css/style.css",
+            "fileName": "style.html",
+            "title": "HTML Demo: <style>",
+            "type": "tabbed"
+        }
+    }
+}

--- a/live-examples/html-examples/document-metadata/style.html
+++ b/live-examples/html-examples/document-metadata/style.html
@@ -1,0 +1,7 @@
+<style type="text/css">
+p {
+  color: green;
+}
+</style>
+<p>This text will be green. Inline styles take precedence over CSS included externally.</p>
+<p style="color: blue">The <code>style</code> attribute can override it, though.</p>


### PR DESCRIPTION
Example for https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style

The idea here is to show the order of precedence. (which I would have expected to be documented on that page btw).

Fixes #738