### PR TITLE
Improv cite example

### DIFF
--- a/live-examples/html-examples/inline-text-semantics/cite.html
+++ b/live-examples/html-examples/inline-text-semantics/cite.html
@@ -1,6 +1,6 @@
 <blockquote>
     <p>It was a bright cold day in April, and the clocks were striking thirteen.</p>
     <footer>
-        First sentence in <cite><a href="http://www.george-orwell.org/1984/0.html"><i>Nineteen Eighty-Four</i></a></cite> by George Orwell (Part 1, Chapter 1).
+        First sentence in <cite><a href="http://www.george-orwell.org/1984/0.html">Nineteen Eighty-Four</a></cite> by George Orwell (Part 1, Chapter 1).
     </footer>
 </blockquote>

--- a/live-examples/html-examples/inline-text-semantics/cite.html
+++ b/live-examples/html-examples/inline-text-semantics/cite.html
@@ -1,6 +1,7 @@
 <blockquote>
     <p>It was a bright cold day in April, and the clocks were striking thirteen.</p>
     <footer>
-        First sentence in <cite><a href="http://www.george-orwell.org/1984/0.html">Nineteen Eighty-Four</a></cite> by George Orwell (Part 1, Chapter 1).
+        First sentence in <cite><a href="http://www.george-orwell.org/1984/0.html">Nineteen 
+        Eighty-Four</a></cite> by George Orwell (Part 1, Chapter 1).
     </footer>
 </blockquote>

--- a/live-examples/html-examples/inline-text-semantics/cite.html
+++ b/live-examples/html-examples/inline-text-semantics/cite.html
@@ -1,7 +1,6 @@
 <blockquote>
     <p>It was a bright cold day in April, and the clocks were striking thirteen.</p>
     <footer>
-        First sentence in <cite><a href="http://www.george-orwell.org/1984/0.html">Nineteen 
-        Eighty-Four</a></cite> by George Orwell (Part 1, Chapter 1).
+        First sentence in <cite><a href="http://www.george-orwell.org/1984/0.html">Nineteen Eighty-Four</a></cite> by George Orwell (Part 1, Chapter 1).
     </footer>
 </blockquote>


### PR DESCRIPTION
The `<cite>` element already makes the text italicized by default. From the [MDN `<cite>` reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite):
> Typically, browsers style the contents of a <cite> element in italics by default. 

Removing `<i>` for simplicity.