### PR TITLE
Replace H1 with H2 in multiple sections example

### DIFF
--- a/live-examples/html-examples/content-sectioning/section.html
+++ b/live-examples/html-examples/content-sectioning/section.html
@@ -1,9 +1,9 @@
 <section>
-    <h1>Introduction</h1>
+    <h2>Introduction</h2>
     <p>People have been catching fish for food since before recorded history...</p>
 </section>
 
 <section>
-    <h1>Equipment</h1>
+    <h2>Equipment</h2>
     <p>The first thing you'll need is a fishing rod or pole that you find comfortable and is strong enough for the kind of fish you're expecting to try to land...</p>
 </section>


### PR DESCRIPTION
Having several H1 on the same page is not recommended. Citing MDN itself https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements
"You should consider avoiding using < h1 > more than once on a page. See Defining sections in Using HTML sections and outlines for more information."

Update this multiple section example to replace use of H1 elements with H2, as it does not reflect the best practice to have several H1.