### PR TITLE
New PR for scroll snap examples

### DIFF
--- a/live-examples/css-examples/scroll-snap/meta.json
+++ b/live-examples/css-examples/scroll-snap/meta.json
@@ -1,6 +1,153 @@
 {
     "pages": {
-        "scrollSnap": {
+        "scrollMargin": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-margin.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-margin.html",
+            "fileName": "scroll-margin.html",
+            "title": "CSS Demo: scroll-margin",
+            "type": "css"
+        },
+        "scrollMarginBlock": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-margin-top.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-margin-block.html",
+            "fileName": "scroll-margin-block.html",
+            "title": "CSS Demo: scroll-margin-block",
+            "type": "css"
+        },
+        "scrollMarginBlockEnd": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-margin-bottom.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-margin-block-end.html",
+            "fileName": "scroll-margin-block-end.html",
+            "title": "CSS Demo: scroll-margin-block-end",
+            "type": "css"
+        },
+        "scrollMarginBlockStart": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-margin-top.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-margin-block-start.html",
+            "fileName": "scroll-margin-block-start.html",
+            "title": "CSS Demo: scroll-margin-block-start",
+            "type": "css"
+        },
+        "scrollMarginBottom": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-margin-bottom.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-margin-bottom.html",
+            "fileName": "scroll-margin-bottom.html",
+            "title": "CSS Demo: scroll-margin-bottom",
+            "type": "css"
+        },
+        "scrollMarginInlineEnd": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-margin-right.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-margin-inline-end.html",
+            "fileName": "scroll-margin-inline-end.html",
+            "title": "CSS Demo: scroll-margin-inline-end",
+            "type": "css"
+        },
+        "scrollMarginInlineStart": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-margin.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-margin-inline-start.html",
+            "fileName": "scroll-margin-inline-start.html",
+            "title": "CSS Demo: scroll-margin-inline-start",
+            "type": "css"
+        },
+        "scrollMarginInlineRight": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-margin-right.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-margin-right.html",
+            "fileName": "scroll-margin-right.html",
+            "title": "CSS Demo: scroll-margin-right",
+            "type": "css"
+        },
+        "scrollMarginLeft": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-margin.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-margin-left.html",
+            "fileName": "scroll-margin-left.html",
+            "title": "CSS Demo: scroll-margin-left",
+            "type": "css"
+        },
+        "scrollMarginTop": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-margin-top.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-margin-top.html",
+            "fileName": "scroll-margin-top.html",
+            "title": "CSS Demo: scroll-margin-top",
+            "type": "css"
+        },
+        "scrollPadding": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-padding.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-padding.html",
+            "fileName": "scroll-padding.html",
+            "title": "CSS Demo: scroll-padding",
+            "type": "css"
+        },
+        "scrollPaddingBlock": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-padding-top.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-padding-block.html",
+            "fileName": "scroll-padding-block.html",
+            "title": "CSS Demo: scroll-padding-block",
+            "type": "css"
+        },
+        "scrollPaddingBlockEnd": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-padding-bottom.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-padding-block-end.html",
+            "fileName": "scroll-padding-block-end.html",
+            "title": "CSS Demo: scroll-padding-block-end",
+            "type": "css"
+        },
+        "scrollPaddingBottom": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-padding-bottom.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-padding-bottom.html",
+            "fileName": "scroll-padding-bottom.html",
+            "title": "CSS Demo: scroll-padding-bottom",
+            "type": "css"
+        },
+        "scrollPaddingBlockStart": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-padding-top.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-padding-block-start.html",
+            "fileName": "scroll-padding-block-start.html",
+            "title": "CSS Demo: scroll-padding-block-start",
+            "type": "css"
+        },
+        "scrollPaddingInline": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-padding.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-padding-inline.html",
+            "fileName": "scroll-padding-inline.html",
+            "title": "CSS Demo: scroll-padding-inline",
+            "type": "css"
+        },
+        "scrollPaddingInlineEnd": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-padding-right.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-padding-inline-end.html",
+            "fileName": "scroll-padding-inline-end.html",
+            "title": "CSS Demo: scroll-padding-inline-end",
+            "type": "css"
+        },
+        "scrollPaddingInlineStart": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-padding.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-padding-inline-start.html",
+            "fileName": "scroll-padding-inline-start.html",
+            "title": "CSS Demo: scroll-padding-inline-start",
+            "type": "css"
+        },
+        "scrollPaddingLeft": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-padding.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-padding-left.html",
+            "fileName": "scroll-padding-left.html",
+            "title": "CSS Demo: scroll-padding-left",
+            "type": "css"
+        },
+        "scrollPaddingRight": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-padding-right.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-padding-right.html",
+            "fileName": "scroll-padding-right.html",
+            "title": "CSS Demo: scroll-padding-right",
+            "type": "css"
+        },
+        "scrollPaddingTop": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-padding-top.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-padding-top.html",
+            "fileName": "scroll-padding-top.html",
+            "title": "CSS Demo: scroll-padding-top",
+            "type": "css"
+        },
+        "scrollSnapType": {
             "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-snap-type.css",
             "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-snap-type.html",
             "fileName": "scroll-snap-type.html",

--- a/live-examples/css-examples/scroll-snap/meta.json
+++ b/live-examples/css-examples/scroll-snap/meta.json
@@ -49,7 +49,7 @@
             "title": "CSS Demo: scroll-margin-inline-start",
             "type": "css"
         },
-        "scrollMarginInlineRight": {
+        "scrollMarginRight": {
             "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-margin-right.css",
             "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-margin-right.html",
             "fileName": "scroll-margin-right.html",

--- a/live-examples/css-examples/scroll-snap/scroll-margin-block-end.html
+++ b/live-examples/css-examples/scroll-snap/scroll-margin-block-end.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-margin-block-end">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-margin-block-end: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-margin-block-end: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-margin-block-end: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,12 +21,10 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller">
             <div>1</div>
-            <div>2</div>
+            <div id="example-element">2</div>
             <div>3</div>
         </div>
 

--- a/live-examples/css-examples/scroll-snap/scroll-margin-block-start.html
+++ b/live-examples/css-examples/scroll-snap/scroll-margin-block-start.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-margin-block-start">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-margin-block-start: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-margin-block-start: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-margin-block-start: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,12 +21,10 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller">
             <div>1</div>
-            <div>2</div>
+            <div id="example-element">2</div>
             <div>3</div>
         </div>
 

--- a/live-examples/css-examples/scroll-snap/scroll-margin-block.html
+++ b/live-examples/css-examples/scroll-snap/scroll-margin-block.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-margin-block">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-margin-block: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-margin-block: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-margin-block: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,12 +21,10 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller">
             <div>1</div>
-            <div>2</div>
+            <div id="example-element">2</div>
             <div>3</div>
         </div>
 

--- a/live-examples/css-examples/scroll-snap/scroll-margin-bottom.css
+++ b/live-examples/css-examples/scroll-snap/scroll-margin-bottom.css
@@ -1,36 +1,34 @@
-.default-example {
-    flex-wrap: wrap;
-}
-
 .default-example .info {
-    width: 100%;
+    inline-size: 100%;
     padding: .5em 0;
     font-size: 90%;
+    writing-mode: vertical-rl;
 }
 
-#example-element {
+.scroller {
     text-align: left;
-    width: 250px;
     height: 250px;
-    overflow-x: scroll;
+    width: 270px;
+    overflow-y: scroll;
     display: flex;
+    flex-direction: column;
     box-sizing: border-box;
     border: 1px solid black;
+    scroll-snap-type: y mandatory;
 }
 
-#example-element > div {
+.scroller > div {
     flex: 0 0 250px;
-    width: 250px;
     background-color: rebeccapurple;
     color: #fff;
     font-size: 30px;
     display: flex;
     align-items: center;
     justify-content: center;
-    scroll-snap-align: start;
+    scroll-snap-align: end;
 }
 
-#example-element > div:nth-child(even) {
+.scroller > div:nth-child(even) {
     background-color: #fff;
     color: rebeccapurple;
 }

--- a/live-examples/css-examples/scroll-snap/scroll-margin-bottom.html
+++ b/live-examples/css-examples/scroll-snap/scroll-margin-bottom.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-margin-bottom">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-margin-bottom: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-margin-bottom: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-margin-bottom: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,12 +21,10 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller">
             <div>1</div>
-            <div>2</div>
+            <div id="example-element">2</div>
             <div>3</div>
         </div>
 

--- a/live-examples/css-examples/scroll-snap/scroll-margin-inline-end.html
+++ b/live-examples/css-examples/scroll-snap/scroll-margin-inline-end.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-margin-inline-end">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-margin-inline-end: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-margin-inline-end: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-margin-inline-end: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,12 +21,10 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller">
             <div>1</div>
-            <div>2</div>
+            <div id="example-element">2</div>
             <div>3</div>
         </div>
 

--- a/live-examples/css-examples/scroll-snap/scroll-margin-inline-start.html
+++ b/live-examples/css-examples/scroll-snap/scroll-margin-inline-start.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-margin-inline-start">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-margin-inline-start: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-margin-inline-start: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-margin-inline-start: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,12 +21,10 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller">
             <div>1</div>
-            <div>2</div>
+            <div id="example-element">2</div>
             <div>3</div>
         </div>
 

--- a/live-examples/css-examples/scroll-snap/scroll-margin-left.html
+++ b/live-examples/css-examples/scroll-snap/scroll-margin-left.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-margin-left">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-margin-left: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-margin-left: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-margin-left: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,12 +21,10 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller">
             <div>1</div>
-            <div>2</div>
+            <div id="example-element">2</div>
             <div>3</div>
         </div>
 

--- a/live-examples/css-examples/scroll-snap/scroll-margin-right.css
+++ b/live-examples/css-examples/scroll-snap/scroll-margin-right.css
@@ -8,7 +8,7 @@
     font-size: 90%;
 }
 
-#example-element {
+.scroller {
     text-align: left;
     width: 250px;
     height: 250px;
@@ -16,9 +16,10 @@
     display: flex;
     box-sizing: border-box;
     border: 1px solid black;
+    scroll-snap-type: x mandatory;
 }
 
-#example-element > div {
+.scroller > div {
     flex: 0 0 250px;
     width: 250px;
     background-color: rebeccapurple;
@@ -27,10 +28,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    scroll-snap-align: start;
+    scroll-snap-align: end;
 }
 
-#example-element > div:nth-child(even) {
+.scroller > div:nth-child(even) {
     background-color: #fff;
     color: rebeccapurple;
 }

--- a/live-examples/css-examples/scroll-snap/scroll-margin-right.html
+++ b/live-examples/css-examples/scroll-snap/scroll-margin-right.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-margin-right">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-margin-right: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-margin-right: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-margin-right: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,12 +21,10 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller">
             <div>1</div>
-            <div>2</div>
+            <div id="example-element">2</div>
             <div>3</div>
         </div>
 

--- a/live-examples/css-examples/scroll-snap/scroll-margin-top.css
+++ b/live-examples/css-examples/scroll-snap/scroll-margin-top.css
@@ -1,26 +1,24 @@
-.default-example {
-    flex-wrap: wrap;
-}
-
 .default-example .info {
-    width: 100%;
+    inline-size: 100%;
     padding: .5em 0;
     font-size: 90%;
+    writing-mode: vertical-rl;
 }
 
-#example-element {
+.scroller {
     text-align: left;
-    width: 250px;
     height: 250px;
-    overflow-x: scroll;
+    width: 270px;
+    overflow-y: scroll;
     display: flex;
+    flex-direction: column;
     box-sizing: border-box;
     border: 1px solid black;
+    scroll-snap-type: y mandatory;
 }
 
-#example-element > div {
+.scroller > div {
     flex: 0 0 250px;
-    width: 250px;
     background-color: rebeccapurple;
     color: #fff;
     font-size: 30px;
@@ -30,7 +28,7 @@
     scroll-snap-align: start;
 }
 
-#example-element > div:nth-child(even) {
+.scroller > div:nth-child(even) {
     background-color: #fff;
     color: rebeccapurple;
 }

--- a/live-examples/css-examples/scroll-snap/scroll-margin-top.html
+++ b/live-examples/css-examples/scroll-snap/scroll-margin-top.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-margin-top">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-margin-top: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-margin-top: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-margin-top: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,12 +21,10 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller">
             <div>1</div>
-            <div>2</div>
+            <div id="example-element">2</div>
             <div>3</div>
         </div>
 

--- a/live-examples/css-examples/scroll-snap/scroll-margin.css
+++ b/live-examples/css-examples/scroll-snap/scroll-margin.css
@@ -8,7 +8,7 @@
     font-size: 90%;
 }
 
-#example-element {
+.scroller {
     text-align: left;
     width: 250px;
     height: 250px;
@@ -16,9 +16,10 @@
     display: flex;
     box-sizing: border-box;
     border: 1px solid black;
+    scroll-snap-type: x mandatory;
 }
 
-#example-element > div {
+.scroller > div {
     flex: 0 0 250px;
     width: 250px;
     background-color: rebeccapurple;
@@ -30,7 +31,7 @@
     scroll-snap-align: start;
 }
 
-#example-element > div:nth-child(even) {
+.scroller > div:nth-child(even) {
     background-color: #fff;
     color: rebeccapurple;
 }

--- a/live-examples/css-examples/scroll-snap/scroll-margin.html
+++ b/live-examples/css-examples/scroll-snap/scroll-margin.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-margin">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-margin: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-margin: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-margin: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,12 +21,10 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller">
             <div>1</div>
-            <div>2</div>
+            <div id="example-element">2</div>
             <div>3</div>
         </div>
 

--- a/live-examples/css-examples/scroll-snap/scroll-padding-block-end.html
+++ b/live-examples/css-examples/scroll-snap/scroll-padding-block-end.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-padding-block-end">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-padding-block-end: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-padding-block-end: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-padding-block-end: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,10 +21,8 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller" id="example-element">
             <div>1</div>
             <div>2</div>
             <div>3</div>

--- a/live-examples/css-examples/scroll-snap/scroll-padding-block-start.html
+++ b/live-examples/css-examples/scroll-snap/scroll-padding-block-start.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-padding-block-start">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-padding-block-start: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-padding-block-start: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-padding-block-start: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,10 +21,8 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller" id="example-element">
             <div>1</div>
             <div>2</div>
             <div>3</div>

--- a/live-examples/css-examples/scroll-snap/scroll-padding-block.html
+++ b/live-examples/css-examples/scroll-snap/scroll-padding-block.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-padding-block">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-padding-block: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-padding-block: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-padding-block: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,10 +21,8 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller" id="example-element">
             <div>1</div>
             <div>2</div>
             <div>3</div>

--- a/live-examples/css-examples/scroll-snap/scroll-padding-bottom.css
+++ b/live-examples/css-examples/scroll-snap/scroll-padding-bottom.css
@@ -1,36 +1,33 @@
-.default-example {
-    flex-wrap: wrap;
-}
-
 .default-example .info {
-    width: 100%;
+    inline-size: 100%;
     padding: .5em 0;
     font-size: 90%;
+    writing-mode: vertical-rl;
 }
-
-#example-element {
+.scroller {
     text-align: left;
-    width: 250px;
     height: 250px;
-    overflow-x: scroll;
+    width: 270px;
+    overflow-y: scroll;
     display: flex;
+    flex-direction: column;
     box-sizing: border-box;
     border: 1px solid black;
+    scroll-snap-type: y mandatory;
 }
 
-#example-element > div {
+.scroller > div {
     flex: 0 0 250px;
-    width: 250px;
     background-color: rebeccapurple;
     color: #fff;
     font-size: 30px;
     display: flex;
     align-items: center;
     justify-content: center;
-    scroll-snap-align: start;
+    scroll-snap-align: end;
 }
 
-#example-element > div:nth-child(even) {
+.scroller > div:nth-child(even) {
     background-color: #fff;
     color: rebeccapurple;
 }

--- a/live-examples/css-examples/scroll-snap/scroll-padding-bottom.html
+++ b/live-examples/css-examples/scroll-snap/scroll-padding-bottom.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-padding-bottom">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-padding-bottom: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-padding-bottom: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-padding-bottom: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,10 +21,8 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller" id="example-element">
             <div>1</div>
             <div>2</div>
             <div>3</div>

--- a/live-examples/css-examples/scroll-snap/scroll-padding-inline-end.html
+++ b/live-examples/css-examples/scroll-snap/scroll-padding-inline-end.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-padding-inline-end">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-padding-inline-end: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-padding-inline-end: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-padding-inline-end: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,10 +21,8 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller" id="example-element">
             <div>1</div>
             <div>2</div>
             <div>3</div>

--- a/live-examples/css-examples/scroll-snap/scroll-padding-inline-start.html
+++ b/live-examples/css-examples/scroll-snap/scroll-padding-inline-start.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-padding-inline-start">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-padding-inline-start: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-padding-inline-start: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-padding-inline-start: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,10 +21,8 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller" id="example-element">
             <div>1</div>
             <div>2</div>
             <div>3</div>

--- a/live-examples/css-examples/scroll-snap/scroll-padding-inline.html
+++ b/live-examples/css-examples/scroll-snap/scroll-padding-inline.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-padding-inline">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-padding-inline: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-padding-inline: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-padding-inline: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,10 +21,8 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller" id="example-element">
             <div>1</div>
             <div>2</div>
             <div>3</div>

--- a/live-examples/css-examples/scroll-snap/scroll-padding-left.html
+++ b/live-examples/css-examples/scroll-snap/scroll-padding-left.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-padding-left">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-padding-left: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-padding-left: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-padding-left: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,10 +21,8 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller" id="example-element">
             <div>1</div>
             <div>2</div>
             <div>3</div>

--- a/live-examples/css-examples/scroll-snap/scroll-padding-right.css
+++ b/live-examples/css-examples/scroll-snap/scroll-padding-right.css
@@ -8,7 +8,7 @@
     font-size: 90%;
 }
 
-#example-element {
+.scroller {
     text-align: left;
     width: 250px;
     height: 250px;
@@ -16,9 +16,10 @@
     display: flex;
     box-sizing: border-box;
     border: 1px solid black;
+    scroll-snap-type: x mandatory;
 }
 
-#example-element > div {
+.scroller > div {
     flex: 0 0 250px;
     width: 250px;
     background-color: rebeccapurple;
@@ -27,10 +28,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    scroll-snap-align: start;
+    scroll-snap-align: end;
 }
 
-#example-element > div:nth-child(even) {
+.scroller > div:nth-child(even) {
     background-color: #fff;
     color: rebeccapurple;
 }

--- a/live-examples/css-examples/scroll-snap/scroll-padding-right.html
+++ b/live-examples/css-examples/scroll-snap/scroll-padding-right.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-padding-right">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-padding-right: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-padding-right: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-padding-right: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,10 +21,8 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller" id="example-element">
             <div>1</div>
             <div>2</div>
             <div>3</div>

--- a/live-examples/css-examples/scroll-snap/scroll-padding-top.css
+++ b/live-examples/css-examples/scroll-snap/scroll-padding-top.css
@@ -1,26 +1,24 @@
-.default-example {
-    flex-wrap: wrap;
-}
-
 .default-example .info {
-    width: 100%;
+    inline-size: 100%;
     padding: .5em 0;
     font-size: 90%;
+    writing-mode: vertical-rl;
 }
 
-#example-element {
+.scroller {
     text-align: left;
-    width: 250px;
     height: 250px;
-    overflow-x: scroll;
+    width: 270px;
+    overflow-y: scroll;
     display: flex;
+    flex-direction: column;
     box-sizing: border-box;
     border: 1px solid black;
+    scroll-snap-type: y mandatory;
 }
 
-#example-element > div {
+.scroller > div {
     flex: 0 0 250px;
-    width: 250px;
     background-color: rebeccapurple;
     color: #fff;
     font-size: 30px;
@@ -30,7 +28,7 @@
     scroll-snap-align: start;
 }
 
-#example-element > div:nth-child(even) {
+.scroller > div:nth-child(even) {
     background-color: #fff;
     color: rebeccapurple;
 }

--- a/live-examples/css-examples/scroll-snap/scroll-padding-top.html
+++ b/live-examples/css-examples/scroll-snap/scroll-padding-top.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-padding-top">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-padding-top: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-padding-top: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-padding-top: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,10 +21,8 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller" id="example-element">
             <div>1</div>
             <div>2</div>
             <div>3</div>

--- a/live-examples/css-examples/scroll-snap/scroll-padding.css
+++ b/live-examples/css-examples/scroll-snap/scroll-padding.css
@@ -8,7 +8,7 @@
     font-size: 90%;
 }
 
-#example-element {
+.scroller {
     text-align: left;
     width: 250px;
     height: 250px;
@@ -16,9 +16,10 @@
     display: flex;
     box-sizing: border-box;
     border: 1px solid black;
+    scroll-snap-type: x mandatory;
 }
 
-#example-element > div {
+.scroller > div {
     flex: 0 0 250px;
     width: 250px;
     background-color: rebeccapurple;
@@ -30,7 +31,7 @@
     scroll-snap-align: start;
 }
 
-#example-element > div:nth-child(even) {
+.scroller > div:nth-child(even) {
     background-color: #fff;
     color: rebeccapurple;
 }

--- a/live-examples/css-examples/scroll-snap/scroll-padding.html
+++ b/live-examples/css-examples/scroll-snap/scroll-padding.html
@@ -1,20 +1,19 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-type">
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-padding">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">scroll-snap-type: none;</code></pre>
+        <pre><code class="language-css">scroll-padding: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-padding: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x mandatory;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">scroll-snap-type: x proximity;</code></pre>
+        <pre><code class="language-css">scroll-padding: 2em;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -22,10 +21,8 @@
 </section>
 
 <div id="output" class="output large hidden">
-
     <section id="default-example" class="default-example">
-
-        <div id="example-element">
+        <div class="scroller" id="example-element">
             <div>1</div>
             <div>2</div>
             <div>3</div>


### PR DESCRIPTION
This is a new PR to try and fix the unresolvable mess I created in my last one!

Old PR (which I will close) https://github.com/mdn/interactive-examples/pull/1260

I have added some text to each example which I help demonstrates what people are supposed to do.

I have removed `scroll-snap-align` as that shouldn't be in there until we decide what to do about this issue: https://github.com/mdn/interactive-examples/issues/1263