### PR TITLE
Adding Symbol.asyncIterator example

### DIFF
--- a/live-examples/js-examples/symbol/meta.json
+++ b/live-examples/js-examples/symbol/meta.json
@@ -1,5 +1,11 @@
 {
     "pages": {
+        "symbolAsyncIterator": {
+            "exampleCode": "./live-examples/js-examples/symbol/symbol-async-iterator.html",
+            "fileName": "symbol-async-iterator.html",
+            "title": "JavaScript Demo: Symbol.asyncIterator",
+            "type": "js"
+        },
         "symbolConstructor": {
             "exampleCode": "./live-examples/js-examples/symbol/symbol-constructor.html",
             "fileName": "symbol-constructor.html",

--- a/live-examples/js-examples/symbol/symbol-async-iterator.html
+++ b/live-examples/js-examples/symbol/symbol-async-iterator.html
@@ -1,0 +1,20 @@
+<pre>
+<code id="static-js">const asyncIterableObj = new Object();
+
+asyncIterableObj[Symbol.asyncIterator] = async function* () {
+  yield 1;
+  yield 2;
+  yield 3;
+};
+
+(async function () {
+  for await (let num of asyncIterableObj) {
+    console.log(num);
+  }
+})();
+// expected output:
+// > 1
+// > 2
+// > 3
+</code>
+</pre>


### PR DESCRIPTION
This PR aims to add a new example for `Symbol.asyncIterator` as a supporting example for  Symbol.asyncIterator MDN docs page.
