### PR TITLE
Repair <label> html example

### DIFF
--- a/live-examples/html-examples/forms/label.html
+++ b/live-examples/html-examples/forms/label.html
@@ -1,5 +1,5 @@
 <div class="preference">
-    <label for="cheese">Do you like cheese?</label>
+    <span>Do you like cheese?</span>
     <input type="checkbox" name="cheese" id="cheese">
 </div>
 


### PR DESCRIPTION
The whole point in the example was to have one checkbox with and one without a label.

This was reverted in the cleanup PR #1210 and is now not in sync with the main text in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label

@wbamberg @chrisdavidmills 