### PR TITLE
Use semicolon in inlined perf code

### DIFF
--- a/lib/pageBuilderUtils.js
+++ b/lib/pageBuilderUtils.js
@@ -15,7 +15,8 @@ module.exports = {
     injectPerf(tmpl) {
         const regex = /%inject-perf%/g;
         const perfJs = './js/editor-libs/perf.js';
-        let minified = uglify.minify(fse.readFileSync(perfJs, 'utf-8')).code;
+        let minified = uglify.minify(fse.readFileSync(perfJs, 'utf-8'),
+                                     {compress: {sequences: false}}).code;
         return tmpl.replace(regex, minified);
     },
     /**


### PR DESCRIPTION
Tell ``uglify-es`` to turn off the sequences optimization, which joins the top-level statements with a comma instead of a semicolon. This is a wild guess for a fix for Chrome skipping a statement on reload, when the minified JS is injected into a ``<head>`` ``<script>`` element.

Here's the current performance code, beautified:

```js
"use strict";

function postToKuma(e) {
    window.parent.postMessage(e, "https://developer.mozilla.org")
}
postToKuma({
    markName: "interactive-editor-loading"
}), document.addEventListener("readystatechange", function(e) {
    switch (e.target.readyState) {
        case "interactive":
            postToKuma({
                markName: "interactive-editor-interactive",
                measureName: "ie-time-to-interactive",
                startMark: "interactive-editor-loading",
                endMark: "interactive-editor-interactive"
            });
            break;
        case "complete":
            postToKuma({
                markName: "interactive-editor-complete",
                measureName: "ie-time-to-complete",
                startMark: "interactive-editor-loading",
                endMark: "interactive-editor-complete"
            })
    }
});
```

And the code after this change:
```js
"use strict";

function postToKuma(e) {
    window.parent.postMessage(e, "https://developer.mozilla.org")
}
postToKuma({
    markName: "interactive-editor-loading"
});
document.addEventListener("readystatechange", function(e) {
    switch (e.target.readyState) {
        case "interactive":
            postToKuma({
                markName: "interactive-editor-interactive",
                measureName: "ie-time-to-interactive",
                startMark: "interactive-editor-loading",
                endMark: "interactive-editor-interactive"
            });
            break;
        case "complete":
            postToKuma({
                markName: "interactive-editor-complete",
                measureName: "ie-time-to-complete",
                startMark: "interactive-editor-loading",
                endMark: "interactive-editor-complete"
            })
    }
});
```

The only difference is a semicolon ``;`` rather than a comma ``,`` splitting the call to ``postToKuma`` from ``document.addEventListener``.
```