### PR TITLE
bug 1483072: handle new jenkins/aws services

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,33 +2,42 @@
 
 def buildSite() {
     stage ('build') {
-      try {
-        sh 'bin/build.sh'
-      } catch(err) {
-        sh "bin/irc-notify.sh --stage 'build " + env.BRANCH_NAME + "' --status 'failed'"
-        throw err
-      }
+        try {
+            sh 'bin/build.sh'
+        } catch(err) {
+            sh "bin/irc-notify.sh --stage 'build " + env.BRANCH_NAME + "' --status 'failed'"
+            throw err
+        }
     }
 }
 
 def syncS3(String bucket) {
     stage ('s3 sync') {
         try {
-          sh "bin/s3-sync.sh " + bucket
+            sh "bin/s3-sync.sh " + bucket
         } catch(err) {
-          sh "bin/irc-notify.sh --stage 's3 sync " + env.BRANCH_NAME + "' --status 'failed'"
-          throw err
+            sh "bin/irc-notify.sh --stage 's3 sync " + env.BRANCH_NAME + "' --status 'failed'"
+            throw err
         }
         sh "bin/irc-notify.sh --stage 's3 sync " + env.BRANCH_NAME + "' --status 'shipped'"
     }
 }
 
+def is_mozmeao_pipeline() {
+    /*
+     * Temporary function that returns true if this is running on the
+     * MozMEAO-owned Jenkins service targeting the MozMEAO-owned S3 bucket.
+     * TODO: After cutover to IT-owned services, remove this function.
+     */
+    return env.JOB_NAME.startsWith('mdn_interactive_examples/')
+}
+
 node {
     stage ('Prepare') {
-      checkout scm
+        checkout scm
     }
     if ( env.BRANCH_NAME == 'prod' ) {
-      buildSite()
-      syncS3('mdninteractive')
+        buildSite()
+        syncS3(is_mozmeao_pipeline() ? 'mdninteractive' : 'mdninteractive-b77d14bceaaa9ea4')
     }
 }


### PR DESCRIPTION
This PR allows this `Jenkinsfile` to run on both the new IT-owned Jenkins service as well as the existing MozMEAO-owned Jenkins service. It simply changes the name of the S3 bucket (to which the build artifacts will be sync'ed) depending upon the Jenkins service.

I also took the liberty of making the indentation consistent (4 spaces).

These changes have been successfully tested on both the new IT-owned Jenkins service and the existing MozMEAO-owned Jenkins service.