### PR TITLE
Fix incorrect label selector in password example

### DIFF
--- a/live-examples/html-examples/input/password.html
+++ b/live-examples/html-examples/input/password.html
@@ -2,7 +2,7 @@
     <legend>Sign in</legend>
 
     <div>
-        <label for="userName">Username:</label>
+        <label for="username">Username:</label>
         <input type="text" id="username" name="username"
                required />
     </div>


### PR DESCRIPTION
[HTML element names are case sensitive](https://www.w3.org/TR/1999/REC-html401-19991224/struct/global.html#adef-id)