### PR TITLE
Revert "added anywhere value to overflow-wrap property"

### DIFF
--- a/live-examples/css-examples/text/overflow-wrap.css
+++ b/live-examples/css-examples/text/overflow-wrap.css
@@ -1,13 +1,6 @@
-.default-example {
-    display: flex;
-}
-
-.default-example > div {
-    background-color: lemonchiffon;
-    padding: .75em;
-    width: 200px;
-}
-
 #example-element {
     background-color: gold;
+    padding: .75em;
+    width: 200px;
+    height: 200px;
 }

--- a/live-examples/css-examples/text/overflow-wrap.html
+++ b/live-examples/css-examples/text/overflow-wrap.html
@@ -7,14 +7,8 @@
         </button>
     </div>
 
-    <div class="example-choice">
+    <div class="example-choice" initial-choice="true">
         <pre><code class="language-css">overflow-wrap: break-word;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-    <div class="example-choice">
-        <pre><code class="language-css">overflow-wrap: anywhere;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -24,8 +18,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
-        <div class="transition-all">This element is positioned before the example element, in a flex layout.</div>
         <div id="example-element" class="transition-all">Most of this text uses short words that won't need to break. However, <b>Antidisestablishmentarianism</b> is a very long word!</div>
-        <div class="transition-all">This element is positioned after the example element, in a flex layout.</div>
     </section>
 </div>


### PR DESCRIPTION
Reverts mdn/interactive-examples#1284

Nesting `overflow-wrap: anywhere` in `flex` element is unproperly. For better understand this rule see [this example](https://jsfiddle.net/ofgd83um/80/)