### PR TITLE
Add examples for matchAll

### DIFF
--- a/live-examples/js-examples/regexp/meta.json
+++ b/live-examples/js-examples/regexp/meta.json
@@ -24,6 +24,12 @@
             "title": "JavaScript Demo: RegExp.prototype[@@match]",
             "type": "js"
         },
+        "regexpPrototype@@MatchAll": {
+            "exampleCode": "./live-examples/js-examples/regexp/regexp-prototype-@@matchall.html",
+            "fileName": "regexp-prototype-@@matchall.html",
+            "title": "JavaScript Demo: RegExp.prototype[@@matchAll]",
+            "type": "js"
+        },
         "regexpPrototype@@Replace": {
             "exampleCode": "./live-examples/js-examples/regexp/regexp-prototype-@@replace.html",
             "fileName": "regexp-prototype-@@replace.html",

--- a/live-examples/js-examples/regexp/regexp-prototype-@@matchall.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-@@matchall.html
@@ -1,0 +1,16 @@
+<pre>
+<code id="static-js">class MyRegExp extends RegExp {
+    [Symbol.matchAll](str) {
+        var result = RegExp.prototype[Symbol.matchAll].call(this, str);
+        if (!result) return null;
+        return Array.from(result);
+    }
+}
+var re = new MyRegExp('([0-9]+)-([0-9]+)-([0-9]+)', 'g');
+var result = '2016-01-02|2019-03-07'.matchAll(re);
+console.log(result[0]);
+// expected output: [ "2016-01-02", "2016", "01", "02" ]
+console.log(result[1]);
+// expected output: [ "2019-03-07", "2019", "03", "07" ]
+</code>
+</pre>

--- a/live-examples/js-examples/regexp/regexp-prototype-@@matchall.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-@@matchall.html
@@ -1,16 +1,16 @@
 <pre>
 <code id="static-js">class MyRegExp extends RegExp {
     [Symbol.matchAll](str) {
-        var result = RegExp.prototype[Symbol.matchAll].call(this, str);
-        if (!result) return null;
+        let result = RegExp.prototype[Symbol.matchAll].call(this, str);
+        if (!result) {
+            return null;
+        }
         return Array.from(result);
     }
 }
-var re = new MyRegExp('([0-9]+)-([0-9]+)-([0-9]+)', 'g');
-var result = '2016-01-02|2019-03-07'.matchAll(re);
-console.log(result[0]);
-// expected output: [ "2016-01-02", "2016", "01", "02" ]
-console.log(result[1]);
-// expected output: [ "2019-03-07", "2019", "03", "07" ]
+
+let re = new MyRegExp('-[0-9]+', 'g');
+console.log('2016-01-02|2019-03-07'.matchAll(re));
+// expected output: Array [Array ["-01"], Array ["-02"], Array ["-03"], Array ["-07"]]
 </code>
 </pre>

--- a/live-examples/js-examples/string/meta.json
+++ b/live-examples/js-examples/string/meta.json
@@ -85,6 +85,12 @@
             "title": "JavaScript Demo: String.match()",
             "type": "js"
         },
+        "stringMatchAll": {
+            "exampleCode": "./live-examples/js-examples/string/string-matchall.html",
+            "fileName": "string-matchall.html",
+            "title": "JavaScript Demo: String.matchAll()",
+            "type": "js"
+        },
         "stringNormalize": {
             "exampleCode": "./live-examples/js-examples/string/string-normalize.html",
             "fileName": "string-normalize.html",

--- a/live-examples/js-examples/string/string-matchall.html
+++ b/live-examples/js-examples/string/string-matchall.html
@@ -1,0 +1,13 @@
+<pre>
+<code id="static-js">var regexp = /t(e)(st(\d?))/g;
+var str = 'test1test2';
+
+let array = [...str.matchAll(regexp)];
+
+console.log(array[0]);
+// expected output: ['test1', 'e', 'st1', '1']
+
+console.log(array[1]);
+// expected output: ['test2', 'e', 'st2', '2']
+</code>
+</pre>

--- a/live-examples/js-examples/string/string-matchall.html
+++ b/live-examples/js-examples/string/string-matchall.html
@@ -1,13 +1,13 @@
 <pre>
-<code id="static-js">var regexp = /t(e)(st(\d?))/g;
-var str = 'test1test2';
+<code id="static-js">let regexp = /t(e)(st(\d?))/g;
+let str = 'test1test2';
 
 let array = [...str.matchAll(regexp)];
 
 console.log(array[0]);
-// expected output: ['test1', 'e', 'st1', '1']
+// expected output: Array ["test1", "e", "st1", "1"]
 
 console.log(array[1]);
-// expected output: ['test2', 'e', 'st2', '2']
+// expected output: Array ["test2", "e", "st2", "2"]
 </code>
 </pre>

--- a/live-examples/js-examples/symbol/meta.json
+++ b/live-examples/js-examples/symbol/meta.json
@@ -42,6 +42,12 @@
             "title": "JavaScript Demo: Symbol.match",
             "type": "js"
         },
+        "symbolMatchAll": {
+            "exampleCode": "./live-examples/js-examples/symbol/symbol-matchall.html",
+            "fileName": "symbol-matchall.html",
+            "title": "JavaScript Demo: Symbol.matchAll",
+            "type": "js"
+        },
         "symbolPrototypeDescription": {
             "exampleCode": "./live-examples/js-examples/symbol/symbol-prototype-description.html",
             "fileName": "symbol-prototype-description.html",

--- a/live-examples/js-examples/symbol/symbol-matchall.html
+++ b/live-examples/js-examples/symbol/symbol-matchall.html
@@ -1,0 +1,9 @@
+<pre>
+<code id="static-js">var re = /[0-9]+/g;
+var str = '2016-01-02|2019-03-07';
+var result = re[Symbol.matchAll](str);
+
+console.log(Array.from(result, x => x[0]));
+// expected output: ["2016", "01", "02", "2019", "03", "07"]
+</code>
+</pre>

--- a/live-examples/js-examples/symbol/symbol-matchall.html
+++ b/live-examples/js-examples/symbol/symbol-matchall.html
@@ -1,9 +1,9 @@
 <pre>
-<code id="static-js">var re = /[0-9]+/g;
-var str = '2016-01-02|2019-03-07';
-var result = re[Symbol.matchAll](str);
+<code id="static-js">let re = /[0-9]+/g;
+let str = '2016-01-02|2019-03-07';
+let result = re[Symbol.matchAll](str);
 
 console.log(Array.from(result, x => x[0]));
-// expected output: ["2016", "01", "02", "2019", "03", "07"]
+// expected output: Array ["2016", "01", "02", "2019", "03", "07"]
 </code>
 </pre>


### PR DESCRIPTION
Examples for:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/matchAll
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll

This will work in Chrome 73 and Firefox 67 (or the nightly versions of these browsers).