### PR TITLE
Add interactive example for <h1>-<h6>

### DIFF
--- a/live-examples/html-examples/content-sectioning/css/h1-h6.css
+++ b/live-examples/html-examples/content-sectioning/css/h1-h6.css
@@ -1,0 +1,20 @@
+@font-face {
+    font-family: 'Fira Sans';
+    src: local('FiraSans-Regular'),
+    url('/media/fonts/FiraSans-Regular.woff2') format('woff2');
+}
+
+h1 {
+    margin-top: 2px;
+    margin-bottom: 3px;
+    text-decoration: underline;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Fira Sans', 'Verdana', 'Arial', sans-serif;
+    margin-bottom: 1px;
+}
+
+h2 + p, h3 + p, h4 + p, h5 + p, h6 + p {
+    margin-top: 1px;
+}

--- a/live-examples/html-examples/content-sectioning/h1-h6.html
+++ b/live-examples/html-examples/content-sectioning/h1-h6.html
@@ -1,0 +1,12 @@
+<h1 id="title-heading">Page Title (Heading 1)</h1>
+<h2>Section Title (Heading 2)</h2>
+<p>Here's some text. It's very interesting text.</p>
+<h3>Subsection Title (Heading 3)</h3>
+<p>Here's text in a nested subsection.</p>
+<h4>Heading Level 4</h4>
+<p>And so on...</p>
+<h5>Heading Level 5</h5>
+<p>And so on...</p>
+<h6>Heading Level 6</h6>
+<p>And so on.</p>
+<p><a href="#title-heading">Return to top</a></p>

--- a/live-examples/html-examples/content-sectioning/meta.json
+++ b/live-examples/html-examples/content-sectioning/meta.json
@@ -40,6 +40,14 @@
             "title": "HTML Demo: <footer>",
             "type": "tabbed"
         },
+        "h1": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode": "live-examples/html-examples/content-sectioning/h1-h6.html",
+            "cssExampleSrc": "live-examples/html-examples/content-sectioning/css/h1-h6.css",
+            "fileName": "h1-h6.html",
+            "title": "HTML Demo: <h1> - <h6>",
+            "type": "tabbed"
+        },
         "header": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode": "live-examples/html-examples/content-sectioning/header.html",


### PR DESCRIPTION
A simple tabbed example for the section heading elements.
The example includes all six elements and a "return to top"
link to demonstrate linking to a heading given its ID.
Some styles are applied to the headings as well.