### PR TITLE
Add one-value example for place-content

### DIFF
--- a/live-examples/css-examples/box-alignment/place-content.html
+++ b/live-examples/css-examples/box-alignment/place-content.html
@@ -18,14 +18,21 @@
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
-    </div> 
+    </div>
 
     <div class="example-choice">
         <pre><code class="language-css">place-content: end center;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
-    </div>  
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">place-content: end;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
 </section>
 
 <div id="output" class="output large hidden">


### PR DESCRIPTION
The one-value syntax works in most browsers (I verified in Firefox/Chrome/Safari), so we should include a demo of it.