### PR TITLE
Make the first Math.round example simpler

### DIFF
--- a/live-examples/js-examples/math/math-round.html
+++ b/live-examples/js-examples/math/math-round.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">console.log(Math.round(0.9))
+<code id="static-js">console.log(Math.round(0.9));
 // expected output: 1
 
 console.log(Math.round(5.95), Math.round(5.5), Math.round(5.05));

--- a/live-examples/js-examples/math/math-round.html
+++ b/live-examples/js-examples/math/math-round.html
@@ -1,5 +1,8 @@
 <pre>
-<code id="static-js">console.log(Math.round(5.95), Math.round(5.5), Math.round(5.05));
+<code id="static-js">console.log(Math.round(0.9))
+// expected output: 1
+
+console.log(Math.round(5.95), Math.round(5.5), Math.round(5.05));
 // expected output: 6 6 5
 
 console.log(Math.round(-5.05), Math.round(-5.5), Math.round(-5.95));


### PR DESCRIPTION
It confusing that there are three arguments to the first console.log also since the NodeSchool.io has a chapter about rounding numbers.