### PR TITLE
Fix #1115: position: sticky not working in Safari

### DIFF
--- a/live-examples/css-examples/positioned-layout/position.css
+++ b/live-examples/css-examples/positioned-layout/position.css
@@ -30,11 +30,3 @@
     border: 3px solid red;
     z-index: 1;
 }
-
-#example-element-placeholder {
-    background-color: transparent;
-    border: 3px dotted red;
-    position: absolute;
-    top: 56px;
-    left: 65px;
-}

--- a/live-examples/css-examples/positioned-layout/position.css
+++ b/live-examples/css-examples/positioned-layout/position.css
@@ -1,29 +1,16 @@
+.output section {
+    align-items: flex-start;
+    overflow: auto;
+}
 
 #example-element-container {
     text-align: left;
-    position: relative;
-    overflow: scroll;
-    height: 100%;
-    width: 100%;
-}
-
-.box {
-    display: inline-block;
-    height: 65px;
-    width: 65px;
-    margin: 10px;
-    background-color: rgba(0, 0, 255, 0.2);
-    border: 3px solid blue;
 }
 
 #example-element {
     background-color: yellow;
     border: 3px solid red;
-}
-
-#example-element-placeholder {
-    position: absolute;
-    left: 85px;
-    background-color: transparent;
-    border: 3px dotted red;
+    display: block;
+    width: 65px;
+    height: 65px;
 }

--- a/live-examples/css-examples/positioned-layout/position.css
+++ b/live-examples/css-examples/positioned-layout/position.css
@@ -3,14 +3,38 @@
     overflow: auto;
 }
 
+.box {
+    background-color: rgba(0, 0, 255, 0.2);
+    border: 3px solid blue;
+    float: left;
+    width: 65px;
+    height: 65px;
+}
+
+.box + .box {
+    margin-left: 10px;
+}
+
+.clear {
+    clear: both;
+    padding-top: 1em;
+}
+
 #example-element-container {
+    position: relative;
     text-align: left;
 }
 
 #example-element {
     background-color: yellow;
     border: 3px solid red;
-    display: block;
-    width: 65px;
-    height: 65px;
+    z-index: 1;
+}
+
+#example-element-placeholder {
+    background-color: transparent;
+    border: 3px dotted red;
+    position: absolute;
+    top: 56px;
+    left: 65px;
 }

--- a/live-examples/css-examples/positioned-layout/position.html
+++ b/live-examples/css-examples/positioned-layout/position.html
@@ -25,6 +25,7 @@ top: 40px; left: 40px;</code></pre>
 
 <div id="choice-sticky" class="example-choice">
 <pre><code class="language-css">position: sticky;
+position: -webkit-sticky;
 top: 20px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
@@ -36,7 +37,7 @@ top: 20px;</code></pre>
     <section id="default-example" class="default-example">
       <div id="example-element-container">
 <p>In this demo you can control the <code>position</code> property for the yellow box.</p>
-        <div class="box"></div><div class="box" id="example-element-placeholder"></div><div class="box transition-all" id="example-element"></div><div class="box"></div>
+<div class="transition-all" id="example-element"></div>
 <p>To see the effect of <code>sticky</code> positioning, select the <code>position: sticky</code> option and scroll this container.</p>
 <p>The element will scroll along with its container, until it is at the top of the container (or reaches the offset specified in <code>top</code>), and will then stop scrolling, so it stays visible.</p>
 <p>The rest of this text is only supplied to make sure the container overflows, so as to enable you to scroll it and see the effect.</p>

--- a/live-examples/css-examples/positioned-layout/position.html
+++ b/live-examples/css-examples/positioned-layout/position.html
@@ -38,7 +38,6 @@ top: 20px;</code></pre>
             <p>In this demo you can control the <code>position</code> property for the yellow box.</p>
             <div class="box"></div>
             <div class="box" id="example-element"></div>
-            <div class="box" id="example-element-placeholder"></div>
             <div class="box"></div>
             <p class="clear">To see the effect of <code>sticky</code> positioning, select the <code>position: sticky</code> option and scroll this container.</p>
             <p>The element will scroll along with its container, until it is at the top of the container (or reaches the offset specified in <code>top</code>), and will then stop scrolling, so it stays visible.</p>

--- a/live-examples/css-examples/positioned-layout/position.html
+++ b/live-examples/css-examples/positioned-layout/position.html
@@ -9,7 +9,7 @@
 
 <div class="example-choice">
 <pre><code class="language-css">position: relative;
-top: 65px; left: 65px;</code></pre>
+top: 40px; left: 40px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
@@ -37,8 +37,11 @@ top: 20px;</code></pre>
     <section id="default-example" class="default-example">
       <div id="example-element-container">
 <p>In this demo you can control the <code>position</code> property for the yellow box.</p>
-<div class="transition-all" id="example-element"></div>
-<p>To see the effect of <code>sticky</code> positioning, select the <code>position: sticky</code> option and scroll this container.</p>
+<div class="box"></div>
+<div class="box" id="example-element"></div>
+<div class="box" id="example-element-placeholder"></div>
+<div class="box"></div>
+<p class="clear">To see the effect of <code>sticky</code> positioning, select the <code>position: sticky</code> option and scroll this container.</p>
 <p>The element will scroll along with its container, until it is at the top of the container (or reaches the offset specified in <code>top</code>), and will then stop scrolling, so it stays visible.</p>
 <p>The rest of this text is only supplied to make sure the container overflows, so as to enable you to scroll it and see the effect.</p>
 <hr/>

--- a/live-examples/css-examples/positioned-layout/position.html
+++ b/live-examples/css-examples/positioned-layout/position.html
@@ -1,52 +1,50 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="position">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">position: static;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
 
-<div class="example-choice" initial-choice="true">
-<pre><code class="language-css">position: static;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true">
-    <span class="visually-hidden">Copy to Clipboard</span>
-</button>
-</div>
-
-<div class="example-choice">
-<pre><code class="language-css">position: relative;
+    <div class="example-choice">
+        <pre><code class="language-css">position: relative;
 top: 40px; left: 40px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true">
-    <span class="visually-hidden">Copy to Clipboard</span>
-</button>
-</div>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
 
-<div class="example-choice">
-<pre><code class="language-css">position: absolute;
+    <div class="example-choice">
+        <pre><code class="language-css">position: absolute;
 top: 40px; left: 40px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true">
-    <span class="visually-hidden">Copy to Clipboard</span>
-</button>
-</div>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
 
-<div id="choice-sticky" class="example-choice">
-<pre><code class="language-css">position: sticky;
+    <div id="choice-sticky" class="example-choice">
+        <pre><code class="language-css">position: sticky;
 position: -webkit-sticky;
 top: 20px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true">
-    <span class="visually-hidden">Copy to Clipboard</span>
-</button>
-</div>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
 </section>
 
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
-      <div id="example-element-container">
-<p>In this demo you can control the <code>position</code> property for the yellow box.</p>
-<div class="box"></div>
-<div class="box" id="example-element"></div>
-<div class="box" id="example-element-placeholder"></div>
-<div class="box"></div>
-<p class="clear">To see the effect of <code>sticky</code> positioning, select the <code>position: sticky</code> option and scroll this container.</p>
-<p>The element will scroll along with its container, until it is at the top of the container (or reaches the offset specified in <code>top</code>), and will then stop scrolling, so it stays visible.</p>
-<p>The rest of this text is only supplied to make sure the container overflows, so as to enable you to scroll it and see the effect.</p>
-<hr/>
-<p>Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a small unregarded yellow sun. Orbiting this at a distance of roughly ninety-two million miles is an utterly insignificant little blue green planet whose ape-descended life forms are so amazingly primitive that they still think digital watches are a pretty neat idea.</p> 
-      </div>
+        <div id="example-element-container">
+            <p>In this demo you can control the <code>position</code> property for the yellow box.</p>
+            <div class="box"></div>
+            <div class="box" id="example-element"></div>
+            <div class="box" id="example-element-placeholder"></div>
+            <div class="box"></div>
+            <p class="clear">To see the effect of <code>sticky</code> positioning, select the <code>position: sticky</code> option and scroll this container.</p>
+            <p>The element will scroll along with its container, until it is at the top of the container (or reaches the offset specified in <code>top</code>), and will then stop scrolling, so it stays visible.</p>
+            <p>The rest of this text is only supplied to make sure the container overflows, so as to enable you to scroll it and see the effect.</p>
+            <hr/>
+            <p>Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a small unregarded yellow sun. Orbiting this at a distance of roughly ninety-two million miles is an utterly insignificant little blue green planet whose ape-descended life forms are so amazingly primitive that they still think digital watches are a pretty neat idea.</p> 
+        </div>
     </section>
-
 </div>


### PR DESCRIPTION
This fixes #1115 by building on top of PR #1121 (using prefixed `-webkit-sticky` and making the boxes `display: block`).

The remaining issue was the fixed height of the inner container `.example-element-container` which Safari seems to use for calculating how long a sticky element is allowed to scroll (even if it is scrollable itself). Removing any height constraints on that `div` and instead making the outer section `overflow: auto` solved the problem (tested in Safari 12.0, FF, and Chrome).

I also recreated the blue boxes/placeholder behavior from before, removed the animation (was quite confusing for me, because you cannot animate `position` changes), and fixed the code formatting a bit.