### PR TITLE
Add HTML example for <summary>

### DIFF
--- a/live-examples/html-examples/interactive-elements/css/summary.css
+++ b/live-examples/html-examples/interactive-elements/css/summary.css
@@ -1,4 +1,20 @@
-code {
-    background-color: #fdf6e3;
-    color: #268bd2;
+details {
+    border: 1px solid #aaa;
+    border-radius: 4px;
+    padding: .5em .5em 0;
+}
+
+summary {
+    font-weight: bold;
+    margin: -.5em -.5em 0;
+    padding: .5em;
+}
+
+details[open] {
+    padding: .5em;
+}
+
+details[open] summary {
+    border-bottom: 1px solid #aaa;
+    margin-bottom: .5em;
 }

--- a/live-examples/html-examples/interactive-elements/css/summary.css
+++ b/live-examples/html-examples/interactive-elements/css/summary.css
@@ -1,0 +1,4 @@
+code {
+    background-color: #fdf6e3;
+    color: #268bd2;
+}

--- a/live-examples/html-examples/interactive-elements/meta.json
+++ b/live-examples/html-examples/interactive-elements/meta.json
@@ -1,0 +1,12 @@
+{
+    "pages": {
+        "summary": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode": "live-examples/html-examples/interactive-elements/summary.html",
+            "cssExampleSrc": "live-examples/html-examples/interactive-elements/css/summary.css",
+            "fileName": "summary.html",
+            "title": "HTML Demo: <summary>",
+            "type": "tabbed"
+        }
+    }
+}

--- a/live-examples/html-examples/interactive-elements/summary.html
+++ b/live-examples/html-examples/interactive-elements/summary.html
@@ -1,0 +1,6 @@
+<details>
+    <summary>See more details about the summary element</summary>
+    The <code>summary</code> element teasers some information, that might be hidden initially with the <code>details</code> element.
+    The <code>summary</code> element itself acts as the toggle element for the details.
+    If you omit the summary tag, the browser will create a default one within the Shadow DOM.
+</details>

--- a/live-examples/html-examples/interactive-elements/summary.html
+++ b/live-examples/html-examples/interactive-elements/summary.html
@@ -1,6 +1,4 @@
 <details>
-    <summary>See more details about the summary element</summary>
-    The <code>summary</code> element teasers some information, that might be hidden initially with the <code>details</code> element.
-    The <code>summary</code> element itself acts as the toggle element for the details.
-    If you omit the summary tag, the browser will create a default one within the Shadow DOM.
+    <summary>I have keys but no locks. I have space but no room. You can enter but can't leave. What am I?</summary>
+    A keyboard.
 </details>


### PR DESCRIPTION
The merge will potentially fail, when #924 is merged before, because I created a new directory for the interactive elements.
I created a slightly simpler example compared to my `<details>` example.
I can surely do a rebase and fix the merge conflicts if #924 is merged before.