### PR TITLE
bug 1483072: make awscli profile optional

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,10 +11,10 @@ def buildSite() {
     }
 }
 
-def syncS3(String bucket) {
+def syncS3(String bucket, String extra_args='') {
     stage ('s3 sync') {
         try {
-            sh "bin/s3-sync.sh " + bucket
+            sh "bin/s3-sync.sh ${bucket} ${extra_args}"
         } catch(err) {
             sh "bin/irc-notify.sh --stage 's3 sync " + env.BRANCH_NAME + "' --status 'failed'"
             throw err
@@ -38,6 +38,11 @@ node {
     }
     if ( env.BRANCH_NAME == 'prod' ) {
         buildSite()
-        syncS3(is_mozmeao_pipeline() ? 'mdninteractive' : 'mdninteractive-b77d14bceaaa9ea4')
+        if (is_mozmeao_pipeline()) {
+            // TODO: After cutover to IT-owned services, remove this branch.
+            syncS3('mdninteractive', '--profile mdninteractive')
+        } else {
+            syncS3('mdninteractive-b77d14bceaaa9ea4')
+        }
     }
 }

--- a/bin/s3-sync.sh
+++ b/bin/s3-sync.sh
@@ -7,7 +7,7 @@ fi
 
 SHORT_CACHE="--cache-control max-age=1800" # 30 minutes
 LONG_CACHE="--cache-control max-age=2629800" # 1 month
-ARGS="--acl public-read --delete --profile mdninteractive"
+ARGS="--acl public-read --delete ${@:2}"
 cd docs
 
 for path in pages live-examples; do


### PR DESCRIPTION
The MozMEAO-owned Jenkins service uses locally-installed AWS credentials within the `mdninteractive` profile in order to perform its `aws s3 sync` command, but the new IT-owned Jenkins service has moved to the AWS-recommended approach of associating IAM roles with EC2 instances (see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html). This PR allows us to satisfy both approaches during this interim period until we make the cutover to the IT-owned services.

This has been successfully tested for both the new IT-owned and MozMEAO-owned Jenkins services.