### PR TITLE
Added no-repeat property for background-origin example.

### DIFF
--- a/live-examples/css-examples/backgrounds-and-borders/background-clip.css
+++ b/live-examples/css-examples/backgrounds-and-borders/background-clip.css
@@ -5,4 +5,5 @@
     border: 10px dashed #333;
     font-size: 2em;
     font-weight: bold;
+    background-repeat: no-repeat;
 }

--- a/live-examples/css-examples/backgrounds-and-borders/background-clip.css
+++ b/live-examples/css-examples/backgrounds-and-borders/background-clip.css
@@ -5,5 +5,4 @@
     border: 10px dashed #333;
     font-size: 2em;
     font-weight: bold;
-    background-repeat: no-repeat;
 }

--- a/live-examples/css-examples/backgrounds-and-borders/background-origin.html
+++ b/live-examples/css-examples/backgrounds-and-borders/background-origin.html
@@ -1,20 +1,23 @@
 <section id="example-choice-list" class="example-choice-list" data-property="backgroundOrigin">
 <div class="example-choice">
-<pre><code class="language-css">background-origin: border-box;</code></pre>
+<pre><code class="language-css">background-origin: border-box;
+background-repeat: no-repeat;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code class="language-css">background-origin: padding-box;</code></pre>
+<pre><code class="language-css">background-origin: padding-box;
+background-repeat: no-repeat;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code class="language-css">background-origin: content-box;</code></pre>
+<pre><code class="language-css">background-origin: content-box;
+background-repeat: no-repeat;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>


### PR DESCRIPTION
Adding a no-repeat property makes the example clearer because it shows the effect of the background-origin property on the the extent of background image. Before and after images below:
<img width="311" alt="screen shot 2018-05-11 at 10 24 03 am" src="https://user-images.githubusercontent.com/650450/39937759-9933c772-5505-11e8-9f85-573ee28875b5.png">
<img width="412" alt="screen shot 2018-05-11 at 10 24 53 am" src="https://user-images.githubusercontent.com/650450/39937766-9d5ff4ba-5505-11e8-94f2-47d7da8548cd.png">

