### PR TITLE
adding oblique plus angle option to font-style example

### DIFF
--- a/live-examples/css-examples/fonts/font-style.css
+++ b/live-examples/css-examples/fonts/font-style.css
@@ -1,4 +1,10 @@
+@font-face {
+	  src: url('/media/fonts/AmstelvarAlpha-VF.ttf');
+	  font-family:'Amstelvar';
+	  font-style: normal;
+}
+
 #output section {
     font-size: 1.2em;
-    font-family: Georgia, serif;
+    font-family: Amstelvar;
 }

--- a/live-examples/css-examples/fonts/font-style.html
+++ b/live-examples/css-examples/fonts/font-style.html
@@ -19,6 +19,13 @@
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
+
+<div class="example-choice">
+<pre><code class="language-css">font-style: oblique 40deg;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
 </section>
 
 <div id="output" class="output hidden">


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1436048

The example also now uses an open type font. I added this because the oblique angle values don't seem to work with normal fonts.