### PR TITLE
Use foo-bar convention

### DIFF
--- a/live-examples/js-examples/expressions/expressions-deleteoperator.html
+++ b/live-examples/js-examples/expressions/expressions-deleteoperator.html
@@ -1,11 +1,11 @@
 <pre>
 <code id="static-js">var Employee = {
-  firstname: "Mohammed",
-  lastname: "Haddad"
+  firstname: "foo",
+  lastname: "bar"
 }
 
 console.log(Employee.firstname);
-// expected output: "Mohammed"
+// expected output: "foo"
 
 delete Employee.firstname;
 


### PR DESCRIPTION
Generic the code by replacing the human names with `foo-bar` convention instead