### PR TITLE
Fix example: issue #925, add (max-)width to container

### DIFF
--- a/live-examples/css-examples/basic-user-interface/text-overflow.css
+++ b/live-examples/css-examples/basic-user-interface/text-overflow.css
@@ -1,5 +1,6 @@
 #example-element-container {
-    width: 70%;
+    width: 100%;
+    max-width: 18em;
 }
 
 #example-element {
@@ -9,4 +10,5 @@
     white-space: nowrap;
     font-family: sans-serif;
     padding: 0 0.5em;
+    text-align: left;
 }


### PR DESCRIPTION
I used the `max-width`/`width` combination to make that example also work on narrow screens. Left-aligning the paragraph also keeps the text from slightly "jumping" between `clip` and `ellipsis` and is hopefully less distracting from the intended effect.