### PR TITLE
bug 1483072: handle new jenkins/aws services

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,33 +2,42 @@
 
 def buildSite() {
     stage ('build') {
-      try {
-        sh 'bin/build.sh'
-      } catch(err) {
-        sh "bin/irc-notify.sh --stage 'build " + env.BRANCH_NAME + "' --status 'failed'"
-        throw err
-      }
+        try {
+            sh 'bin/build.sh'
+        } catch(err) {
+            sh "bin/irc-notify.sh --stage 'build " + env.BRANCH_NAME + "' --status 'failed'"
+            throw err
+        }
     }
 }
 
 def syncS3(String bucket) {
     stage ('s3 sync') {
         try {
-          sh "bin/s3-sync.sh " + bucket
+            sh "bin/s3-sync.sh " + bucket
         } catch(err) {
-          sh "bin/irc-notify.sh --stage 's3 sync " + env.BRANCH_NAME + "' --status 'failed'"
-          throw err
+            sh "bin/irc-notify.sh --stage 's3 sync " + env.BRANCH_NAME + "' --status 'failed'"
+            throw err
         }
         sh "bin/irc-notify.sh --stage 's3 sync " + env.BRANCH_NAME + "' --status 'shipped'"
     }
 }
 
+def is_mozmeao_pipeline() {
+    /*
+     * Temporary function that returns true if this is running on the
+     * MozMEAO-owned Jenkins service targeting the MozMEAO-owned S3 bucket.
+     * TODO: After cutover to IT-owned services, remove this function.
+     */
+    return env.JOB_NAME.startsWith('mdn_interactive_examples/')
+}
+
 node {
     stage ('Prepare') {
-      checkout scm
+        checkout scm
     }
     if ( env.BRANCH_NAME == 'prod' ) {
-      buildSite()
-      syncS3('mdninteractive')
+        buildSite()
+        syncS3(is_mozmeao_pipeline() ? 'mdninteractive' : 'mdninteractive-b77d14bceaaa9ea4')
     }
 }

--- a/bin/irc-notify.sh
+++ b/bin/irc-notify.sh
@@ -8,8 +8,6 @@ set -eo pipefail
 NICK="examplesbot"
 CHANNEL="#mdndev"
 SERVER="irc.mozilla.org:6697"
-BLUE_BUILD_URL="https://ci.us-west.moz.works/blue/organizations/jenkins/mdn_interactive_examples"
-BLUE_BUILD_URL="${BLUE_BUILD_URL}/detail/${BRANCH_NAME/\//%2f}/${BUILD_NUMBER}/pipeline"
 # colors and styles: values from the following links
 # http://www.mirc.com/colors.html
 # http://stackoverflow.com/a/13382032
@@ -76,7 +74,7 @@ fi
 
 if [[ -n "$STAGE" ]]; then
     MESSAGE="${STATUS}${STAGE}:"
-    MESSAGE="$MESSAGE Branch ${BOLD}${BRANCH_NAME}${NORMAL} build #${BUILD_NUMBER}: ${BLUE_BUILD_URL}"
+    MESSAGE="$MESSAGE Branch ${BOLD}${BRANCH_NAME}${NORMAL} build #${BUILD_NUMBER}: ${RUN_DISPLAY_URL}"
 elif [[ -n "$MESSAGE" ]]; then
     MESSAGE="${STATUS}${MESSAGE}"
 else


### PR DESCRIPTION
This PR allows this Jenkinsfile to run on both the new IT-owned Jenkins service as well as the existing MozMEAO-owned Jenkins service.

- Changes the name of the S3 bucket (to which the build artifacts will be sync'ed) depending upon the Jenkins service.
- Change the `bin/irc-notify.sh` script to use `RUN_DISPLAY_URL` instead of the fixed `BLUE_BUILD_URL`

I also took the liberty of making the indentation consistent (4 spaces). For easier review, you may want to check the `Hide whitespace changes` checkbox under the `Diff settings` button.

These changes have been successfully tested on both the new IT-owned Jenkins service and the existing MozMEAO-owned Jenkins service.