### PR TITLE
Issue #1013 <style> elements in HTML editor break editor's render method

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -66,6 +66,7 @@
             if (typeof ShadyDOM !== 'undefined' && ShadyDOM.inUse) {
                 shadow.innerHTML = '';
             } else {
+                shadow.removeChild(shadow.querySelector('div'));
                 var styleElements = shadow.querySelectorAll('style');
 
                 for (var styleElement in styleElements) {
@@ -73,8 +74,6 @@
                         shadow.removeChild(styleElements[styleElement]);
                     }
                 }
-
-                shadow.removeChild(shadow.querySelector('div'));
             }
         }
 


### PR DESCRIPTION
**Problem:** Calling `removeChild` on a non-child node throws an error.

**Fix:** The cheap solution here is to delete the content coming from the HTML editor first, then query all remaining `<style>` elements (coming from CSS editor and output base styles) and remove them from shadow root.