### PR TITLE
fix issues with the Jenkins build step

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -x
 cd "$(dirname ${BASH_SOURCE[0]})"/..
 echo "Starting build"
-docker run -v "$PWD":/mdn -w /mdn node:latest bash -c "/usr/local/bin/npm install && /usr/local/bin/npm run build"
-echo "Build finished"
+docker run -v "$PWD":/mdn -w /mdn node:latest bash -c "rm -rf node_modules && /usr/local/bin/npm install && /usr/local/bin/npm run build"
+if [ $? -eq 0 ]; then
+    echo "Build finished"
+    exit 0
+else
+    echo "Build failed" >&2
+    exit 1
+fi


### PR DESCRIPTION
This PR resolves #1211 such that hopefully its root cause never happens again:
* remove the `node_modules` directory prior to calling `npm install` in order to prevent install failures due to conflicts between the contents of the `node_modules` directory leftover from the previous install and the current install
* `bin/build.sh` failures are no longer silent

This has been tested on Jenkins using a special test branch (`ryan-test`), both for the case of a successful build as well as for the case of a build failure.