### PR TITLE
html/input: Lowercase attributes

### DIFF
--- a/live-examples/html-examples/input/password.html
+++ b/live-examples/html-examples/input/password.html
@@ -10,7 +10,7 @@
     <div>
         <label for="password">Password:</label>
         <input type="password" id="password" name="password"
-               minLength="8" required
+               minlength="8" required
                placeholder="8 characters minimum" />
     </div>
 

--- a/live-examples/html-examples/input/text.html
+++ b/live-examples/html-examples/input/text.html
@@ -4,7 +4,7 @@
     <div class="username">
         <label for="uname">Username:</label>
         <input type="text" id="uname" name="uname" required
-               minLength="4" maxLength="8"
+               minlength="4" maxLength="8"
                placeholder="4 to 8 characters long" />
         <span class="validity"></span>
     </div>

--- a/live-examples/html-examples/input/text.html
+++ b/live-examples/html-examples/input/text.html
@@ -4,7 +4,7 @@
     <div class="username">
         <label for="uname">Username:</label>
         <input type="text" id="uname" name="uname" required
-               minlength="4" maxLength="8"
+               minlength="4" maxlength="8"
                placeholder="4 to 8 characters long" />
         <span class="validity"></span>
     </div>


### PR DESCRIPTION
Attributes are case-insensitive, and they are conventionally written
in lowercase to reduce confusion.

It seems this particular example accidentally used the naming of
the IDL property (which is different from the DOM attribute).

In most cases the only difference is the casing, but in some cases
(such as node.className vs "class"), the name is different entirely.

In general to avoid confusion, attributes should consistently be
written in lowercase.