### PR TITLE
Add CSS Examples for scrollbar-color and scrollbar-width

### DIFF
--- a/live-examples/css-examples/scrollbars/meta.json
+++ b/live-examples/css-examples/scrollbars/meta.json
@@ -1,0 +1,18 @@
+{
+  "pages": {
+      "scrollbar-color": {
+          "cssExampleSrc": "./live-examples/css-examples/scrollbars/scrollbar-common.css",
+          "exampleCode": "./live-examples/css-examples/scrollbars/scrollbar-color.html",
+          "fileName": "scrollbar-color.html",
+          "title": "CSS Demo: scrollbar-color",
+          "type": "css"
+      },
+      "scrollbar-width": {
+        "cssExampleSrc": "./live-examples/css-examples/scrollbars/scrollbar-common.css",
+        "exampleCode": "./live-examples/css-examples/scrollbars/scrollbar-width.html",
+        "fileName": "scrollbar-width.html",
+        "title": "CSS Demo: scrollbar-width",
+        "type": "css"
+    }
+  }
+}

--- a/live-examples/css-examples/scrollbars/scrollbar-color.html
+++ b/live-examples/css-examples/scrollbars/scrollbar-color.html
@@ -1,0 +1,37 @@
+<section
+    id="example-choice-list"
+    class="example-choice-list large"
+    data-property="scrollbar-color"
+>
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">scrollbar-color: yellow blue;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scrollbar-color: #87ceeb #ff5621;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scrollbar-color: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <div id="example-element" class="transition-all">
+            Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi
+            welsh onion daikon amaranth tatsoi tomatillo melon azuki bean
+            garlic. Gumbo beet greens corn soko endive gumbo gourd. Parsley
+            shallot courgette tatsoi pea sprouts fava bean collard greens
+            dandelion okra wakame tomato. Dandelion cucumber earthnut pea peanut
+            soko zucchini.
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/scrollbars/scrollbar-common.css
+++ b/live-examples/css-examples/scrollbars/scrollbar-common.css
@@ -1,0 +1,5 @@
+#example-element {
+    width: 300px;
+    height: 100px;
+    overflow-y: scroll;
+}

--- a/live-examples/css-examples/scrollbars/scrollbar-width.html
+++ b/live-examples/css-examples/scrollbars/scrollbar-width.html
@@ -1,0 +1,50 @@
+<section
+    id="example-choice-list"
+    class="example-choice-list large"
+    data-property="scrollbar-width"
+>
+    <div class="example-choice">
+        <pre><code class="language-css">scrollbar-width: none;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">scrollbar-width: thin;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scrollbar-width: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">scrollbar-width: 15px;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scrollbar-width: 3em;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <div id="example-element" class="transition-all">
+            Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi
+            welsh onion daikon amaranth tatsoi tomatillo melon azuki bean
+            garlic. Gumbo beet greens corn soko endive gumbo gourd. Parsley
+            shallot courgette tatsoi pea sprouts fava bean collard greens
+            dandelion okra wakame tomato. Dandelion cucumber earthnut pea peanut
+            soko zucchini.
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
Fixes #1267 

## scrollbar-color

<img width="1421" alt="screen shot 2018-12-14 at 11 08 49 pm" src="https://user-images.githubusercontent.com/3090380/50010981-cca16600-fff5-11e8-996a-9b6b7b7713f8.png">

![capture-scrollbar-color](https://user-images.githubusercontent.com/3090380/50228818-d5be7880-03e3-11e9-8cad-eefcc9086871.PNG)

### Notes

- On Firefox 65 (beta) on MacOS (10.12 Sierra) and also on Windows 10 (1809), `scrollbar-color: dark` and `scrollbar-color: light` seems not to have any effect

## scrollbar-width

<img width="1423" alt="screen shot 2018-12-14 at 11 08 37 pm" src="https://user-images.githubusercontent.com/3090380/50010979-cca16600-fff5-11e8-9f7b-3bb63a2965b2.png">

![capture-scrollbar-width](https://user-images.githubusercontent.com/3090380/50228824-dbb45980-03e3-11e9-8e41-4aa9d639a995.PNG)

### Notes

- On Firefox 65 (beta) on MacOS (10.12 Sierra) and also on Windows 10 (1809), `scrollbar-color: <length>` seems not to have any effect
