### PR TITLE
Add example of string replace without regex

### DIFF
--- a/live-examples/js-examples/string/string-replace.html
+++ b/live-examples/js-examples/string/string-replace.html
@@ -4,6 +4,11 @@
 var regex = /dog/gi;
 
 console.log(p.replace(regex, 'ferret'));
+console.log(p.replace('dog', 'monkey'));
 
-// expected output: "The quick brown fox jumps over the lazy ferret. If the ferret reacted, was it really lazy?"</code>
+/* expected output:
+* "The quick brown fox jumps over the lazy ferret. If the ferret reacted, was it really lazy?"
+* "The quick brown fox jumps over the lazy monkey. If the dog reacted, was it really lazy?"
+*/
+</code>
 </pre>

--- a/live-examples/js-examples/string/string-replace.html
+++ b/live-examples/js-examples/string/string-replace.html
@@ -1,14 +1,13 @@
 <pre>
-<code id="static-js">var p = 'The quick brown fox jumps over the lazy dog. If the dog reacted, was it really lazy?';
+<code id="static-js">
+var p = 'The quick brown fox jumps over the lazy dog. If the dog reacted, was it really lazy?';
 
 var regex = /dog/gi;
 
 console.log(p.replace(regex, 'ferret'));
-console.log(p.replace('dog', 'monkey'));
+// expected output: "The quick brown fox jumps over the lazy ferret. If the ferret reacted, was it really lazy?"
 
-/* expected output:
-* "The quick brown fox jumps over the lazy ferret. If the ferret reacted, was it really lazy?"
-* "The quick brown fox jumps over the lazy monkey. If the dog reacted, was it really lazy?"
-*/
+console.log(p.replace('dog', 'monkey'));
+// expected output: "The quick brown fox jumps over the lazy monkey. If the dog reacted, was it really lazy?"
 </code>
 </pre>


### PR DESCRIPTION
Otherwise, it's easy to miss this use case. Also, shows the single operation limit in contrast to using regex.