### PR TITLE
rename offset properties

### DIFF
--- a/live-examples/css-examples/logical-properties/inset-block-end.css
+++ b/live-examples/css-examples/logical-properties/inset-block-end.css
@@ -11,6 +11,7 @@
     background-color: yellow;
     border: 3px solid red;
     position: absolute;
-    offset-block-start: 50px;
+    inset-block-end: 20px;
     inline-size: 140px;
+    min-block-size: 200px;
 }

--- a/live-examples/css-examples/logical-properties/inset-block-end.html
+++ b/live-examples/css-examples/logical-properties/inset-block-end.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="offset-block-start">
+<section id="example-choice-list" class="example-choice-list large" data-property="inset-block-end">
     <div class="example-choice" initial-choice="true">
         <pre><code class="language-css">writing-mode: horizontal-tb;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
@@ -30,8 +30,12 @@ direction: rtl;</code></pre>
 </section>
 
 <div id="output" class="output large hidden">
-    <section id="default-example"><div class="example-container" id="example-element">
-        <div id="abspos">I am absolutely positioned with offset-block-start: 50px</div>
-        <p>As much mud in the streets as if the waters had but newly retired from the face of the earth, and it would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine lizard up Holborn Hill.</p>
-    </div></section>
+    <section id="default-example">
+        <div class="example-container" id="example-element">
+            <div id="abspos">I am absolutely positioned with inset-block-end: 20px</div>
+            <p>As much mud in the streets as if the waters had but newly retired from the face of the earth, and it
+                would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine
+                lizard up Holborn Hill.</p>
+        </div>
+    </section>
 </div>

--- a/live-examples/css-examples/logical-properties/inset-block-start.css
+++ b/live-examples/css-examples/logical-properties/inset-block-start.css
@@ -11,7 +11,6 @@
     background-color: yellow;
     border: 3px solid red;
     position: absolute;
-    offset-inline-start: 50px;
+    inset-block-start: 50px;
     inline-size: 140px;
-    min-block-size: 80px;
 }

--- a/live-examples/css-examples/logical-properties/inset-block-start.html
+++ b/live-examples/css-examples/logical-properties/inset-block-start.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="offset-inline-end">
+<section id="example-choice-list" class="example-choice-list large" data-property="inset-block-start">
     <div class="example-choice" initial-choice="true">
         <pre><code class="language-css">writing-mode: horizontal-tb;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
@@ -30,8 +30,12 @@ direction: rtl;</code></pre>
 </section>
 
 <div id="output" class="output large hidden">
-    <section id="default-example"><div class="example-container" id="example-element">
-        <div id="abspos">I am absolutely positioned with offset-inline-end: 50px</div>
-        <p>As much mud in the streets as if the waters had but newly retired from the face of the earth, and it would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine lizard up Holborn Hill.</p>
-    </div></section>
+    <section id="default-example">
+        <div class="example-container" id="example-element">
+            <div id="abspos">I am absolutely positioned with inset-block-start: 50px</div>
+            <p>As much mud in the streets as if the waters had but newly retired from the face of the earth, and it
+                would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine
+                lizard up Holborn Hill.</p>
+        </div>
+    </section>
 </div>

--- a/live-examples/css-examples/logical-properties/inset-inline-end.css
+++ b/live-examples/css-examples/logical-properties/inset-inline-end.css
@@ -11,7 +11,7 @@
     background-color: yellow;
     border: 3px solid red;
     position: absolute;
-    offset-block-end: 20px;
+    inset-inline-end: 50px;
     inline-size: 140px;
-    min-block-size: 200px;
+    min-block-size: 80px;
 }

--- a/live-examples/css-examples/logical-properties/inset-inline-end.html
+++ b/live-examples/css-examples/logical-properties/inset-inline-end.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="offset-inline-start">
+<section id="example-choice-list" class="example-choice-list large" data-property="inset-inline-end">
     <div class="example-choice" initial-choice="true">
         <pre><code class="language-css">writing-mode: horizontal-tb;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
@@ -30,8 +30,12 @@ direction: rtl;</code></pre>
 </section>
 
 <div id="output" class="output large hidden">
-    <section id="default-example"><div class="example-container" id="example-element">
-        <div id="abspos">I am absolutely positioned with offset-inline-start: 50px</div>
-        <p>As much mud in the streets as if the waters had but newly retired from the face of the earth, and it would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine lizard up Holborn Hill.</p>
-    </div></section>
+    <section id="default-example">
+        <div class="example-container" id="example-element">
+            <div id="abspos">I am absolutely positioned with inset-inline-end: 50px</div>
+            <p>As much mud in the streets as if the waters had but newly retired from the face of the earth, and it
+                would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine
+                lizard up Holborn Hill.</p>
+        </div>
+    </section>
 </div>

--- a/live-examples/css-examples/logical-properties/inset-inline-start.css
+++ b/live-examples/css-examples/logical-properties/inset-inline-start.css
@@ -11,7 +11,7 @@
     background-color: yellow;
     border: 3px solid red;
     position: absolute;
-    offset-inline-end: 50px;
+    inset-inline-start: 50px;
     inline-size: 140px;
     min-block-size: 80px;
 }

--- a/live-examples/css-examples/logical-properties/inset-inline-start.html
+++ b/live-examples/css-examples/logical-properties/inset-inline-start.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="offset-block-end">
+<section id="example-choice-list" class="example-choice-list large" data-property="inset-inline-start">
     <div class="example-choice" initial-choice="true">
         <pre><code class="language-css">writing-mode: horizontal-tb;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
@@ -30,8 +30,12 @@ direction: rtl;</code></pre>
 </section>
 
 <div id="output" class="output large hidden">
-    <section id="default-example"><div class="example-container" id="example-element">
-        <div id="abspos">I am absolutely positioned with offset-block-end: 20px</div>
-        <p>As much mud in the streets as if the waters had but newly retired from the face of the earth, and it would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine lizard up Holborn Hill.</p>
-    </div></section>
+    <section id="default-example">
+        <div class="example-container" id="example-element">
+            <div id="abspos">I am absolutely positioned with inset-inline-start: 50px</div>
+            <p>As much mud in the streets as if the waters had but newly retired from the face of the earth, and it
+                would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine
+                lizard up Holborn Hill.</p>
+        </div>
+    </section>
 </div>


### PR DESCRIPTION
The offset-* logical properties have been renamed. This makes that update to the interactive examples.

See the page for inset-block-end for details of the renaming: https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block-end