### PR TITLE
Update interactive elements examples

### DIFF
--- a/live-examples/css-examples/logical-properties/meta.json
+++ b/live-examples/css-examples/logical-properties/meta.json
@@ -182,32 +182,32 @@
             "title": "CSS Demo: min-inline-size",
             "type": "css"
         },
-        "offset-block-end": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/offset-block-end.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/offset-block-end.html",
-            "fileName": "offset-block-end.html",
-            "title": "CSS Demo: offset-block-end",
+        "inset-block-end": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-block-end.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-block-end.html",
+            "fileName": "inset-block-end.html",
+            "title": "CSS Demo: inset-block-end",
             "type": "css"
         },
-        "offset-block-start": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/offset-block-start.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/offset-block-start.html",
-            "fileName": "offset-block-start.html",
-            "title": "CSS Demo: offset-block-start",
+        "inset-block-start": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-block-start.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-block-start.html",
+            "fileName": "inset-block-start.html",
+            "title": "CSS Demo: inset-block-start",
             "type": "css"
         },
-        "offset-inline-end": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/offset-inline-end.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/offset-inline-end.html",
-            "fileName": "offset-inline-end.html",
-            "title": "CSS Demo: offset-inline-end",
+        "inset-inline-end": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-inline-end.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-inline-end.html",
+            "fileName": "inset-inline-end.html",
+            "title": "CSS Demo: inset-inline-end",
             "type": "css"
         },
-        "offset-inline-start": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/offset-inline-start.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/offset-inline-start.html",
-            "fileName": "offset-inline-start.html",
-            "title": "CSS Demo: offset-inline-start",
+        "inset-inline-start": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-inline-start.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-inline-start.html",
+            "fileName": "inset-inline-start.html",
+            "title": "CSS Demo: inset-inline-start",
             "type": "css"
         },
         "paddingBlockEnd": {

--- a/live-examples/css-examples/logical-properties/meta.json
+++ b/live-examples/css-examples/logical-properties/meta.json
@@ -126,6 +126,34 @@
             "title": "CSS Demo: inline-size",
             "type": "css"
         },
+        "inset-block-end": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-block-end.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-block-end.html",
+            "fileName": "inset-block-end.html",
+            "title": "CSS Demo: inset-block-end",
+            "type": "css"
+        },
+        "inset-block-start": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-block-start.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-block-start.html",
+            "fileName": "inset-block-start.html",
+            "title": "CSS Demo: inset-block-start",
+            "type": "css"
+        },
+        "inset-inline-end": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-inline-end.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-inline-end.html",
+            "fileName": "inset-inline-end.html",
+            "title": "CSS Demo: inset-inline-end",
+            "type": "css"
+        },
+        "inset-inline-start": {
+            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-inline-start.css",
+            "exampleCode": "./live-examples/css-examples/logical-properties/inset-inline-start.html",
+            "fileName": "inset-inline-start.html",
+            "title": "CSS Demo: inset-inline-start",
+            "type": "css"
+        },
         "marginBlockStart": {
             "cssExampleSrc": "./live-examples/css-examples/logical-properties/margin-block.css",
             "exampleCode": "./live-examples/css-examples/logical-properties/margin-block-start.html",
@@ -180,34 +208,6 @@
             "exampleCode": "./live-examples/css-examples/logical-properties/min-inline-size.html",
             "fileName": "min-inline-size.html",
             "title": "CSS Demo: min-inline-size",
-            "type": "css"
-        },
-        "inset-block-end": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-block-end.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/inset-block-end.html",
-            "fileName": "inset-block-end.html",
-            "title": "CSS Demo: inset-block-end",
-            "type": "css"
-        },
-        "inset-block-start": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-block-start.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/inset-block-start.html",
-            "fileName": "inset-block-start.html",
-            "title": "CSS Demo: inset-block-start",
-            "type": "css"
-        },
-        "inset-inline-end": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-inline-end.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/inset-inline-end.html",
-            "fileName": "inset-inline-end.html",
-            "title": "CSS Demo: inset-inline-end",
-            "type": "css"
-        },
-        "inset-inline-start": {
-            "cssExampleSrc": "./live-examples/css-examples/logical-properties/inset-inline-start.css",
-            "exampleCode": "./live-examples/css-examples/logical-properties/inset-inline-start.html",
-            "fileName": "inset-inline-start.html",
-            "title": "CSS Demo: inset-inline-start",
             "type": "css"
         },
         "paddingBlockEnd": {

--- a/live-examples/html-examples/interactive-elements/meta.json
+++ b/live-examples/html-examples/interactive-elements/meta.json
@@ -6,7 +6,7 @@
             "fileName": "details.html",
             "title": "HTML Demo: <details>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         },
         "summary": {
             "exampleCode": "./live-examples/html-examples/interactive-elements/summary.html",
@@ -14,7 +14,7 @@
             "fileName": "summary.html",
             "title": "HTML Demo: <summary>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         }
     }
 }


### PR DESCRIPTION
Part of #1138: this part addressed the examples in the "interactive elements" category, following the notes in column C of https://docs.google.com/spreadsheets/d/1EC23mRNF7i-Bd29A4wEcFV_iiThL1P-NBtH4lzme8eM/edit#gid=0.

Note that this also include #1217, since I needed that to test the examples.

Tiny changes - there are only 2 examples and they are nice and simple already. I've just set the editor to "shorter" for them both.