### PR TITLE
text-transform: full-size-kana value

### DIFF
--- a/live-examples/css-examples/text/text-transform.html
+++ b/live-examples/css-examples/text/text-transform.html
@@ -35,11 +35,20 @@
 </div>
 </section>
 
+<div class="example-choice">
+<pre><code class="language-css">text-transform: full-size-kana;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+</section>
+
 <div id="output" class="output large hidden">
     <section id="default-example">
         <div id="example-element" class="transition-all">
-            <p>London. Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather.</p>
+            <p>London. Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall.</p>
             <p>Σ is a Greek letter and appears in ΟΔΥΣΣΕΥΣ. Θα πάμε στο "Θεϊκό φαΐ" ή στη "Νεράιδα"</p>
+            <p>ァィゥェ ォヵㇰヶ</p>
         </div>
     </section>
 </div>

--- a/live-examples/css-examples/text/text-transform.html
+++ b/live-examples/css-examples/text/text-transform.html
@@ -1,4 +1,5 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="textTransform">
+
 <div class="example-choice">
 <pre><code class="language-css">text-transform: capitalize;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
@@ -33,7 +34,6 @@
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
-</section>
 
 <div class="example-choice">
 <pre><code class="language-css">text-transform: full-size-kana;</code></pre>
@@ -41,6 +41,7 @@
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
+
 </section>
 
 <div id="output" class="output large hidden">


### PR DESCRIPTION
added kana example and full-size-kana value. Works in FF only.
https://bugzilla.mozilla.org/show_bug.cgi?id=1498148
https://drafts.csswg.org/css-text-3/#propdef-text-transform
https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform