### PR TITLE
added path() example to basic shapes (CSS values)

### DIFF
--- a/live-examples/css-examples/values-and-units/type-basic-shape.html
+++ b/live-examples/css-examples/values-and-units/type-basic-shape.html
@@ -35,7 +35,7 @@
         </button>
     </div>
     <div class="example-choice">
-        <pre><code class="language-css">clip-path: path('M 10,30 A 20,20 0,0,1 50,30 z');</code></pre>
+        <pre><code class="language-css">clip-path: path('M 20,60 A 40,40 0,0,1 100,60 z');</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/values-and-units/type-basic-shape.html
+++ b/live-examples/css-examples/values-and-units/type-basic-shape.html
@@ -22,20 +22,14 @@
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">clip-path: polygon(50% 20%, 90% 80%, 10% 80%);</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
         <pre><code class="language-css">clip-path: polygon(50% 2.4%, 34.5% 33.8%, 0% 38.8%, 25% 63.1%, 19.1% 97.6%, 50% 81.3%, 80.9% 97.6%, 75% 63.1%, 100% 38.8%, 65.5% 33.8%);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
+    
     <div class="example-choice">
-        <pre><code class="language-css">clip-path: path('M 20,60 A 40,40 0,0,1 100,60 z');</code></pre>
+        <pre><code class="language-css">clip-path: path('M 50,245 A 160,160 0,0,1 360,120 z')</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/values-and-units/type-basic-shape.html
+++ b/live-examples/css-examples/values-and-units/type-basic-shape.html
@@ -34,6 +34,12 @@
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
+    <div class="example-choice">
+        <pre><code class="language-css">clip-path: path('M 10,30 A 20,20 0,0,1 50,30 z');</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
 
 </section>
 


### PR DESCRIPTION
Adding path() as a basic shape.
It is not supported in clip-path. (but it is supported in offset-path in FF63, with motion path in Chrome)


specs: 
Definition of path()
https://drafts.csswg.org/css-shapes-2/#supported-basic-shapes

to be added to basic shapes at:
https://www.w3.org/TR/css-shapes/#basic-shape-functions

as per bugzilla
https://bugzilla.mozilla.org/show_bug.cgi?id=1246764