### PR TITLE
Add window.ieConfig.origin for the target origin

### DIFF
--- a/js/editor-libs/analytics.js
+++ b/js/editor-libs/analytics.js
@@ -7,7 +7,7 @@ module.exports = {
         'use strict';
         window.parent.postMessage(
             eventDetails,
-            'https://developer.mozilla.org'
+            window.ieConfig && window.ieConfig.origin ? window.ieConfig.origin : 'https://developer.mozilla.org'
         );
     },
     /**

--- a/js/editor-libs/events.js
+++ b/js/editor-libs/events.js
@@ -93,8 +93,9 @@ function addPostMessageListener() {
     window.addEventListener(
         'message',
         function(event) {
+            var expectedOrigin = window.ieConfig && window.ieConfig.origin ? window.ieConfig.origin : 'https://developer.mozilla.org';
             var isExpectedOrigin =
-                event.origin === 'https://developer.mozilla.org';
+                event.origin === expectedOrigin;
 
             /* there may be other post messages so, ensure that the origin is as
             expected and, that `event.data` contains an `smallViewport` property */

--- a/js/editor-libs/mce-utils.js
+++ b/js/editor-libs/mce-utils.js
@@ -56,7 +56,10 @@ module.exports = {
      * @param {Object} perf - The performance object sent to Kuma
      */
     postToKuma: function(perf) {
-        window.parent.postMessage(perf, 'https://developer.mozilla.org');
+        window.parent.postMessage(
+            perf,
+            window.ieConfig && window.ieConfig.origin ? window.ieConfig.origin : 'https://developer.mozilla.org'
+        );
     },
     /**
      * Interrupts the default click event on relative links inside

--- a/js/editor-libs/perf.js
+++ b/js/editor-libs/perf.js
@@ -1,14 +1,39 @@
 'use strict';
 
 /**
+ * Setup the global configuration
+ * Override the target origin with ?origin=<origin URL>
+ * This uses URLSearchParams, which is supported in modern browsers.
+ * No polyfill or fallback is provided, because this override is for
+ * development and testing.
+ * https://stackoverflow.com/a/979995/10612
+ */
+function setupConfig() {
+    var origin = 'https://developer.mozilla.org';
+    if (window.URL) {
+        var url = new URL(window.location.href);
+        if (url.searchParams) {
+            var param = url.searchParams.get('origin');
+            if (param) {
+                origin = param;
+            }
+        }
+    }
+    window.ieConfig = {
+        origin: origin
+    };
+}
+
+/**
  * Posts a name to set as a mark to Kuma for
  * processing and beaconing to GA
  * @param {Object} perf - The performance object sent to Kuma
  */
 function postToKuma(perf) {
-    window.parent.postMessage(perf, 'https://developer.mozilla.org');
+    window.parent.postMessage(perf, window.ieConfig.origin);
 }
 
+setupConfig();
 postToKuma({ markName: 'interactive-editor-loading' });
 
 /**


### PR DESCRIPTION
Add a global configuration ``ieConfig``, with a single member ``origin`` for the target origin for ``postMessage`` calls. Allow overriding the origin with ``?origin=https://example.com``.

Fixes #257.