### PR TITLE
added fantasy font-family for font-family example

### DIFF
--- a/live-examples/css-examples/fonts/font-family.html
+++ b/live-examples/css-examples/fonts/font-family.html
@@ -42,6 +42,14 @@
 </div>
 </section>
 
+<div class="example-choice">
+<pre><code class="language-css">font-family: fantasy;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+</section>
+
 <div id="output" class="output hidden">
     <section id="default-example">
         <p id="example-element">London. Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather. As much mud in the streets as if the waters had but newly retired from the face of the earth, and it would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine lizard up Holborn Hill.</p>


### PR DESCRIPTION
Improved existing example - `font-family.html` which relates to [font-family article on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family).

- Added `font-family: fantasy;` option.