### PR TITLE
Put prefixed sticky value before standard value

### DIFF
--- a/live-examples/css-examples/positioned-layout/position.html
+++ b/live-examples/css-examples/positioned-layout/position.html
@@ -23,8 +23,8 @@ top: 40px; left: 40px;</code></pre>
     </div>
 
     <div id="choice-sticky" class="example-choice">
-        <pre><code class="language-css">position: sticky;
-position: -webkit-sticky;
+        <pre><code class="language-css">position: -webkit-sticky;
+position: sticky;
 top: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>


### PR DESCRIPTION
Right now, the `position:sticky` demo CSS lists the prefixed value after the standard value.

Best practice is to use the opposite ordering -- putting the standard value last -- which ensures that it "wins" in cases where the browser supports both prefixed & unprefixed keywords and has quirky legacy behavior for the prefixed value.