### PR TITLE
Fix Object.entries example

### DIFF
--- a/live-examples/js-examples/object/object-entries.html
+++ b/live-examples/js-examples/object/object-entries.html
@@ -1,14 +1,16 @@
 <pre>
-<code id="static-js">const object1 = { foo: 'bar', baz: 42 };
-console.log(Object.entries(object1)[1]);
-// expected output: Array ["baz", 42]
+<code id="static-js">const object1 = {
+  a: 'somestring',
+  b: 42
+};
 
-const object2 = { 0: 'a', 1: 'b', 2: 'c' };
-console.log(Object.entries(object2)[2]);
-// expected output: Array ["2", "c"]
+for (let [key, value] of Object.entries(object1)) {
+  console.log(`${key}: ${value}`);
+}
 
-const result = Object.entries(object2).sort((a, b) => a - b);
-console.log(Object.entries(result)[1]);
-// expected output: Array ["1", Array ["1", "b"]]
+// expected output:
+// "a: somestring"
+// "b: 42"
+// order is not guaranteed
 </code>
 </pre>


### PR DESCRIPTION
This PR fixes the example for [`Object.entries`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries), since both https://github.com/mdn/interactive-examples/pull/1238 and https://github.com/mdn/interactive-examples/pull/1303 seem to have stalled.

It's just a lightly cleaned-up version of https://github.com/mdn/interactive-examples/pull/1238#issuecomment-440647014.