### PR TITLE
Add more Intl.RelativeTimeFormat examples

### DIFF
--- a/live-examples/js-examples/intl/intl-relativetimeformat-prototype-format.html
+++ b/live-examples/js-examples/intl/intl-relativetimeformat-prototype-format.html
@@ -1,0 +1,13 @@
+<pre>
+<code id="static-js">var rtf1 = new Intl.RelativeTimeFormat('en', { style: 'narrow' });
+
+console.log(rtf1.format(3, 'quarter'));
+// expected output: "in 3 qtrs."
+
+console.log(rtf1.format(-1, 'day'));
+// expected output: "1 day ago"
+
+console.log(rtf1.format(10, 'seconds'));
+// expected output: "in 10 sec."
+</code>
+</pre>

--- a/live-examples/js-examples/intl/intl-relativetimeformat-prototype-formattoparts.html
+++ b/live-examples/js-examples/intl/intl-relativetimeformat-prototype-formattoparts.html
@@ -1,0 +1,11 @@
+<pre>
+<code id="static-js">var rtf1 = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+console.log(rtf1.formatToParts(-1, 'day'));
+// expected output: [{ type: "literal", value: "yesterday"}]
+
+console.log(rtf1.formatToParts(10, 'seconds'));
+// expected output:  [{ type: "literal", value: "in " },
+//                    { type: "integer", value: "10", unit: "second" },
+//                    { type: "literal", value: " seconds" }]
+</code>
+</pre>

--- a/live-examples/js-examples/intl/intl-relativetimeformat-prototype-formattoparts.html
+++ b/live-examples/js-examples/intl/intl-relativetimeformat-prototype-formattoparts.html
@@ -1,11 +1,14 @@
 <pre>
 <code id="static-js">var rtf1 = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
-console.log(rtf1.formatToParts(-1, 'day'));
-// expected output: [{ type: "literal", value: "yesterday"}]
+var parts = rtf1.formatToParts(10, 'seconds');
 
-console.log(rtf1.formatToParts(10, 'seconds'));
-// expected output:  [{ type: "literal", value: "in " },
-//                    { type: "integer", value: "10", unit: "second" },
-//                    { type: "literal", value: " seconds" }]
+console.log(parts[0].value);
+// expected output: "in "
+
+console.log(parts[1].value);
+// expected output: "10"
+
+console.log(parts[2].value);
+// expected output: " seconds"
 </code>
 </pre>

--- a/live-examples/js-examples/intl/intl-relativetimeformat-prototype-resolvedoptions.html
+++ b/live-examples/js-examples/intl/intl-relativetimeformat-prototype-resolvedoptions.html
@@ -1,0 +1,15 @@
+<pre>
+<code id="static-js">var rtf1 = new Intl.RelativeTimeFormat('de-DE');
+var options1 = rtf1.resolvedOptions();
+
+console.log(options1.locale);
+// expected output (Firefox / Safari): "de-DE"
+// expected output (Chrome): "de"
+
+console.log(options1.style);
+// expected output: "long"
+
+console.log(options1.numeric);
+// expected output: "always"
+</code>
+</pre>

--- a/live-examples/js-examples/intl/intl-relativetimeformat-prototype-resolvedoptions.html
+++ b/live-examples/js-examples/intl/intl-relativetimeformat-prototype-resolvedoptions.html
@@ -1,15 +1,14 @@
 <pre>
-<code id="static-js">var rtf1 = new Intl.RelativeTimeFormat('de-DE');
+<code id="static-js">var rtf1 = new Intl.RelativeTimeFormat('en', { style: 'narrow' });
 var options1 = rtf1.resolvedOptions();
 
-console.log(options1.locale);
-// expected output (Firefox / Safari): "de-DE"
-// expected output (Chrome): "de"
+var rtf2 = new Intl.RelativeTimeFormat('es', { numeric: 'auto' });
+var options2 = rtf2.resolvedOptions();
 
-console.log(options1.style);
-// expected output: "long"
+console.log(`${options1.locale}, ${options1.style}, ${options1.numeric}`);
+// expected output: "en, narrow, always"
 
-console.log(options1.numeric);
-// expected output: "always"
+console.log(`${options2.locale}, ${options2.style}, ${options2.numeric}`);
+// expected output: "es, long, auto"
 </code>
 </pre>

--- a/live-examples/js-examples/intl/intl-relativetimeformat-supportedlocalesof.html
+++ b/live-examples/js-examples/intl/intl-relativetimeformat-supportedlocalesof.html
@@ -1,0 +1,9 @@
+<pre>
+<code id="static-js">var locales1 = ['ban', 'id-u-co-pinyin', 'de-ID'];
+var options1 = { localeMatcher: 'lookup' };
+
+console.log(Intl.RelativeTimeFormat.supportedLocalesOf(locales1, options1));
+// expected output: Array ["id-u-co-pinyin", "de-ID"]
+// (Note: the exact output may be browser-dependent)
+</code>
+</pre>

--- a/live-examples/js-examples/intl/meta.json
+++ b/live-examples/js-examples/intl/meta.json
@@ -89,6 +89,30 @@
             "fileName": "intl-relativetimeformat.html",
             "title": "JavaScript Demo: Intl.RelativeTimeFormat",
             "type": "js"
+        },
+        "intlRelativeTimeFormatPrototypeFormat": {
+            "exampleCode": "./live-examples/js-examples/intl/intl-relativetimeformat-prototype-format.html",
+            "fileName": "intl-relativetimeformat-prototype-format.html",
+            "title": "JavaScript Demo: Intl.RelativeTimeFormat.prototype.format",
+            "type": "js"
+        },
+        "intlRelativeTimeFormatPrototypeFormatToParts": {
+            "exampleCode": "./live-examples/js-examples/intl/intl-relativetimeformat-prototype-formattoparts.html",
+            "fileName": "intl-relativetimeformat-prototype-formattoparts.html",
+            "title": "JavaScript Demo: Intl.RelativeTimeFormat.prototype.formatToParts",
+            "type": "js"
+        },
+        "intlRelativeTimeFormatPrototypeResolvedOptions": {
+            "exampleCode": "./live-examples/js-examples/intl/intl-relativetimeformat-prototype-resolvedoptions.html",
+            "fileName": "intl-relativetimeformat-prototype-resolvedoptions.html",
+            "title": "JavaScript Demo: Intl.RelativeTimeFormat.prototype.resolvedOptions",
+            "type": "js"
+        },
+        "intlRelativeTimeFormatSupportedLocalesOf": {
+            "exampleCode": "./live-examples/js-examples/intl/intl-relativetimeformat-supportedlocalesof.html",
+            "fileName": "intl-relativetimeformat-prototype-supportedlocalesof.html",
+            "title": "JavaScript Demo: Intl.RelativeTimeFormat.prototype.supportedLocalesOf",
+            "type": "js"
         }
     }
 }


### PR DESCRIPTION
Examples for
[RelativeTimeFormat.format](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/format)
[RelativeTimeFormat.formatToParts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/formatToParts)
[RelativeTimeFormat.resolvedOptions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/resolvedOptions)
[RelativeTimeFormat.supportedLocalesOf](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/supportedLocalesOf)

Remaining work to fix https://github.com/tc39/proposal-intl-relative-time/issues/102
cc @romulocintra 

This can be tested in the current Chrome release (71) or in the upcoming Firefox 65 release.