### PR TITLE
fix(performance): send post to kuma for custom ie-load-event-end metric

### DIFF
--- a/js/editable-css.js
+++ b/js/editable-css.js
@@ -103,6 +103,8 @@
                         'CSS editor load time',
                         performance.timing.loadEventEnd
                     );
+                    // Posts mark to set on the Kuma side and used in measure
+                    mceUtils.postToKuma({ markName: 'css-ie-load-event-end' });
                 }, 100);
             }
         });

--- a/js/editable-js.js
+++ b/js/editable-js.js
@@ -4,6 +4,7 @@
     var featureDetector = require('./editor-libs/feature-detector.js');
     var mceConsole = require('./editor-libs/console');
     var mceEvents = require('./editor-libs/events.js');
+    var mceUtils = require('./editor-libs/mce-utils');
 
     var codeBlock = document.getElementById('static-js');
     var exampleFeature = codeBlock.dataset['feature'];
@@ -116,6 +117,8 @@
                         'JS editor load time',
                         performance.timing.loadEventEnd
                     );
+                    // Posts mark to set on the Kuma side and used in measure
+                    mceUtils.postToKuma({ markName: 'js-ie-load-event-end' });
                 }, 300);
             }
         });

--- a/js/editor-libs/mce-utils.js
+++ b/js/editor-libs/mce-utils.js
@@ -38,6 +38,14 @@ module.exports = {
         return tmpElem.style[property] !== undefined;
     },
     /**
+     * Posts a name to set as a mark to Kuma for
+     * processing and beaconing to GA
+     * @param {Object} perf - The performance object sent to Kuma
+     */
+    postToKuma: function(perf) {
+        window.parent.postMessage(perf, 'https://developer.mozilla.org');
+    },
+    /**
      * Hides the default example and shows the custom block
      * @param {object} customBlock - The HTML section to show
      */

--- a/js/editor.js
+++ b/js/editor.js
@@ -2,6 +2,7 @@
     'use strict';
 
     var mceEvents = require('./editor-libs/events.js');
+    var mceUtils = require('./editor-libs/mce-utils');
     var shadowOutput = require('./editor-libs/shadow-output');
     var templateUtils = require('./editor-libs/template-utils');
     var tabby = require('./editor-libs/tabby');
@@ -143,6 +144,8 @@
                         'Tabbed editor load time',
                         performance.timing.loadEventEnd
                     );
+                    // Posts mark to set on the Kuma side and used in measure
+                    mceUtils.postToKuma({ markName: 'tabbed-ie-load-event-end' });
                 }, 100);
             }
         });


### PR DESCRIPTION
@tkadlec This will post a message to Kuma to set a custom mark at the same time as we send `performance.timing.loadEventEnd` for GA beaconing.

On the Kuma side I will then also set a new custom mark in the head of the pages similar to https://github.com/mdn/interactive-examples/blob/master/js/editor-libs/perf.js#L18

I will then also set a new measure which will use the mark from the head in Kuma as `startMark` and then the mark we are creating here as `endMark`. That should then give us the duration equal to `ie-load-complete`

Let me know your thoughts. Thanks!