### PR TITLE
Revert "Use semicolon in inlined perf code"

### DIFF
--- a/lib/pageBuilderUtils.js
+++ b/lib/pageBuilderUtils.js
@@ -15,8 +15,7 @@ module.exports = {
     injectPerf(tmpl) {
         const regex = /%inject-perf%/g;
         const perfJs = './js/editor-libs/perf.js';
-        let minified = uglify.minify(fse.readFileSync(perfJs, 'utf-8'),
-                                     {compress: {sequences: false}}).code;
+        let minified = uglify.minify(fse.readFileSync(perfJs, 'utf-8')).code;
         return tmpl.replace(regex, minified);
     },
     /**


### PR DESCRIPTION
This reverts commit 343e55e9c56f7add234e0d88f7fcebd12b46ef2d, an attempt to fix [bug 1468271](https://bugzilla.mozilla.org/show_bug.cgi?id=1468271).

The problem is not some esoteric JavaScript optimization bug. Go back to the default minimization algorithm.

The problem is that the message handler in the main window is initialized after the message to set a mark for `interactive-editor-loading` (so the mark is not created), but before the message to set a measure starting on that mark (so there is an error raised). The fix will need to be on the Kuma side.