### PR TITLE
Make variable names consistent

### DIFF
--- a/live-examples/js-examples/array/array-reduce-right.html
+++ b/live-examples/js-examples/array/array-reduce-right.html
@@ -1,6 +1,6 @@
 <pre>
 <code id="static-js">const array1 = [[0, 1], [2, 3], [4, 5]].reduceRight(
-  (previousValue, currentValue) => previousValue.concat(currentValue)
+  (accumulator, currentValue) => accumulator.concat(currentValue)
 );
 
 console.log(array1);


### PR DESCRIPTION
Let's align the naming of the variables to `Array.reduce()` on MDN - the first variable in the callback there is called "accumulator" rather than "previousValue". It makes sense because "accumulator" implies it's previous value and also is easier to understand that value "accumulates" instead of just being "previous".