### PR TITLE
Add An Easy Demonstration Of 2D Matrices

### DIFF
--- a/live-examples/webapi-examples/CanvasRenderingContext2D/meta.json
+++ b/live-examples/webapi-examples/CanvasRenderingContext2D/meta.json
@@ -1,0 +1,13 @@
+{
+    "pages": {
+        "setTransform": {
+            "exampleCode": "./live-examples/webapi-examples/CanvasRenderingContext2D/setTransform/canvas2D-setTransform.html",
+            "jsExampleSrc": "./live-examples/webapi-examples/CanvasRenderingContext2D/setTransform/js/canvas2D-setTransform.js",
+            "fileName": "canvas2D-setTransform.html",
+            "title": "Web API Demo: CanvasRenderingContext2D.setTransform() and CanvasRenderingContext2D.clearReact()",
+            "height": "tabbed-standard",
+            "type": "webapi-tabbed",
+            "tabs": "html,js"
+        }
+    }
+}

--- a/live-examples/webapi-examples/CanvasRenderingContext2D/setTransform/canvas2D-setTransform.html
+++ b/live-examples/webapi-examples/CanvasRenderingContext2D/setTransform/canvas2D-setTransform.html
@@ -1,0 +1,10 @@
+<!-- Learn about this code on MDN: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setTransform -->
+<ul>
+<li>m11 = <input type="range" id="m11" step=".012265625" value="1.00578125" min="-1.57" max="1.57"/></li>
+<li>m12 = <input type="range" id="m12" step=".012265625" value="0.19625" min="-1.57" max="1.57"/></li>
+<li>m21 = <input type="range" id="m21" step=".012265625" value="0" min="-1.57" max="1.57"/></li>
+<li>m22 = <input type="range" id="m22" step=".012265625" value="1.00578125" min="-1.57" max="1.57"/></li>
+<li>dx =&nbsp; &nbsp; <input type="range" id="dx" step="1" value="40" min="-100" max="300"/></li>
+<li>dy =&nbsp; &nbsp; <input type="range" id="dy" step="1" value="20" min="-120" max="150"/></li>
+<br />
+<canvas id="canvas" style="border:1px solid #ddd"></canvas>

--- a/live-examples/webapi-examples/CanvasRenderingContext2D/setTransform/js/canvas2D-setTransform.js
+++ b/live-examples/webapi-examples/CanvasRenderingContext2D/setTransform/js/canvas2D-setTransform.js
@@ -1,0 +1,62 @@
+(function(){"use strict";
+  const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
+
+  const m11 = document.getElementById('m11');
+  const m12 = document.getElementById('m12');
+  const m21 = document.getElementById('m21');
+  const m22 = document.getElementById('m22');
+  const dx = document.getElementById('dx');
+  const dy = document.getElementById('dy');
+
+  function updateRectange() {
+    // Ensure that we do not paint over the prior image. Also, clearRect
+    // (in Chrome) needs to have a 1px margin when transformed to avoid
+    //	ugly aliasing leaving a thin trail of unerased pixels.
+    ctx.clearRect(-1, -1, 102, 102);
+
+    // draw the transformed rectangle
+    ctx.setTransform(
+      m11.value, m12.value,
+      m21.value, m22.value,
+      dx.value, dy.value
+    );
+    ctx.fillRect(0, 0, 100, 100);
+
+    // Do not reset the transformation so that clearRect
+    //	will be transformed and clear the whole rectangle
+  }
+
+  const passiveOption = {"passive": 1};
+  var lastFrameId = -1;
+  function updatePrior(e){
+    e.target.previousSibling.value = e.target.value;
+    cancelAnimationFrame(lastFrameId);
+    lastFrameId = requestAnimationFrame(updateRectange);
+  }
+  function updateNext(e){
+    e.target.nextSibling.value = e.target.value;
+    cancelAnimationFrame(lastFrameId);
+    lastFrameId = requestAnimationFrame(updateRectange);
+  }
+  [m11, m12, m21, m22, dx, dy].forEach(function(ele){
+    // add in a number view of the slide
+    ele.setAttribute("autocomplete", "off"); // avoid unnececary autocomplete
+
+    var numberView = ele.cloneNode(false);
+    numberView.setAttribute("type", "number");
+    numberView.style.cssText = 'width:3em;margin-left:1em'
+    numberView.addEventListener("change", updatePrior, passiveOption);
+    numberView.addEventListener("input", updatePrior, passiveOption);
+    // "input" event does not fire correctly in Internet Explorer
+    numberView.addEventListener("keydown", updatePrior, passiveOption);
+
+    ele.insertAdjacentElement("afterend", numberView);
+    ele.addEventListener("change", updateNext, passiveOption);
+    ele.addEventListener("input", updateNext, passiveOption);
+    // "input" event does not fire correctly in Internet Explorer
+    ele.addEventListener("mousemove", updateNext, passiveOption);
+  });
+
+  updateRectange();
+})();


### PR DESCRIPTION
The [setTransform](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setTransform), [transform](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/transform), and [clearRect](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/clearRect) pages of the CanvasRenderingContext2D could really use a demonstration of how 2D matrices work for those among us who do not know the math yet. I believe that my code (perhaps with some modifications from other people) provides a good solid demonstration. My JSFiddle can be found at https://jsfiddle.net/m3etvgyp/