### PR TITLE
Make position:sticky example work in Safari

### DIFF
--- a/live-examples/css-examples/positioned-layout/position.css
+++ b/live-examples/css-examples/positioned-layout/position.css
@@ -7,13 +7,10 @@
     width: 100%;
 }
 
-.box {
+#example-element {
     display: block;
     height: 65px;
     width: 65px;
-}
-
-#example-element {
     background-color: yellow;
     border: 3px solid red;
 }

--- a/live-examples/css-examples/positioned-layout/position.html
+++ b/live-examples/css-examples/positioned-layout/position.html
@@ -37,7 +37,7 @@ top: 20px;</code></pre>
     <section id="default-example" class="default-example">
       <div id="example-element-container">
 <p>In this demo you can control the <code>position</code> property for the yellow box.</p>
-        <div class="box transition-all" id="example-element"></div>
+        <div class="transition-all" id="example-element"></div>
 <p>To see the effect of <code>sticky</code> positioning, select the <code>position: sticky</code> option and scroll this container.</p>
 <p>The element will scroll along with its container, until it is at the top of the container (or reaches the offset specified in <code>top</code>), and will then stop scrolling, so it stays visible.</p>
 <p>The rest of this text is only supplied to make sure the container overflows, so as to enable you to scroll it and see the effect.</p>


### PR DESCRIPTION
Fix for https://github.com/mdn/interactive-examples/issues/1115.

This adds the `-webkit` prefix for `position: sticky` and makes the element `display: block`. Those changes make it work in Safari.

Because Safari wants the element to be `display: block`, this broke the original layout, so I've ended up simplifying it quite a lot.