### PR TITLE
Added more helpful technique for accessing promise

### DIFF
--- a/live-examples/js-examples/promise/promise-constructor.html
+++ b/live-examples/js-examples/promise/promise-constructor.html
@@ -2,22 +2,16 @@
 <code id="static-js">var promise1 = new Promise(function(resolve, reject) {
   setTimeout(function() { 
     resolve('foo');
-  }, 100);
+  }, 300);
 });
 
+promise1.then(function(value) { 
+  console.log(value)
+  // expected output: "foo"
+});
 
-// How to show the value of promise1: 
-
-promise1.then(value => console.log(value));
-//=> "foo"
-
-// A Promise's value can ONLY be accessed via a `.then()` callback function:
-// promise1.then(function(value) {/* handle value in function here */})
-
-// The following example **won't work**:
-// Reading Synchronously:
 console.log(promise1);
-//=> [object Promise]
+// expected output: [object Promise]
 
 </code>
 </pre>

--- a/live-examples/js-examples/promise/promise-constructor.html
+++ b/live-examples/js-examples/promise/promise-constructor.html
@@ -1,9 +1,23 @@
 <pre>
 <code id="static-js">var promise1 = new Promise(function(resolve, reject) {
-  setTimeout(resolve, 100, 'foo');
+  setTimeout(function() { 
+    resolve('foo');
+  }, 100);
 });
 
+
+// How to show the value of promise1: 
+
+promise1.then(value => console.log(value));
+//=> "foo"
+
+// A Promise's value can ONLY be accessed via a `.then()` callback function:
+// promise1.then(function(value) {/* handle value in function here */})
+
+// The following example **won't work**:
+// Reading Synchronously:
 console.log(promise1);
-// expected output: [object Promise]
+//=> [object Promise]
+
 </code>
 </pre>

--- a/live-examples/js-examples/promise/promise-constructor.html
+++ b/live-examples/js-examples/promise/promise-constructor.html
@@ -6,7 +6,7 @@
 });
 
 promise1.then(function(value) { 
-  console.log(value)
+  console.log(value);
   // expected output: "foo"
 });
 


### PR DESCRIPTION
Showing that a promise evaluates to the string descriptor: `[object Promise]` is not the **most helpful** thing to include in the _first_ example.

Let me know if I need to revise, thanks for any feedback! 💯 