### PR TITLE
chore: remove invalid attribute in progress example

### DIFF
--- a/live-examples/html-examples/forms/progress.html
+++ b/live-examples/html-examples/forms/progress.html
@@ -1,6 +1,3 @@
 <label for="file">File progress:</label>
 
-<progress id="file" name="file"
-          max="100" value="70">
-    70%
-</progress>
+<progress id="file" max="100" value="70"> 70% </progress>


### PR DESCRIPTION
Hi mdn 👋 !!

I've contributed in the past to the main docs but never to the coding examples, hope it's ok 😄 

This PR:
- remove the invalid attribute name from the progress element example
- formats the progress element file with prettier 

The main reason for removing this is: in my personal opinion every snippet / code example should be able to be dropped in file and should just work out of the box, in this particular case, working in a TypeScript project, the `ts-server` was complaining about the name attribute not be in the `HTMLProgressElement` interface.

After cheking this [https://developer.mozilla.org/en-US/docs/Web/API/HTMLProgressElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLProgressElement) the `ts-server` was right to complaing about the name attribure so I've created this PR

Should be quite straightforward to review and merge (🤞 )
![https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

Also thanks for making the web a better place, ❤️ you mnd