### PR TITLE
Add example for window.alert

### DIFF
--- a/live-examples/js-examples/window/meta.json
+++ b/live-examples/js-examples/window/meta.json
@@ -1,0 +1,10 @@
+{
+    "pages": {
+        "stringCharAt": {
+            "exampleCode": "./live-examples/js-examples/window/window-alert.html",
+            "fileName": "window-alert.html",
+            "title": "JavaScript Demo: window.alert()",
+            "type": "js"
+        }
+    }
+}

--- a/live-examples/js-examples/window/window-alert.html
+++ b/live-examples/js-examples/window/window-alert.html
@@ -1,0 +1,4 @@
+<pre>
+<code id="static-js">alert('Hello');
+</code>
+</pre>


### PR DESCRIPTION
There is no interactive examples for window.alert which I found really sad because that is some of the most fun part to learn at the start about JavaScript 😄 

https://developer.mozilla.org/en-US/docs/Web/API/Window/alert

So I made this PR because I couldn't find any examples about `alert` either. So now I am trying to add it all the way.

Btw. couldn't docs inject a editor into for example the alert wiki page and make the static examples interactive? Like there is already a example, but you just can interact with it on the page: https://developer.mozilla.org/en-US/docs/Web/API/Window/alert

Is there any reason for that? 