### PR TITLE
Fix console util to support negative zero

### DIFF
--- a/__tests__/console-utils.test.js
+++ b/__tests__/console-utils.test.js
@@ -2,6 +2,50 @@ const consoleUtils = require('../js/editor-libs/console-utils');
 
 describe('console utils', () => {
     describe('formatOutput', () => {
+        test('String', function() {
+            expect(consoleUtils.formatOutput('lorem ipsum')).toBe(
+                '"lorem ipsum"'
+            );
+        });
+        test('undefined', function() {
+            expect(consoleUtils.formatOutput(undefined)).toBe('undefined');
+        });
+        test('null', function() {
+            expect(consoleUtils.formatOutput(null)).toBe('null');
+        });
+        test('NaN', function() {
+            expect(consoleUtils.formatOutput(NaN)).toBe('NaN');
+        });
+        test('Boolean: true', function() {
+            expect(consoleUtils.formatOutput(true)).toBe('true');
+        });
+        test('Boolean: false', function() {
+            expect(consoleUtils.formatOutput(false)).toBe('false');
+        });
+        test('Positive integer', function() {
+            expect(consoleUtils.formatOutput(42)).toBe('42');
+        });
+        test('Positive floating point', function() {
+            expect(consoleUtils.formatOutput(4.2)).toBe('4.2');
+        });
+        test('Negative integer', function() {
+            expect(consoleUtils.formatOutput(-42)).toBe('-42');
+        });
+        test('Negative floating point', function() {
+            expect(consoleUtils.formatOutput(-4.2)).toBe('-4.2');
+        });
+        test('Infinity', function() {
+            expect(consoleUtils.formatOutput(Infinity)).toBe('Infinity');
+        });
+        test('Negative Infinity', function() {
+            expect(consoleUtils.formatOutput(-Infinity)).toBe('-Infinity');
+        });
+        test('Positive zero', function() {
+            expect(consoleUtils.formatOutput(0)).toBe('0');
+        });
+        test('Negative zero', function() {
+            expect(consoleUtils.formatOutput(-0)).toBe('-0');
+        });
         test('String object', function() {
             expect(consoleUtils.formatOutput(new String('foo'))).toBe(
                 'String { "foo" }'

--- a/js/editor-libs/console-utils.js
+++ b/js/editor-libs/console-utils.js
@@ -103,9 +103,14 @@ module.exports = {
         if (
             input === undefined ||
             input === null ||
-            typeof input === 'number' ||
             typeof input === 'boolean'
         ) {
+            return String(input);
+        } else if (typeof input === 'number') {
+            // Negative zero
+            if (Object.is(input, -0)) {
+                return '-0';
+            }
             return String(input);
         } else if (typeof input === 'string') {
             // string literal


### PR DESCRIPTION
Fixes #952 

The bug is caused by using [`String(value)` function](https://www.ecma-international.org/ecma-262/6.0/#sec-string-constructor-string-value), which per the spec calls [`ToString(value)`](https://www.ecma-international.org/ecma-262/6.0/#sec-tostring). _ToString(value)_ for number as per defined [at the spec](https://www.ecma-international.org/ecma-262/6.0/#sec-tostring-applied-to-the-number-type) states that

> Number m to String format as follows:
> 2.  If m is +0 or −0, return the String "0".

So, this PR adds the case where if we meet negative zero at `formatOutput`, then return `-0`, else call `String(input)`. Also, more tests are added.