### PR TITLE
Remove ending `/` that is not necessary

### DIFF
--- a/live-examples/html-examples/image-and-multimedia/img.html
+++ b/live-examples/html-examples/image-and-multimedia/img.html
@@ -1,4 +1,4 @@
 <img src="/media/examples/frog.png"
-     alt="Frog"/>
+     alt="Frog">
 
 <footer><a href=https://unsplash.com/photos/2slBHG3HtdA>Image</a> by David Clode on Unsplash</footer>


### PR DESCRIPTION
W3C and the examples on the bottom of the page https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Alternative_text tell us the ending `/` is not necessary anymore.
It is confusing to have it on the top of the page: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img