### PR TITLE
Update table content examples

### DIFF
--- a/live-examples/html-examples/table-content/caption.html
+++ b/live-examples/html-examples/table-content/caption.html
@@ -6,6 +6,11 @@
         <th scope="col" class="skeletor">Skeletor</th>
     </tr>
     <tr>
+        <th scope="row">Role</th>
+        <td>Hero</td>
+        <td>Villain</td>
+    </tr>
+    <tr>
         <th scope="row">Weapon</th>
         <td>Power Sword</td>
         <td>Havoc Staff</td>

--- a/live-examples/html-examples/table-content/caption.html
+++ b/live-examples/html-examples/table-content/caption.html
@@ -1,14 +1,9 @@
 <table>
     <caption>He-Man and Skeletor facts</caption>
     <tr>
-        <td>&nbsp;</td>
-        <th scope="col"><span class="heman">He-Man</span></th>
-        <th scope="col"><span class="skeletor">Skeletor</span></th>
-    </tr>
-    <tr>
-        <th scope="row">Role</th>
-        <td>Hero</td>
-        <td>Villain</td>
+        <td> </td>
+        <th scope="col" class="heman">He-Man</th>
+        <th scope="col" class="skeletor">Skeletor</th>
     </tr>
     <tr>
         <th scope="row">Weapon</th>

--- a/live-examples/html-examples/table-content/col.html
+++ b/live-examples/html-examples/table-content/col.html
@@ -6,7 +6,7 @@
         <col span="2" class="flash">
     </colgroup>
     <tr>
-        <td>&nbsp;</td>
+        <td> </td>
         <th scope="col">Batman</th>
         <th scope="col">Robin</th>
         <th scope="col">The Flash</th>
@@ -18,12 +18,5 @@
         <td>Dex, acrobat</td>
         <td>Super speed</td>
         <td>Super speed</td>
-    </tr>
-    <tr>
-        <th scope="row">Weapon</th>
-        <td>Martial, gadgets</td>
-        <td>Martial, gadgets</td>
-        <td>Martial</td>
-        <td>Martial</td>
     </tr>
 </table>

--- a/live-examples/html-examples/table-content/colgroup.html
+++ b/live-examples/html-examples/table-content/colgroup.html
@@ -6,7 +6,7 @@
         <col span="2" class="flash">
     </colgroup>
     <tr>
-        <td>&nbsp;</td>
+        <td> </td>
         <th scope="col">Batman</th>
         <th scope="col">Robin</th>
         <th scope="col">The Flash</th>
@@ -18,12 +18,5 @@
         <td>Dex, acrobat</td>
         <td>Super speed</td>
         <td>Super speed</td>
-    </tr>
-    <tr>
-        <th scope="row">Weapon</th>
-        <td>Martial, gadgets</td>
-        <td>Martial, gadgets</td>
-        <td>Martial</td>
-        <td>Martial</td>
     </tr>
 </table>

--- a/live-examples/html-examples/table-content/css/caption.css
+++ b/live-examples/html-examples/table-content/css/caption.css
@@ -14,7 +14,7 @@ table {
 td,
 th {
     border: 1px solid rgb(190, 190, 190);
-    padding: 7px 15px;
+    padding: 7px 5px;
 }
 
 th {

--- a/live-examples/html-examples/table-content/meta.json
+++ b/live-examples/html-examples/table-content/meta.json
@@ -6,7 +6,7 @@
             "fileName": "caption.html",
             "title": "HTML Demo: <caption>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-taller"
         },
         "col": {
             "exampleCode": "./live-examples/html-examples/table-content/col.html",
@@ -14,7 +14,7 @@
             "fileName": "col.html",
             "title": "HTML Demo: <col>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-taller"
         },
         "colgroup": {
             "exampleCode": "./live-examples/html-examples/table-content/colgroup.html",
@@ -22,7 +22,7 @@
             "fileName": "colgroup.html",
             "title": "HTML Demo: <colgroup>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-taller"
         },
         "table": {
             "exampleCode": "./live-examples/html-examples/table-content/table.html",
@@ -30,7 +30,7 @@
             "fileName": "table.html",
             "title": "HTML Demo: <table>",
             "type": "tabbed",
-            "height": "tabbed-taller"
+            "height": "tabbed-standard"
         },
         "tbody": {
             "exampleCode": "./live-examples/html-examples/table-content/tbody.html",
@@ -38,7 +38,7 @@
             "fileName": "tbody.html",
             "title": "HTML Demo: <tbody>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-taller"
         },
         "td": {
             "exampleCode": "./live-examples/html-examples/table-content/td.html",
@@ -46,7 +46,7 @@
             "fileName": "td.html",
             "title": "HTML Demo: <td>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-taller"
         },
         "tfoot": {
             "exampleCode": "./live-examples/html-examples/table-content/tfoot.html",
@@ -54,7 +54,7 @@
             "fileName": "tfoot.html",
             "title": "HTML Demo: <tfoot>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-taller"
         },
         "th": {
             "exampleCode": "./live-examples/html-examples/table-content/th.html",
@@ -62,7 +62,7 @@
             "fileName": "th.html",
             "title": "HTML Demo: <th>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-taller"
         },
         "thead": {
             "exampleCode": "./live-examples/html-examples/table-content/thead.html",
@@ -70,7 +70,7 @@
             "fileName": "thead.html",
             "title": "HTML Demo: <thead>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-taller"
         },
         "tr": {
             "exampleCode": "./live-examples/html-examples/table-content/tr.html",
@@ -78,7 +78,7 @@
             "fileName": "tr.html",
             "title": "HTML Demo: <tr>",
             "type": "tabbed",
-            "height": "tabbed-standard"
+            "height": "tabbed-taller"
         }
     }
 }

--- a/live-examples/html-examples/table-content/table.html
+++ b/live-examples/html-examples/table-content/table.html
@@ -10,9 +10,4 @@
             <td>with two columns</td>
         </tr>
     </tbody>
-    <tfoot>
-        <tr>
-            <td colspan="2">The table footer</td>
-        </tr>
-    </tfoot>
 </table>

--- a/live-examples/html-examples/table-content/tbody.html
+++ b/live-examples/html-examples/table-content/tbody.html
@@ -1,29 +1,19 @@
 <table>
-    <caption>Council budgets (in £) 2018</caption>
+    <caption>Council budget (in £) 2018</caption>
     <thead>
         <tr>
             <th>Items</th>
-            <th scope="col">Yorkshire</th>
-            <th scope="col">Lancashire</th>
+            <th scope="col">Expenditure</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <th scope="row">Donuts</th>
             <td>3,000</td>
-            <td>5,000</td>
         </tr>
         <tr>
             <th scope="row">Stationary</th>
             <td>18,000</td>
-            <td>17,000</td>
         </tr>
     </tbody>
-    <tfoot>
-        <tr>
-            <th scope="row">Totals</th>
-            <td>21,000</td>
-            <td>22,000</td>
-        </tr>
-    </tfoot>
 </table>

--- a/live-examples/html-examples/table-content/tfoot.html
+++ b/live-examples/html-examples/table-content/tfoot.html
@@ -1,29 +1,24 @@
 <table>
-    <caption>Council budgets (in £) 2018</caption>
     <thead>
         <tr>
             <th>Items</th>
-            <th scope="col">Yorkshire</th>
-            <th scope="col">Lancashire</th>
+            <th scope="col">Expenditure</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <th scope="row">Donuts</th>
             <td>3,000</td>
-            <td>5,000</td>
         </tr>
         <tr>
             <th scope="row">Stationary</th>
             <td>18,000</td>
-            <td>17,000</td>
         </tr>
     </tbody>
     <tfoot>
         <tr>
             <th scope="row">Totals</th>
             <td>21,000</td>
-            <td>22,000</td>
         </tr>
     </tfoot>
 </table>

--- a/live-examples/html-examples/table-content/thead.html
+++ b/live-examples/html-examples/table-content/thead.html
@@ -1,29 +1,19 @@
 <table>
-    <caption>Council budgets (in £) 2018</caption>
+    <caption>Council budget (in £) 2018</caption>
     <thead>
         <tr>
             <th>Items</th>
-            <th scope="col">Yorkshire</th>
-            <th scope="col">Lancashire</th>
+            <th scope="col">Expenditure</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <th scope="row">Donuts</th>
             <td>3,000</td>
-            <td>5,000</td>
         </tr>
         <tr>
             <th scope="row">Stationary</th>
             <td>18,000</td>
-            <td>17,000</td>
         </tr>
     </tbody>
-    <tfoot>
-        <tr>
-            <th scope="row">Totals</th>
-            <td>21,000</td>
-            <td>22,000</td>
-        </tr>
-    </tfoot>
 </table>


### PR DESCRIPTION
Part of #1138: this part addressed the examples in the "table content" category, following the notes in column C of https://docs.google.com/spreadsheets/d/1EC23mRNF7i-Bd29A4wEcFV_iiThL1P-NBtH4lzme8eM/edit#gid=0.

The problem with this category is, the examples look fine but it's not really possible to show these elements outside the context of a table. This has a couple of consequences:

* it's hard to see the target of an example right away, because there's so much markup
* it's very hard to write markup for a table that fits into 14 lines, which is all we get for the "standard" height editor.

I don't like using the "taller" editor (23 lines) but I don't really see an alternative here.

So what I've done is:
* trimmed the examples to fit inside 23 lines, and to simplify them as much as I could
* set them to "taller" in meta.json

I'm open to improvement suggestions, but don't really have a better idea here.
