### PR TITLE
adding accesskey global attribute interactive example

### DIFF
--- a/live-examples/html-examples/global-attributes/accesskey.html
+++ b/live-examples/html-examples/global-attributes/accesskey.html
@@ -1,0 +1,4 @@
+<p>If you need to relax, press the
+<strong><u>S</u></strong>tress reliever!</p>
+
+<button accesskey="s">Stress reliever</button>

--- a/live-examples/html-examples/global-attributes/css/accesskey.css
+++ b/live-examples/html-examples/global-attributes/css/accesskey.css
@@ -1,0 +1,4 @@
+.output {
+    font: 1rem 'Fira Sans', sans-serif;
+    letter-spacing: 1px;
+}

--- a/live-examples/html-examples/global-attributes/css/accesskey.css
+++ b/live-examples/html-examples/global-attributes/css/accesskey.css
@@ -1,3 +1,11 @@
+@font-face {
+    font-family: 'Fira Sans';
+    src: local('FiraSans-Regular'),
+         url('/media/fonts/FiraSans-Regular.woff2') format('woff2');
+    font-weight: normal;
+    font-style: normal;
+}
+
 .output {
     font: 1rem 'Fira Sans', sans-serif;
     letter-spacing: 1px;

--- a/live-examples/html-examples/global-attributes/meta.json
+++ b/live-examples/html-examples/global-attributes/meta.json
@@ -1,0 +1,15 @@
+{
+    "pages": {
+        "accesskey": {
+            "baseTmpl": "tmpl/live-tabbed-tmpl.html",
+            "exampleCode":
+                "live-examples/html-examples/global-attributes/accesskey.html",
+            "cssExampleSrc":
+                "live-examples/html-examples/global-attributes/css/accesskey.css",
+            "fileName": "accesskey.html",
+            "title": "HTML Demo: accesskey",
+            "type": "tabbed",
+            "height": "tabbed-standard"
+        }
+    }
+}


### PR DESCRIPTION
As per https://github.com/mdn/sprints/issues/292, I have started adding interactive examples for HTML global attributes. This one covers accesskey.

Although there is one problem with this example — when I tested it locally, it worked fine in Firefox, Chrome, Safari, and Opera. 

In the interactive example version, it doesn't work in Firefox only. Very strange.