### PR TITLE
overflow-wrap: anywhere

### DIFF
--- a/live-examples/css-examples/text/overflow-wrap.css
+++ b/live-examples/css-examples/text/overflow-wrap.css
@@ -1,6 +1,7 @@
 .example-container {
     background-color: gold;
     padding: .75em;
-    max-width: 14em;
+    width: min-content;
+    max-width: 11em;
     height: 200px;
 }

--- a/live-examples/css-examples/text/overflow-wrap.css
+++ b/live-examples/css-examples/text/overflow-wrap.css
@@ -1,6 +1,6 @@
-#example-element {
+.example-container {
     background-color: gold;
     padding: .75em;
-    width: 200px;
+    max-width: 14em;
     height: 200px;
 }

--- a/live-examples/css-examples/text/overflow-wrap.html
+++ b/live-examples/css-examples/text/overflow-wrap.html
@@ -25,6 +25,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
-        <div class="example-container">Most of this text uses short words that won't need to break. However, <b class="transition-all" id="example-element">Antidisestablishmentarianism</b> is a very long word, one character longer than the URL "https://developer.mozilla.org"</div>
+        <div class="example-container">Most words are short &amp; don't need to break. But <b class="transition-all" id="example-element">Antidisestablishmentarianism</b> is long. The width is set to min-content, with a max-width of 11em.</div>
     </section>
 </div>

--- a/live-examples/css-examples/text/overflow-wrap.html
+++ b/live-examples/css-examples/text/overflow-wrap.html
@@ -8,6 +8,13 @@
     </div>
 
     <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">overflow-wrap: anywhere;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice" initial-choice="true">
         <pre><code class="language-css">overflow-wrap: break-word;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
@@ -18,6 +25,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
-        <div id="example-element" class="transition-all">Most of this text uses short words that won't need to break. However, <b>Antidisestablishmentarianism</b> is a very long word!</div>
+        <div class="example-container">Most of this text uses short words that won't need to break. However, <b class="transition-all" id="example-element">Antidisestablishmentarianism</b> is a very long word, one character longer than the URL "https://developer.mozilla.org"</div>
     </section>
 </div>


### PR DESCRIPTION
Finally found an example where anywhere is different from break-word. Squeee! 
for ticket #937
https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap