### PR TITLE
Switch to https source for HTML audio example

### DIFF
--- a/live-examples/html-examples/image-and-multimedia/audio.html
+++ b/live-examples/html-examples/image-and-multimedia/audio.html
@@ -8,7 +8,7 @@
     <audio
         id="t-rex-roar"
         controls
-        src="http://soundbible.com/mp3/Tyrannosaurus%20Rex%20Roar-SoundBible.com-807702404.mp3">
+        src="https://soundbible.com/mp3/Tyrannosaurus%20Rex%20Roar-SoundBible.com-807702404.mp3">
         Your browser does not support the <code>audio</code> element.
     </audio>
 </p>
@@ -24,7 +24,7 @@
     <audio id="t-rex-roar-loop" controls loop>
         <source
             type="audio/mpeg"
-            src="http://soundbible.com/mp3/Tyrannosaurus%20Rex%20Roar-SoundBible.com-807702404.mp3"/>
+            src="https://soundbible.com/mp3/Tyrannosaurus%20Rex%20Roar-SoundBible.com-807702404.mp3"/>
         Your browser does not support the <code>audio</code> element.
     </audio>
 </p>


### PR DESCRIPTION
The ``http://`` URL results in a mixed content warning when [embedded on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio).

Both links work:

* https://soundbible.com/mp3/Tyrannosaurus%20Rex%20Roar-SoundBible.com-807702404.mp3
* http://soundbible.com/mp3/Tyrannosaurus%20Rex%20Roar-SoundBible.com-807702404.mp3