### PR TITLE
Add samples for BigInt typed array API

### DIFF
--- a/live-examples/js-examples/dataview/dataview-getbigint64.html
+++ b/live-examples/js-examples/dataview/dataview-getbigint64.html
@@ -1,0 +1,11 @@
+<pre>
+<code id="static-js">// create an ArrayBuffer with a size in bytes
+var buffer = new ArrayBuffer(16);
+
+var view = new DataView(buffer);
+view.setBigInt64(1, 13n);
+
+console.log(view.getBigInt64(1));
+// expected output: 13n
+</code>
+</pre>

--- a/live-examples/js-examples/dataview/dataview-getbigint64.html
+++ b/live-examples/js-examples/dataview/dataview-getbigint64.html
@@ -1,10 +1,11 @@
 <pre>
 <code id="static-js">// create an ArrayBuffer with a size in bytes
-var buffer = new ArrayBuffer(16);
+const buffer = new ArrayBuffer(16);
+
 // Highest possible BigInt value that fits in a signed 64-bit integer
 const max = 2n ** (64n -1n) - 1n;
 
-var view = new DataView(buffer);
+const view = new DataView(buffer);
 view.setBigInt64(1, max);
 
 console.log(view.getBigInt64(1));

--- a/live-examples/js-examples/dataview/dataview-getbigint64.html
+++ b/live-examples/js-examples/dataview/dataview-getbigint64.html
@@ -1,11 +1,13 @@
 <pre>
 <code id="static-js">// create an ArrayBuffer with a size in bytes
 var buffer = new ArrayBuffer(16);
+// Highest possible BigInt value that fits in a signed 64-bit integer
+const max = 2n ** (64n -1n) - 1n;
 
 var view = new DataView(buffer);
-view.setBigInt64(1, 13n);
+view.setBigInt64(1, max);
 
 console.log(view.getBigInt64(1));
-// expected output: 13n
+// expected output: 9223372036854775807n
 </code>
 </pre>

--- a/live-examples/js-examples/dataview/dataview-getbiguint64.html
+++ b/live-examples/js-examples/dataview/dataview-getbiguint64.html
@@ -1,10 +1,11 @@
 <pre>
 <code id="static-js">// create an ArrayBuffer with a size in bytes
-var buffer = new ArrayBuffer(16);
+const buffer = new ArrayBuffer(16);
+
 // Highest possible BigInt value that fits in an unsigned 64-bit integer
 const max = 2n ** 64n - 1n;
 
-var view = new DataView(buffer);
+const view = new DataView(buffer);
 view.setBigUint64(1, max);
 
 console.log(view.getBigUint64(1));

--- a/live-examples/js-examples/dataview/dataview-getbiguint64.html
+++ b/live-examples/js-examples/dataview/dataview-getbiguint64.html
@@ -1,0 +1,11 @@
+<pre>
+<code id="static-js">// create an ArrayBuffer with a size in bytes
+var buffer = new ArrayBuffer(16);
+
+var view = new DataView(buffer);
+view.setBigUint64(1, 13n);
+
+console.log(view.getBigUint64(1));
+// expected output: 13n
+</code>
+</pre>

--- a/live-examples/js-examples/dataview/dataview-getbiguint64.html
+++ b/live-examples/js-examples/dataview/dataview-getbiguint64.html
@@ -1,11 +1,13 @@
 <pre>
 <code id="static-js">// create an ArrayBuffer with a size in bytes
 var buffer = new ArrayBuffer(16);
+// Highest possible BigInt value that fits in an unsigned 64-bit integer
+const max = 2n ** 64n - 1n;
 
 var view = new DataView(buffer);
-view.setBigUint64(1, 13n);
+view.setBigUint64(1, max);
 
 console.log(view.getBigUint64(1));
-// expected output: 13n
+// expected output: 18446744073709551615n
 </code>
 </pre>

--- a/live-examples/js-examples/dataview/dataview-setbigint64.html
+++ b/live-examples/js-examples/dataview/dataview-setbigint64.html
@@ -1,0 +1,11 @@
+<pre>
+<code id="static-js">// create an ArrayBuffer with a size in bytes
+var buffer = new ArrayBuffer(16);
+
+var view = new DataView(buffer);
+view.setBigInt64(1, 13n);
+
+console.log(view.getBigInt64(1));
+// expected output: 13n
+</code>
+</pre>

--- a/live-examples/js-examples/dataview/dataview-setbigint64.html
+++ b/live-examples/js-examples/dataview/dataview-setbigint64.html
@@ -1,10 +1,11 @@
 <pre>
 <code id="static-js">// create an ArrayBuffer with a size in bytes
-var buffer = new ArrayBuffer(16);
+const buffer = new ArrayBuffer(16);
+
 // Highest possible BigInt value that fits in a signed 64-bit integer
 const max = 2n ** (64n -1n) - 1n;
 
-var view = new DataView(buffer);
+const view = new DataView(buffer);
 view.setBigInt64(1, max);
 
 console.log(view.getBigInt64(1));

--- a/live-examples/js-examples/dataview/dataview-setbigint64.html
+++ b/live-examples/js-examples/dataview/dataview-setbigint64.html
@@ -1,11 +1,13 @@
 <pre>
 <code id="static-js">// create an ArrayBuffer with a size in bytes
 var buffer = new ArrayBuffer(16);
+// Highest possible BigInt value that fits in a signed 64-bit integer
+const max = 2n ** (64n -1n) - 1n;
 
 var view = new DataView(buffer);
-view.setBigInt64(1, 13n);
+view.setBigInt64(1, max);
 
 console.log(view.getBigInt64(1));
-// expected output: 13n
+// expected output: 9223372036854775807n
 </code>
 </pre>

--- a/live-examples/js-examples/dataview/dataview-setbiguint64.html
+++ b/live-examples/js-examples/dataview/dataview-setbiguint64.html
@@ -1,10 +1,11 @@
 <pre>
 <code id="static-js">// create an ArrayBuffer with a size in bytes
-var buffer = new ArrayBuffer(16);
+const buffer = new ArrayBuffer(16);
+
 // Highest possible BigInt value that fits in an unsigned 64-bit integer
 const max = 2n ** 64n - 1n;
 
-var view = new DataView(buffer);
+const view = new DataView(buffer);
 view.setBigUint64(1, max);
 
 console.log(view.getBigUint64(1));

--- a/live-examples/js-examples/dataview/dataview-setbiguint64.html
+++ b/live-examples/js-examples/dataview/dataview-setbiguint64.html
@@ -1,0 +1,11 @@
+<pre>
+<code id="static-js">// create an ArrayBuffer with a size in bytes
+var buffer = new ArrayBuffer(16);
+
+var view = new DataView(buffer);
+view.setBigUint64(1, 13n);
+
+console.log(view.getBigUint64(1));
+// expected output: 13n
+</code>
+</pre>

--- a/live-examples/js-examples/dataview/dataview-setbiguint64.html
+++ b/live-examples/js-examples/dataview/dataview-setbiguint64.html
@@ -1,11 +1,13 @@
 <pre>
 <code id="static-js">// create an ArrayBuffer with a size in bytes
 var buffer = new ArrayBuffer(16);
+// Highest possible BigInt value that fits in an unsigned 64-bit integer
+const max = 2n ** 64n - 1n;
 
 var view = new DataView(buffer);
-view.setBigUint64(1, 13n);
+view.setBigUint64(1, max);
 
 console.log(view.getBigUint64(1));
-// expected output: 13n
+// expected output: 18446744073709551615n
 </code>
 </pre>

--- a/live-examples/js-examples/dataview/meta.json
+++ b/live-examples/js-examples/dataview/meta.json
@@ -24,6 +24,18 @@
             "title": "JavaScript Demo: DataView Constructor",
             "type": "js"
         },
+        "dataviewGetBigInt64": {
+            "exampleCode": "./live-examples/js-examples/dataview/dataview-getbigint64.html",
+            "fileName": "dataview-getbigint64.html",
+            "title": "JavaScript Demo: DataView.getBigInt64()",
+            "type": "js"
+        },
+        "dataviewGetBigUint64": {
+            "exampleCode": "./live-examples/js-examples/dataview/dataview-getbiguint64.html",
+            "fileName": "dataview-getbiguint64.html",
+            "title": "JavaScript Demo: DataView.getBigUint64()",
+            "type": "js"
+        },
         "dataviewGetFloat32": {
             "exampleCode": "./live-examples/js-examples/dataview/dataview-getfloat32.html",
             "fileName": "dataview-getfloat32.html",
@@ -70,6 +82,18 @@
             "exampleCode": "./live-examples/js-examples/dataview/dataview-getuint32.html",
             "fileName": "dataview-getuint32.html",
             "title": "JavaScript Demo: DataView.getUint32()",
+            "type": "js"
+        },
+        "dataviewSetBigInt64": {
+            "exampleCode": "./live-examples/js-examples/dataview/dataview-setbigint64.html",
+            "fileName": "dataview-setbigint64.html",
+            "title": "JavaScript Demo: DataView.setBigInt64()",
+            "type": "js"
+        },
+        "dataviewSetBigUint64": {
+            "exampleCode": "./live-examples/js-examples/dataview/dataview-setbiguint64.html",
+            "fileName": "dataview-setbiguint64.html",
+            "title": "JavaScript Demo: DataView.setBigUint64()",
             "type": "js"
         },
         "dataviewSetFloat32": {


### PR DESCRIPTION
Examples for these pages:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigInt64
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigUint64
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigInt64
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigUint64

These example are very trivial and maybe not very useful, vut so are the other dataview getter/setter examples. Let me know if you have ideas and want me to try harder.


Looks better with https://github.com/mdn/bob/pull/254 which I spent more time on than the examples itself.