### PR TITLE
Issue#1192 links to media files broken

### DIFF
--- a/CONTRIBUTING-HTML.md
+++ b/CONTRIBUTING-HTML.md
@@ -183,13 +183,13 @@ In particular, see the following guidelines for the HTML source and the output:
 * **Use line breaks for readability**: keep in mind that at different browser widths longer lines will wrap and this can hurt readability. By including line breaks you can make the example more readable at different browser widths. For example, consider an example like this:
 
 ```
-<img class="fit-picture" src="/media/cc0-images/Grapefruit_Slice--332x332.jpg" alt="Grapefruit slice atop a pile of other slices"/>
+<img class="fit-picture" src="/media/examples/Grapefruit_Slice--332x332.jpg" alt="Grapefruit slice atop a pile of other slices"/>
 ```
 
 With a browser window width of 1000 pixels, this will wrap like this:
 
 ```
-<img class="fit-picture" src="/media/cc0-images
+<img class="fit-picture" src="/media/examples
 /Grapefruit_Slice--332x332.jpg" alt="Grapefruit slice atop a pile
 of other slices"/>
 ```
@@ -198,7 +198,7 @@ If we add line breaks after each attribute, the example is much more readable:
 
 ```
 <img class="fit-picture"
-     src="/media/cc0-images/Grapefruit_Slice--332x332.jpg"
+     src="/media/examples/Grapefruit_Slice--332x332.jpg"
      alt="Grapefruit slice atop a pile of other slices"/>
 ```
 

--- a/live-examples/html-examples/embedded-content/picture.html
+++ b/live-examples/html-examples/embedded-content/picture.html
@@ -1,7 +1,7 @@
 <!--Change the browser window width to see the image change.-->
 
 <picture>
-    <source srcset="/media/cc0-images/Wave_and_Surfer--240x200.jpg"
+    <source srcset="/media/examples/Wave_and_Surfer--240x200.jpg"
             media="(min-width: 800px)">
-    <img src="/media/cc0-images/Painted_Hand--298x332.jpg">
+    <img src="/media/examples/Painted_Hand--298x332.jpg">
 </picture>

--- a/live-examples/html-examples/image-and-multimedia/img.html
+++ b/live-examples/html-examples/image-and-multimedia/img.html
@@ -1,3 +1,3 @@
 <img class="fit-picture"
-     src="/media/cc0-images/Grapefruit_Slice--332x332.jpg"
+     src="/media/examples/Grapefruit_Slice--332x332.jpg"
      alt="Grapefruit slice atop a pile of other slices"/>

--- a/live-examples/html-examples/text-content/figcaption.html
+++ b/live-examples/html-examples/text-content/figcaption.html
@@ -1,4 +1,4 @@
 <figure>
-    <img src="/media/cc0-images/Elephant_In_Silhouette_Closer--660x480.jpg" alt="Elephant at sunset" />
+    <img src="/media/examples/Elephant_In_Silhouette_Closer--660x480.jpg" alt="Elephant at sunset" />
     <figcaption>An elephant at sunset</figcaption>
 </figure>

--- a/live-examples/html-examples/text-content/main.html
+++ b/live-examples/html-examples/text-content/main.html
@@ -1,5 +1,5 @@
 <header>
-    <img class="logo" src="/media/cc0-images/Gecko--320x213.jpg" />
+    <img class="logo" src="/media/examples/Gecko--320x213.jpg" />
     <span>Gecko facts</span>
 </header>
 


### PR DESCRIPTION
Fixed #1192 by changing media `src` to flat `/examples` folder.