### PR TITLE
Add String trim examples

### DIFF
--- a/live-examples/js-examples/string/meta.json
+++ b/live-examples/js-examples/string/meta.json
@@ -1,0 +1,25 @@
+{
+    "pages": {
+        "stringTrim": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/string/string-trim.html",
+            "fileName": "string-trim.html",
+            "title": "JavaScript Demo: String.trim()",
+            "type": "js"
+        },
+        "stringTrimEnd": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/string/string-trimend.html",
+            "fileName": "string-trimend.html",
+            "title": "JavaScript Demo: String.trimEnd()",
+            "type": "js"
+        },
+        "stringTrimStart": {
+            "baseTmpl": "tmpl/live-js-tmpl.html",
+            "exampleCode": "live-examples/js-examples/string/string-trimstart.html",
+            "fileName": "string-trimstart.html",
+            "title": "JavaScript Demo: String.trimStart()",
+            "type": "js"
+        }
+    }
+}

--- a/live-examples/js-examples/string/string-trim.html
+++ b/live-examples/js-examples/string/string-trim.html
@@ -1,0 +1,10 @@
+<pre>
+<code id="static-js">var greeting = "   Hello world!   ";
+
+console.log(greeting);
+// expected output: "   Hello world!   ";
+
+console.log(greeting.trim());
+// expected output: "Hello world!";
+</code>
+</pre>

--- a/live-examples/js-examples/string/string-trimend.html
+++ b/live-examples/js-examples/string/string-trimend.html
@@ -1,0 +1,10 @@
+<pre>
+<code id="static-js">var greeting = "   Hello world!   ";
+
+console.log(greeting);
+// expected output: "   Hello world!   ";
+
+console.log(greeting.trimEnd());
+// expected output: "   Hello world!";
+</code>
+</pre>

--- a/live-examples/js-examples/string/string-trimstart.html
+++ b/live-examples/js-examples/string/string-trimstart.html
@@ -1,0 +1,10 @@
+<pre>
+<code id="static-js">var greeting = "   Hello world!   ";
+
+console.log(greeting);
+// expected output: "   Hello world!   ";
+
+console.log(greeting.trimStart());
+// expected output: "Hello world!   ";
+</code>
+</pre>


### PR DESCRIPTION
I am a little puzzled why there are no String examples yet... Did we decide against doing live examples for String or is this an oversight? 

Anyway, here is my first JS examples PR that creates examples for:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd