### PR TITLE
Add example for <link>

### DIFF
--- a/live-examples/html-examples/document-metadata/link.html
+++ b/live-examples/html-examples/document-metadata/link.html
@@ -1,0 +1,4 @@
+<link href="/media/examples/link-element-example.css" rel="stylesheet">
+
+<p>This text will be red as defined in the external stylesheet.</p>
+<p style="color: blue">The <code>style</code> attribute can override it, though.</p>

--- a/live-examples/html-examples/document-metadata/meta.json
+++ b/live-examples/html-examples/document-metadata/meta.json
@@ -1,5 +1,16 @@
 {
     "pages": {
+        "link": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode":
+                "live-examples/html-examples/document-metadata/link.html",
+            "cssExampleSrc":
+                "live-examples/html-examples/document-metadata/css/link.css",
+            "fileName": "link.html",
+            "title": "HTML Demo: <link>",
+            "type": "tabbed",
+            "height": "tabbed-shorter"
+        },
         "style": {
             "baseTmpl": "tmpl/live-tabbed-tmpl.html",
             "exampleCode":

--- a/media/examples/link-element-example.css
+++ b/media/examples/link-element-example.css
@@ -1,0 +1,7 @@
+/* 
+    This CSS file is used in the example for the <link> element.
+*/
+
+p {
+    color: #f00;
+}


### PR DESCRIPTION
This addresses issue #737 with an example loading an external stylesheet via `<link>`.