### PR TITLE
Fix typo n Date.valueOf example (bug 1459457)

### DIFF
--- a/live-examples/js-examples/date/date-valueof.html
+++ b/live-examples/js-examples/date/date-valueof.html
@@ -6,7 +6,7 @@ console.log(date1.valueOf());
 
 var date2 = new Date('02 Feb 1996 03:04:05 GMT');
 
-console.log(date1.valueOf());
+console.log(date2.valueOf());
 // expected output: 823230245000
 </code>
 </pre>


### PR DESCRIPTION
Fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1459457