### PR TITLE
Bugfix 948422: increase colour contract of comments in code examples

### DIFF
--- a/css/editor-libs/codemirror-override.css
+++ b/css/editor-libs/codemirror-override.css
@@ -3,7 +3,7 @@
 }
 
 .cm-s-default .cm-comment {
-    color: #7d8b99;
+    color: #6b7884;
 }
 
 .cm-s-default .cm-keyword {


### PR DESCRIPTION
Update colour contrast of commented code
The current contrast is 3.49:1, which is below the minimum 4.5 ratio needed to meet the WCAG AA guidelines. The proposed change increases the contrast to 4.52:1

Example of how new contract looks
![image](https://user-images.githubusercontent.com/9624541/45918070-28d26f00-be79-11e8-8d49-74ba2693863d.png)

also see bug https://bugzilla.mozilla.org/show_bug.cgi?id=948422 