### PR TITLE
Add <nav> example

### DIFF
--- a/live-examples/html-examples/content-sectioning/css/nav.css
+++ b/live-examples/html-examples/content-sectioning/css/nav.css
@@ -1,0 +1,11 @@
+.crumbs ol {
+    list-style-type: none;
+}
+.crumb a::after {
+    display: inline-block;
+    color: #000;
+    content: '>';
+    font-size: 80%;
+    font-weight: bold;
+    padding: 0 3px;
+}

--- a/live-examples/html-examples/content-sectioning/css/nav.css
+++ b/live-examples/html-examples/content-sectioning/css/nav.css
@@ -1,6 +1,12 @@
 .crumbs ol {
     list-style-type: none;
+    padding-left: 0;
 }
+
+.crumb {
+    display: inline-block;
+}
+
 .crumb a::after {
     display: inline-block;
     color: #000;

--- a/live-examples/html-examples/content-sectioning/meta.json
+++ b/live-examples/html-examples/content-sectioning/meta.json
@@ -56,6 +56,14 @@
             "title": "HTML Demo: <hgroup>",
             "type": "tabbed"
         },
+        "nav": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode": "live-examples/html-examples/content-sectioning/nav.html",
+            "cssExampleSrc": "live-examples/html-examples/content-sectioning/css/nav.css",
+            "fileName": "nav.html",
+            "title": "HTML Demo: <nav>",
+            "type": "tabbed"
+        },
         "section": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode": "live-examples/html-examples/content-sectioning/section.html",

--- a/live-examples/html-examples/content-sectioning/nav.html
+++ b/live-examples/html-examples/content-sectioning/nav.html
@@ -1,0 +1,9 @@
+<nav class="crumbs">
+    <ol>
+        <li class="crumb"><a href="https://example.org/bikes">Bikes</a></li>
+        <li class="crumb"><a href="https://example.org/bikes/bmx">BMX</a></li>
+        <li class="crumb">Jump Bike 3000</li>
+    </ol>
+</nav>
+<h1>Jump Bike 3000</h1>
+<p>This BMX bike is a sold step into the pro world. It looks as legit as it rides and is built to polish your skills.</p>

--- a/live-examples/html-examples/content-sectioning/nav.html
+++ b/live-examples/html-examples/content-sectioning/nav.html
@@ -6,4 +6,4 @@
     </ol>
 </nav>
 <h1>Jump Bike 3000</h1>
-<p>This BMX bike is a sold step into the pro world. It looks as legit as it rides and is built to polish your skills.</p>
+<p>This BMX bike is a solid step into the pro world. It looks as legit as it rides and is built to polish your skills.</p>


### PR DESCRIPTION
Example for https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav

Just a classic breadcrumb navigation inspired by MDN itself.

Fixes https://github.com/mdn/interactive-examples/issues/733