### PR TITLE
Add HTML example for <details>

### DIFF
--- a/live-examples/html-examples/interactive-elements/css/details.css
+++ b/live-examples/html-examples/interactive-elements/css/details.css
@@ -1,24 +1,13 @@
 details {
-    border: 1px solid #aaaaaa;
+    border: 1px solid #aaa;
     border-radius: 4px;
     padding: .5em .5em 0;
 }
 
 summary {
     font-weight: bold;
-    margin-left: -.5em;
-    margin-right: -.5em;
-    margin-top: -.5em;
+    margin: -.5em -.5em 0;
     padding: .5em;
-}
-
-summary::-webkit-details-marker {
-    display: none;
-}
-
-summary::before {
-    content: '+';
-    margin-right: .25em;
 }
 
 details[open] {
@@ -27,15 +16,5 @@ details[open] {
 
 details[open] summary {
     border-bottom: 1px solid #aaa;
-    color: #aaa;
     margin-bottom: .5em;
-}
-
-details[open] summary::before {
-    content: '–';
-}
-
-code {
-    background-color: #fdf6e3;
-    color: #268bd2;
 }

--- a/live-examples/html-examples/interactive-elements/css/details.css
+++ b/live-examples/html-examples/interactive-elements/css/details.css
@@ -1,0 +1,41 @@
+details {
+    border: 1px solid #aaaaaa;
+    border-radius: 4px;
+    padding: .5em .5em 0;
+}
+
+summary {
+    font-weight: bold;
+    margin-left: -.5em;
+    margin-right: -.5em;
+    margin-top: -.5em;
+    padding: .5em;
+}
+
+summary::-webkit-details-marker {
+    display: none;
+}
+
+summary::before {
+    content: '+';
+    margin-right: .25em;
+}
+
+details[open] {
+    padding: .5em;
+}
+
+details[open] summary {
+    border-bottom: 1px solid #aaa;
+    color: #aaa;
+    margin-bottom: .5em;
+}
+
+details[open] summary::before {
+    content: '–';
+}
+
+code {
+    background-color: #fdf6e3;
+    color: #268bd2;
+}

--- a/live-examples/html-examples/interactive-elements/details.html
+++ b/live-examples/html-examples/interactive-elements/details.html
@@ -1,4 +1,4 @@
 <details>
     <summary>Details</summary>
-    The content of <code>details</code> is hidden until the <code>details</code> element receives the <code>open</code> attribute. You can refer to the <code>open</code> attribute in CSS to style the details component and the appearance of the <code>summary</code> element accordingly.
+    Something small enough to escape casual notice.
 </details>

--- a/live-examples/html-examples/interactive-elements/details.html
+++ b/live-examples/html-examples/interactive-elements/details.html
@@ -1,0 +1,4 @@
+<details>
+    <summary>Details</summary>
+    The content of <code>details</code> is hidden until the <code>details</code> element receives the <code>open</code> attribute. You can refer to the <code>open</code> attribute in CSS to style the details component and the appearance of the <code>summary</code> element accordingly.
+</details>

--- a/live-examples/html-examples/interactive-elements/meta.json
+++ b/live-examples/html-examples/interactive-elements/meta.json
@@ -1,0 +1,12 @@
+{
+    "pages": {
+        "details": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode": "live-examples/html-examples/interactive-elements/details.html",
+            "cssExampleSrc": "live-examples/html-examples/interactive-elements/css/details.css",
+            "fileName": "details.html",
+            "title": "HTML Demo: <details>",
+            "type": "tabbed"
+        }
+    }
+}


### PR DESCRIPTION
No github issue created so far.
I added some more styles to the element to make clear that it is a fully customizable element.