### PR TITLE
Correcting `contenteditable` attribute value in `spellcheck` example

### DIFF
--- a/live-examples/html-examples/global-attributes/attribute-spellcheck.html
+++ b/live-examples/html-examples/global-attributes/attribute-spellcheck.html
@@ -1,3 +1,3 @@
-<p contenteditable spellcheck="true">This exampull will be checkd fur spellung when you try to edit it.</p>
+<p contenteditable="true" spellcheck="true">This exampull will be checkd fur spellung when you try to edit it.</p>
 
-<p contenteditable spellcheck="false">This exampull will nut be checkd fur spellung when you try to edit it.</p>
+<p contenteditable="true" spellcheck="false">This exampull will nut be checkd fur spellung when you try to edit it.</p>


### PR DESCRIPTION
As per the spec for `contenteditable`:

> This attribute is an enumerated one and not a Boolean one. This means that the
> explicit usage of one of the values `true`, `false` or the empty string is
> mandatory and that a shorthand like `<label contenteditable>Example Label</label>`
> is not allowed. The correct usage is `<label contenteditable="true">Example Label</label>`.

The `spellcheck` example was incorrect using it without a value.