### PR TITLE
Fix bug in String.normalize live example

### DIFF
--- a/live-examples/js-examples/string/string-normalize.html
+++ b/live-examples/js-examples/string/string-normalize.html
@@ -12,6 +12,6 @@ console.log(first + ' and ' + second + ' can' +
 
 var oldWord = 'mañana';
 var newWord = oldWord.normalize('NFD');
-console.log('The word did ' + ((oldWord != newWord)? 'not ' : '') + 'change.');
+console.log('The word did ' + ((oldWord != newWord)? '' : 'not ') + 'change.');
 // expected output: "The word did change."</code>
 </pre>


### PR DESCRIPTION
The error in the ternary operator.