### PR TITLE
Provide valid and more semantic HTML with <audio>

### DIFF
--- a/live-examples/html-examples/image-and-multimedia/audio.html
+++ b/live-examples/html-examples/image-and-multimedia/audio.html
@@ -1,8 +1,9 @@
-<label for="t-rex-roar">Listen to the T-Rex:</label>
-
-<audio
-    id="t-rex-roar"
-    controls
-    src="/media/examples/t-rex-roar.mp3">
-    Your browser does not support the <code>audio</code> element.
-</audio>
+<figure>
+    <figcaption>Listen to the T-Rex:</figcaption>
+    <audio
+        controls
+        src="/media/examples/t-rex-roar.mp3">
+            Your browser does not support the
+            <code>audio</code> element.
+    </audio>
+</figure>

--- a/live-examples/html-examples/image-and-multimedia/css/audio.css
+++ b/live-examples/html-examples/image-and-multimedia/css/audio.css
@@ -1,4 +1,4 @@
-label {
+figcaption {
     font-size: 1rem;
     display: block;
 }


### PR DESCRIPTION
The old example used <label>, which while permitted in this context, the
value of `for` must be a labelable form element. In HTML 5.2, that list
is at https://www.w3.org/TR/html/sec-forms.html#labelable-element (W3C)
https://html.spec.whatwg.org/multipage/forms.html#category-label (TLS).
Because <audio> is not in that list, the previous example triggered
validation errors with both the W3C and WHATWG validators.

I have rewritten the example with a more accessible, semantic solution
using the <figure> element. The accompanying <figcaption> serves a more
semantic role than <label> in this context.

I've also updated the CSS for example, although it is kind of
superfluous.