### PR TITLE
Use CC0 images in <picture> example

### DIFF
--- a/live-examples/html-examples/embedded-content/picture.html
+++ b/live-examples/html-examples/embedded-content/picture.html
@@ -1,9 +1,7 @@
 <!--Change the browser window width to see the image change.-->
 
 <picture>
-    <source srcset="/media/examples/frog.png"
+    <source srcset="/media/cc0-images/Wave_and_Surfer--240x200.jpg"
             media="(min-width: 1000px)">
-    <img src="/media/examples/fish.png">
+    <img src="/media/cc0-images/Painted_Hand--298x332.jpg">
 </picture>
-
-<footer>Images by <a href="https://unsplash.com/@davidclode">David Clode</a> on Unsplash</footer>


### PR DESCRIPTION
Replaced the two images used in this example with CC0
ones and removed the attribution. Part of issue #997.