### PR TITLE
Added grid-area label indicators to div content

### DIFF
--- a/live-examples/css-examples/grid/grid-template-areas.html
+++ b/live-examples/css-examples/grid/grid-template-areas.html
@@ -34,9 +34,9 @@
     <section id="default-example" class="default-example">
         <div class="example-container">
             <div id="example-element" class="transition-all">
-                <div>One</div>
-                <div>Two</div>
-                <div>Three</div>
+                <div>One (a)</div>
+                <div>Two (b)</div>
+                <div>Three (c)</div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
Clarifies the relationship between the divs in the rendered HTML and the the grid-area names in the grid-template-areas strings. For someone unfamiliar with the concepts already, the relationship between "One" "Two" and "Three" in the rendered HTML and "a" "b" and "c"  in the demo code can be confusing.