### PR TITLE
Adding missing example

### DIFF
--- a/live-examples/css-examples/scroll-snap/meta.json
+++ b/live-examples/css-examples/scroll-snap/meta.json
@@ -35,6 +35,13 @@
             "title": "CSS Demo: scroll-margin-bottom",
             "type": "css"
         },
+        "scrollMarginInline": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-margin-right.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-margin-inline.html",
+            "fileName": "scroll-margin-inline.html",
+            "title": "CSS Demo: scroll-margin-inline",
+            "type": "css"
+        },
         "scrollMarginInlineEnd": {
             "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-margin-right.css",
             "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-margin-inline-end.html",

--- a/live-examples/css-examples/scroll-snap/scroll-margin-inline.html
+++ b/live-examples/css-examples/scroll-snap/scroll-margin-inline.html
@@ -1,0 +1,33 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-margin-inline">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">scroll-margin-inline: 0;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-margin-inline: 20px;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-margin-inline: 2em;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <div class="scroller">
+            <div>1</div>
+            <div id="example-element">2</div>
+            <div>3</div>
+        </div>
+
+        <div class="info">Scroll &raquo;</div>
+    </section>
+</div>


### PR DESCRIPTION
I failed to create an example for the two value shorthand scroll-margin-inline. This adds that example.