### PR TITLE
Update inline text semantics examples

### DIFF
--- a/live-examples/css-examples/logical-properties/meta.json
+++ b/live-examples/css-examples/logical-properties/meta.json
@@ -182,32 +182,32 @@
             "title": "CSS Demo: min-inline-size",
             "type": "css"
         },
-        "offset-block-end": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/offset-block-end.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/offset-block-end.html",
-            "fileName": "offset-block-end.html",
-            "title": "CSS Demo: offset-block-end",
+        "inset-block-end": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-block-end.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-block-end.html",
+            "fileName": "inset-block-end.html",
+            "title": "CSS Demo: inset-block-end",
             "type": "css"
         },
-        "offset-block-start": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/offset-block-start.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/offset-block-start.html",
-            "fileName": "offset-block-start.html",
-            "title": "CSS Demo: offset-block-start",
+        "inset-block-start": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-block-start.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-block-start.html",
+            "fileName": "inset-block-start.html",
+            "title": "CSS Demo: inset-block-start",
             "type": "css"
         },
-        "offset-inline-end": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/offset-inline-end.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/offset-inline-end.html",
-            "fileName": "offset-inline-end.html",
-            "title": "CSS Demo: offset-inline-end",
+        "inset-inline-end": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-inline-end.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-inline-end.html",
+            "fileName": "inset-inline-end.html",
+            "title": "CSS Demo: inset-inline-end",
             "type": "css"
         },
-        "offset-inline-start": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/offset-inline-start.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/offset-inline-start.html",
-            "fileName": "offset-inline-start.html",
-            "title": "CSS Demo: offset-inline-start",
+        "inset-inline-start": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-inline-start.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-inline-start.html",
+            "fileName": "inset-inline-start.html",
+            "title": "CSS Demo: inset-inline-start",
             "type": "css"
         },
         "paddingBlockEnd": {

--- a/live-examples/css-examples/logical-properties/meta.json
+++ b/live-examples/css-examples/logical-properties/meta.json
@@ -126,6 +126,34 @@
             "title": "CSS Demo: inline-size",
             "type": "css"
         },
+        "inset-block-end": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-block-end.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-block-end.html",
+            "fileName": "inset-block-end.html",
+            "title": "CSS Demo: inset-block-end",
+            "type": "css"
+        },
+        "inset-block-start": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-block-start.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-block-start.html",
+            "fileName": "inset-block-start.html",
+            "title": "CSS Demo: inset-block-start",
+            "type": "css"
+        },
+        "inset-inline-end": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-inline-end.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-inline-end.html",
+            "fileName": "inset-inline-end.html",
+            "title": "CSS Demo: inset-inline-end",
+            "type": "css"
+        },
+        "inset-inline-start": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-inline-start.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-inline-start.html",
+            "fileName": "inset-inline-start.html",
+            "title": "CSS Demo: inset-inline-start",
+            "type": "css"
+        },
         "marginBlockStart": {
             "cssExampleSrc": "./live-examples/css-examples/logical-properties/margin-block.css",
             "exampleCode": "./live-examples/css-examples/logical-properties/margin-block-start.html",
@@ -180,34 +208,6 @@
             "exampleCode": "./live-examples/css-examples/logical-properties/min-inline-size.html",
             "fileName": "min-inline-size.html",
             "title": "CSS Demo: min-inline-size",
-            "type": "css"
-        },
-        "inset-block-end": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-block-end.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/inset-block-end.html",
-            "fileName": "inset-block-end.html",
-            "title": "CSS Demo: inset-block-end",
-            "type": "css"
-        },
-        "inset-block-start": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-block-start.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/inset-block-start.html",
-            "fileName": "inset-block-start.html",
-            "title": "CSS Demo: inset-block-start",
-            "type": "css"
-        },
-        "inset-inline-end": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-inline-end.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/inset-inline-end.html",
-            "fileName": "inset-inline-end.html",
-            "title": "CSS Demo: inset-inline-end",
-            "type": "css"
-        },
-        "inset-inline-start": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-inline-start.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/inset-inline-start.html",
-            "fileName": "inset-inline-start.html",
-            "title": "CSS Demo: inset-inline-start",
             "type": "css"
         },
         "paddingBlockEnd": {

--- a/live-examples/html-examples/inline-text-semantics/a.html
+++ b/live-examples/html-examples/inline-text-semantics/a.html
@@ -1,15 +1,7 @@
-<h1 id="imprint">About this Website</h1>
-
-<p>This website was made and is maintained by Michael Bluth.</p>
-
-<p>You can reach Michael via:</p>
+<p>You can reach Michael at:</p>
 
 <ul>
   <li><a href="https://example.com">Website</a></li>
-  <li><a href="mailto:michael.bluth@example.com">Email</a></li>
+  <li><a href="mailto:m.bluth@example.com">Email</a></li>
   <li><a href="tel:+123456789">Phone</a></li>
 </ul>
-
-<hr />
-
-<p><a href="#imprint">Back to top</a></p>

--- a/live-examples/html-examples/inline-text-semantics/b.html
+++ b/live-examples/html-examples/inline-text-semantics/b.html
@@ -1,1 +1,1 @@
-<p>The two most popular science courses offered by the school are <b class='term'>chemistry</b> (the study of chemicals and the composition of substances) and <b class='term'>physics</b> (the study of the nature and properties of matter and energy).</p>
+<p>The two most popular science courses offered by the school are <b class="term">chemistry</b> (the study of chemicals and the composition of substances) and <b class="term">physics</b> (the study of the nature and properties of matter and energy).</p>

--- a/live-examples/html-examples/inline-text-semantics/css/a.css
+++ b/live-examples/html-examples/inline-text-semantics/css/a.css
@@ -1,9 +1,11 @@
-a[href^="http"]::before {
-  background: url(/media/examples/external-link-alt-solid.svg) no-repeat;
-  content: '';
-  display: inline-block;
-  margin-right: 3px;
-  opacity: .6;
-  width: .9em;
-  height: .8em;
+a[href^="https"]::before {
+  content: "🔗 ";
+}
+
+a[href^="mailto"]::before {
+  content: "📧 ";
+}
+
+a[href^="tel"]::before {
+  content: "📞 ";
 }

--- a/live-examples/html-examples/inline-text-semantics/css/a.css
+++ b/live-examples/html-examples/inline-text-semantics/css/a.css
@@ -9,3 +9,7 @@ a[href^="mailto"]::before {
 a[href^="tel"]::before {
   content: "📞 ";
 }
+
+li {
+  margin-bottom: .5rem;
+}

--- a/live-examples/html-examples/inline-text-semantics/css/kbd.css
+++ b/live-examples/html-examples/inline-text-semantics/css/kbd.css
@@ -1,6 +1,13 @@
 kbd {
-    background-color: #f5f5f5;
-    border-style: solid;
-    border-width: 1px 2px 2px 1px;
-    padding: 0 1px;
-}
+    background-color: #eee;
+    border-radius: 3px;
+    border: 1px solid #b4b4b4;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, .2), 0 2px 0 0 rgba(255, 255, 255, .7) inset;
+    color: #333;
+    display: inline-block;
+    font-size: .85em;
+    font-weight: 700;
+    line-height: 1;
+    padding: 2px 4px;
+    white-space: nowrap;
+   }

--- a/live-examples/html-examples/inline-text-semantics/css/q.css
+++ b/live-examples/html-examples/inline-text-semantics/css/q.css
@@ -1,3 +1,3 @@
 q {
-
+    font-style: italic;
 }

--- a/live-examples/html-examples/inline-text-semantics/css/wbr.css
+++ b/live-examples/html-examples/inline-text-semantics/css/wbr.css
@@ -6,5 +6,5 @@
     background-color: white;
     overflow: hidden;
     resize: horizontal;
-    width: 7rem;
+    width: 9rem;
 }

--- a/live-examples/html-examples/inline-text-semantics/dfn.html
+++ b/live-examples/html-examples/inline-text-semantics/dfn.html
@@ -1,2 +1,1 @@
 <p>A <dfn id="def-validator">validator</dfn> is a program that checks for syntax errors in code or documents.</p>
-<p>A common <a href="#def-validator">validator</a> for HTML is the <a href="https://validator.w3.org/">W3C Markup Validation Service</a>.</p>

--- a/live-examples/html-examples/inline-text-semantics/em.html
+++ b/live-examples/html-examples/inline-text-semantics/em.html
@@ -1,3 +1,5 @@
 <p>Get out of bed <em>now</em>!</p>
+
 <p>We <em>had</em> to do something about it.</p>
+
 <p>This is <em>not</em> a drill!<p>

--- a/live-examples/html-examples/inline-text-semantics/kbd.html
+++ b/live-examples/html-examples/inline-text-semantics/kbd.html
@@ -1,1 +1,1 @@
-<p>Please press <kbd>Ctrl</kbd> + <kbd>F5</kbd> to re-render an MDN page.</p>
+<p>Please press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>R</kbd> to re-render an MDN page.</p>

--- a/live-examples/html-examples/inline-text-semantics/mark.html
+++ b/live-examples/html-examples/inline-text-semantics/mark.html
@@ -1,6 +1,3 @@
-<p>Search results for <strong>"tutorials"</strong>:</p>
+<p>Several species of <mark>salamander</mark> inhabit the temperate rainforest of the Pacific Northwest.</p>
 
-<ul>
-  <li><a href="https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial">Canvas <mark>tutorials</mark></a>. How to use the canvas element to draw 2D graphics, starting with the basics.</li>
-  <li><a href="https://developer.mozilla.org/en-US/docs/Learn/HTML">Learning HTML: Guides and <mark>tutorials</mark></a>. To build websites, you should know about HTML — the fundamental technology used to define the structure of a webpage.</li>
-</ul>
+<p>Most <mark>salamander</mark>s are nocturnal, and hunt for insects, worms, and other small creatures.</p>

--- a/live-examples/html-examples/inline-text-semantics/mark.html
+++ b/live-examples/html-examples/inline-text-semantics/mark.html
@@ -1,3 +1,7 @@
+<p>Search results for "salamander":</p>
+
+<hr>
+
 <p>Several species of <mark>salamander</mark> inhabit the temperate rainforest of the Pacific Northwest.</p>
 
 <p>Most <mark>salamander</mark>s are nocturnal, and hunt for insects, worms, and other small creatures.</p>

--- a/live-examples/html-examples/inline-text-semantics/meta.json
+++ b/live-examples/html-examples/inline-text-semantics/meta.json
@@ -22,7 +22,7 @@
             "fileName": "b.html",
             "title": "HTML Demo: <b>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "bdi": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/bdi.html",
@@ -62,7 +62,7 @@
             "fileName": "code.html",
             "title": "HTML Demo: <code>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "data": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/data.html",
@@ -70,7 +70,7 @@
             "fileName": "data.html",
             "title": "HTML Demo: <data>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "dfn": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/dfn.html",
@@ -78,7 +78,7 @@
             "fileName": "dfn.html",
             "title": "HTML Demo: <dfn>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "em": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/em.html",
@@ -86,7 +86,7 @@
             "fileName": "em.html",
             "title": "HTML Demo: <em>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "i": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/i.html",
@@ -94,7 +94,7 @@
             "fileName": "i.html",
             "title": "HTML Demo: <i>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "kbd": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/kbd.html",
@@ -102,7 +102,7 @@
             "fileName": "kbd.html",
             "title": "HTML Demo: <kbd>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "mark": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/mark.html",
@@ -110,7 +110,7 @@
             "fileName": "mark.html",
             "title": "HTML Demo: <mark>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "q": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/q.html",
@@ -118,7 +118,7 @@
             "fileName": "q.html",
             "title": "HTML Demo: <q>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "rb": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/rb.html",
@@ -126,7 +126,7 @@
             "fileName": "rb.html",
             "title": "HTML Demo: <rb>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "rp": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/rp.html",
@@ -134,7 +134,7 @@
             "fileName": "rp.html",
             "title": "HTML Demo: <rp>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "rt": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/rt.html",
@@ -142,7 +142,7 @@
             "fileName": "rt.html",
             "title": "HTML Demo: <rt>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "rtc": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/rtc.html",
@@ -158,7 +158,7 @@
             "fileName": "ruby.html",
             "title": "HTML Demo: <ruby>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "s": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/s.html",
@@ -166,7 +166,7 @@
             "fileName": "s.html",
             "title": "HTML Demo: <s>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "samp": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/samp.html",
@@ -174,7 +174,7 @@
             "fileName": "samp.html",
             "title": "HTML Demo: <samp>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "small": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/small.html",
@@ -182,7 +182,7 @@
             "fileName": "small.html",
             "title": "HTML Demo: <small>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "span": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/span.html",
@@ -190,7 +190,7 @@
             "fileName": "span.html",
             "title": "HTML Demo: <span>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "strong": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/strong.html",
@@ -198,7 +198,7 @@
             "fileName": "strong.html",
             "title": "HTML Demo: <strong>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "sub": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/sub.html",
@@ -206,7 +206,7 @@
             "fileName": "sub.html",
             "title": "HTML Demo: <sub>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "sup": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/sup.html",
@@ -214,7 +214,7 @@
             "fileName": "sup.html",
             "title": "HTML Demo: <sup>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "time": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/time.html",
@@ -222,7 +222,7 @@
             "fileName": "time.html",
             "title": "HTML Demo: <time>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "u": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/u.html",
@@ -230,7 +230,7 @@
             "fileName": "u.html",
             "title": "HTML Demo: <u>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "var": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/var.html",
@@ -238,7 +238,7 @@
             "fileName": "var.html",
             "title": "HTML Demo: <var>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "wbr": {
             "exampleCode": "./live-examples/html-examples/inline-text-semantics/wbr.html",
@@ -246,7 +246,7 @@
             "fileName": "wbr.html",
             "title": "HTML Demo: <wbr>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         }
     }
 }

--- a/live-examples/html-examples/inline-text-semantics/q.html
+++ b/live-examples/html-examples/inline-text-semantics/q.html
@@ -1,1 +1,1 @@
-<p>In <cite>2001: A Space Odyssey</cite>, Dave asks HAL to open the pod bay door and HAL answers: <q cite="https://www.imdb.com/title/tt0062622/quotes/qt0396921">I'm sorry, Dave. I'm afraid I can't do that.</q></p>
+<p>When Dave asks HAL to open the pod bay door, HAL answers: <q cite="https://www.imdb.com/title/tt0062622/quotes/qt0396921">I'm sorry, Dave. I'm afraid I can't do that.</q></p>

--- a/live-examples/html-examples/inline-text-semantics/s.html
+++ b/live-examples/html-examples/inline-text-semantics/s.html
@@ -1,2 +1,3 @@
 <p><s>There will be a few tickets available at the box office tonight.</s><p>
+
 <p>SOLD OUT!</p>

--- a/live-examples/html-examples/inline-text-semantics/samp.html
+++ b/live-examples/html-examples/inline-text-semantics/samp.html
@@ -1,2 +1,3 @@
-<p>I was trying to boot my computer, but I got this hilarious message:<p>
-<p><samp>Keyboard not found <br> Press F1 to continue<samp><p>
+<p>I was trying to boot my computer, but I got this hilarious message:</p>
+
+<p><samp>Keyboard not found <br>Press F1 to continue</samp></p>

--- a/live-examples/html-examples/inline-text-semantics/small.html
+++ b/live-examples/html-examples/inline-text-semantics/small.html
@@ -1,3 +1,5 @@
-<p>MDN Web Docs is an evolving learning platform for Web technologies and the software that powers the Web.</p>
+<p>MDN Web Docs is a learning platform for Web technologies and the software that powers the Web.</p>
+
 <hr>
-<p><small>The content is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/2.5/">Creative Commons Attribution-ShareAlike 2.5 Generic License</a> and by using this site, you agree to our <a href="https://www.mozilla.org/en-US/about/legal/terms/mozilla/">Terms of Use</a> and our <a href="https://www.mozilla.org/en-US/privacy/websites/">Privacy Policy</a></small>.</p>
+
+<p><small>The content is licensed under a Creative Commons Attribution-ShareAlike 2.5 Generic License.</small></p>

--- a/live-examples/html-examples/inline-text-semantics/span.html
+++ b/live-examples/html-examples/inline-text-semantics/span.html
@@ -1,5 +1,3 @@
-<ol>
-    <li>Add the <span class="ingredient">basil</span>, <span class="ingredient">pine nuts</span> and <span class="ingredient">garlic</span> to a blender and blend into a paste.</li>
-    <li>Gradually add the <span class="ingredient">olive oil</span> while running the blender slowly.</li>
-    <li>Mix in the <span class="ingredient">Parmesan</span>. Add <span class="ingredient">salt</span> to taste and plenty of <span class="ingredient">black pepper</span>.</li>
- </ol>
+<p>Add the <span class="ingredient">basil</span>, <span class="ingredient">pine nuts</span> and <span class="ingredient">garlic</span> to a blender and blend into a paste.</p>
+
+<p>Gradually add the <span class="ingredient">olive oil</span> while running the blender slowly.</p>

--- a/live-examples/html-examples/inline-text-semantics/sup.html
+++ b/live-examples/html-examples/inline-text-semantics/sup.html
@@ -1,5 +1,3 @@
 <p>The <b>Pythagorean theorem</b> is often expressed as the following equation:</p>
 
 <p><var>a<sup>2</sup></var> + <var>b<sup>2</sup></var> = <var>c<sup>2</sup></var></p>
-
-<p>Here <var>c</var> represents the length of the hypotenuse, while <var>a</var> and <var>b</var> represent the lengths of the other two sides.</p>

--- a/live-examples/html-examples/inline-text-semantics/time.html
+++ b/live-examples/html-examples/inline-text-semantics/time.html
@@ -1,3 +1,3 @@
-<p>The Cure will be celebrating their 40th anniversary on <time datetime="2018-07-07">July 7</time> in London Hyde Park.</p>
+<p>The Cure will be celebrating their 40th anniversary on <time datetime="2018-07-07">July 7</time> in London's Hyde Park.</p>
 
-<p>The concert starts at <time>20:00</time> and you'll be able to enjoy the band for at least <time>2h 30m</time>.</p>
+<p>The concert starts at <time datetime="20:00">20:00</time> and you'll be able to enjoy the band for at least <time datetime="PT2H30M">2h 30m</time>.</p>


### PR DESCRIPTION
Part of #1138: this part addressed the examples in the "inline text semantics" category, following the notes in column C of https://docs.google.com/spreadsheets/d/1EC23mRNF7i-Bd29A4wEcFV_iiThL1P-NBtH4lzme8eM/edit#gid=0.

Note that this also include https://github.com/mdn/interactive-examples/pull/1217, since I needed that to test the examples.

Mostly these are quite small updates: simplifying the markup, changing the formatting for readability. I've also made most of them use the shorter editor since they tend to be very short examples.