### PR TITLE
Bug 1462897 - Directly use Math.round in the demo code.

### DIFF
--- a/live-examples/js-examples/math/math-round.html
+++ b/live-examples/js-examples/math/math-round.html
@@ -1,13 +1,8 @@
 <pre>
-<code id="static-js">function precisionRound(number, precision) {
-  var factor = Math.pow(10, precision);
-  return Math.round(number * factor) / factor;
-}
+<code id="static-js">console.log(Math.round(5.95), Math.round(5.5), Math.round(5.05));
+// expected output: 6 6 5
 
-console.log(precisionRound(1234.5678, 1));
-// expected output: 1234.6
-
-console.log(precisionRound(1234.5678, -1));
-// expected output: 1230
+console.log(Math.round(-5.05), Math.round(-5.5), Math.round(-5.95));
+// expected output: -5 -5 -6
 </code>
 </pre>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1462897

The demo for Math.round currently implements custom function which performs round in the specified precision, but it's not good function.

Then, the MDN page [1] was describing the issue of the demo, and solution for the function in the demo, instead of the Math.round function itself.
it was completely unrelated to the API and IMO those things shouldn't be on the document,
but the document should describe the API itself.

Changed the demo to directly use the Math.round.
also I've removed the unrelated sections from the MDN [2].

[1] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
[2] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round$compare?locale=en-US&to=1385078&from=1383484