### PR TITLE
Fix RegExp test example

### DIFF
--- a/live-examples/js-examples/regexp/regexp-prototype-test.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-test.html
@@ -1,18 +1,12 @@
 <pre>
-<code id="static-js" data-height="taller">var regex1 = RegExp('foo*');
-var regex2 = RegExp('foo*','g');
+<code id="static-js" data-height="taller">var regex = RegExp('foo*');
 var str1 = 'table football';
+var str2 = 'normal table';
 
-console.log(regex1.test(str1));
+console.log(regex.test(str1));
 // expected output: true
 
-console.log(regex1.test(str1));
-// expected output: true
-
-console.log(regex2.test(str1));
-// expected output: true
-
-console.log(regex2.test(str1));
+console.log(regex.test(str2));
 // expected output: false
 </code>
 </pre>


### PR DESCRIPTION
Previously, the example was incorrect:

```
console.log(regex2.test(str1));
// expected output: true

console.log(regex2.test(str1));
// expected output: false
```