### PR TITLE
replace `span.note` with `small`

### DIFF
--- a/live-examples/html-examples/input/css/single-input.css
+++ b/live-examples/html-examples/input/css/single-input.css
@@ -7,7 +7,3 @@ input,
 label {
     margin: .4rem 0;
 }
-
-.note {
-    font-size: .8em;
-}

--- a/live-examples/html-examples/input/tel.html
+++ b/live-examples/html-examples/input/tel.html
@@ -4,4 +4,4 @@
        pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}"
        required>
 
-<span class="note">Format: 123-456-7890</span>
+<small>Format: 123-456-7890</small>

--- a/live-examples/html-examples/input/time.html
+++ b/live-examples/html-examples/input/time.html
@@ -3,4 +3,4 @@
 <input type="time" id="appt" name="appt"
        min="9:00" max="18:00" required>
 
-<span class="note">Office hours are 9am to 6pm</span>
+<small>Office hours are 9am to 6pm</small>


### PR DESCRIPTION
In the HTML `<input>` examples, replaces the `<span class="note">` elements with “more semantic” `<small>` elements, where the note indicates a [small print](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small) formatting guideline for users. Also deletes the unused `.note` CSS class for those examples.

I’ve checked through all the `/live-examples/html-examples/input/` HTML pages and ensured that `.note` wasn’t used before deleting it. The only pages that used it were `tel.html` and `time.html`, which have been updated with `<small>`.