### PR TITLE
Add examples for BigInt API

### DIFF
--- a/live-examples/js-examples/bigint/bigint-asintn.html
+++ b/live-examples/js-examples/bigint/bigint-asintn.html
@@ -1,0 +1,14 @@
+<pre>
+<code id="static-js">const max = 2n ** (64n - 1n) - 1n;
+
+function check64bit(number) {
+  (number > max) ? console.log("Number doesn't fit in signed 64-bit integer!") : console.log(BigInt.asIntN(64, number));
+}
+
+check64bit(2n ** 64n);
+// expected output: "Number doesn't fit in signed 64-bit integer!"
+
+check64bit(2n ** 32n);
+// expected output: "4294967296n"
+</code>
+</pre>

--- a/live-examples/js-examples/bigint/bigint-asintn.html
+++ b/live-examples/js-examples/bigint/bigint-asintn.html
@@ -2,7 +2,9 @@
 <code id="static-js">const max = 2n ** (64n - 1n) - 1n;
 
 function check64bit(number) {
-  (number > max) ? console.log("Number doesn't fit in signed 64-bit integer!") : console.log(BigInt.asIntN(64, number));
+  (number > max) ?
+    console.log("Number doesn't fit in signed 64-bit integer!") :
+    console.log(BigInt.asIntN(64, number));
 }
 
 check64bit(2n ** 64n);

--- a/live-examples/js-examples/bigint/bigint-asintn.html
+++ b/live-examples/js-examples/bigint/bigint-asintn.html
@@ -11,6 +11,6 @@ check64bit(2n ** 64n);
 // expected output: "Number doesn't fit in signed 64-bit integer!"
 
 check64bit(2n ** 32n);
-// expected output: "4294967296n"
+// expected output: 4294967296n
 </code>
 </pre>

--- a/live-examples/js-examples/bigint/bigint-asuintn.html
+++ b/live-examples/js-examples/bigint/bigint-asuintn.html
@@ -1,0 +1,14 @@
+<pre>
+<code id="static-js">const max = 2n ** 64n - 1n;
+
+function check64bit(number) {
+    (number > max) ? console.log("Number doesn't fit in unsigned 64-bit integer!") : console.log(BigInt.asUintN(64, number));
+}
+
+check64bit(2n ** 64n);
+// expected output: "Number doesn't fit in unsigned 64-bit integer!"
+
+check64bit(2n ** 32n);
+// expected output: "4294967296n"
+</code>
+</pre>

--- a/live-examples/js-examples/bigint/bigint-asuintn.html
+++ b/live-examples/js-examples/bigint/bigint-asuintn.html
@@ -11,6 +11,6 @@ check64bit(2n ** 64n);
 // expected output: "Number doesn't fit in unsigned 64-bit integer!"
 
 check64bit(2n ** 32n);
-// expected output: "4294967296n"
+// expected output: 4294967296n
 </code>
 </pre>

--- a/live-examples/js-examples/bigint/bigint-asuintn.html
+++ b/live-examples/js-examples/bigint/bigint-asuintn.html
@@ -2,7 +2,9 @@
 <code id="static-js">const max = 2n ** 64n - 1n;
 
 function check64bit(number) {
-    (number > max) ? console.log("Number doesn't fit in unsigned 64-bit integer!") : console.log(BigInt.asUintN(64, number));
+  (number > max) ?
+    console.log("Number doesn't fit in unsigned 64-bit integer!") :
+    console.log(BigInt.asUintN(64, number));
 }
 
 check64bit(2n ** 64n);

--- a/live-examples/js-examples/bigint/bigint-tolocalestring.html
+++ b/live-examples/js-examples/bigint/bigint-tolocalestring.html
@@ -1,0 +1,12 @@
+<pre>
+<code id="static-js">let bigint = 123456789123456789n;
+
+// German uses period for thousands
+console.log(bigint.toLocaleString('de-DE'));
+// expected output: "123.456.789.123.456.789"
+
+// request a currency format
+console.log(bigint.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' }));
+// expected output: "123.456.789.123.456.789,00 €"
+</code>
+</pre>

--- a/live-examples/js-examples/bigint/bigint-tolocalestring.html
+++ b/live-examples/js-examples/bigint/bigint-tolocalestring.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">let bigint = 123456789123456789n;
+<code id="static-js">const bigint = 123456789123456789n;
 
 // German uses period for thousands
 console.log(bigint.toLocaleString('de-DE'));

--- a/live-examples/js-examples/bigint/bigint-tostring.html
+++ b/live-examples/js-examples/bigint/bigint-tostring.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">console.log(256n.toString());
-// expected output: "256"
+<code id="static-js">console.log(1024n.toString());
+// expected output: "1024"
 
 console.log(1024n.toString(2));
 // expected output: "10000000000"

--- a/live-examples/js-examples/bigint/bigint-tostring.html
+++ b/live-examples/js-examples/bigint/bigint-tostring.html
@@ -1,0 +1,11 @@
+<pre>
+<code id="static-js">console.log(256n.toString());
+// expected output: "256"
+
+console.log(1024n.toString(2));
+// expected output: "10000000000"
+
+console.log(1024n.toString(16));
+// expected output: "400"
+</code>
+</pre>

--- a/live-examples/js-examples/bigint/bigint-valueof.html
+++ b/live-examples/js-examples/bigint/bigint-valueof.html
@@ -1,0 +1,8 @@
+<pre>
+<code id="static-js">console.log(typeof Object(1n));
+// expected output: "object"
+
+console.log(typeof Object(1n).valueOf());
+// expected output: "bigint"
+</code>
+</pre>

--- a/live-examples/js-examples/bigint/meta.json
+++ b/live-examples/js-examples/bigint/meta.json
@@ -3,13 +3,13 @@
         "bigIntasIntN": {
             "exampleCode": "./live-examples/js-examples/bigint/bigint-asintn.html",
             "fileName": "bigint-asintn.html",
-            "title": "JavaScript Demo: BigInt.asIntN",
+            "title": "JavaScript Demo: BigInt.asIntN()",
             "type": "js"
         },
         "bigIntasUintN": {
             "exampleCode": "./live-examples/js-examples/bigint/bigint-asuintn.html",
             "fileName": "bigint-asuintn.html",
-            "title": "JavaScript Demo: BigInt.asUintN",
+            "title": "JavaScript Demo: BigInt.asUintN()",
             "type": "js"
         },
         "bigIntToLocaleString": {

--- a/live-examples/js-examples/bigint/meta.json
+++ b/live-examples/js-examples/bigint/meta.json
@@ -1,0 +1,34 @@
+{
+    "pages": {
+        "bigIntasIntN": {
+            "exampleCode": "./live-examples/js-examples/bigint/bigint-asintn.html",
+            "fileName": "bigint-asintn.html",
+            "title": "JavaScript Demo: BigInt.asIntN",
+            "type": "js"
+        },
+        "bigIntasUintN": {
+            "exampleCode": "./live-examples/js-examples/bigint/bigint-asuintn.html",
+            "fileName": "bigint-asuintn.html",
+            "title": "JavaScript Demo: BigInt.asUintN",
+            "type": "js"
+        },
+        "bigIntToLocaleString": {
+            "exampleCode": "./live-examples/js-examples/bigint/bigint-tolocalestring.html",
+            "fileName": "bigint-tolocalestring.html",
+            "title": "JavaScript Demo: BigInt.toLocaleString()",
+            "type": "js"
+        },
+        "bigIntToString": {
+            "exampleCode": "./live-examples/js-examples/bigint/bigint-tostring.html",
+            "fileName": "bigint-tostring.html",
+            "title": "JavaScript Demo: BigInt.toString()",
+            "type": "js"
+        },
+        "bigIntValueof": {
+            "exampleCode": "./live-examples/js-examples/bigint/bigint-valueof.html",
+            "fileName": "bigint-valueof.html",
+            "title": "JavaScript Demo: BigInt.valueOf()",
+            "type": "js"
+        }
+    }
+}


### PR DESCRIPTION
Examples for:

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asIntN
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toLocaleString (only works in Chrome 76 for now, soon in Nightly)
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toString
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/valueOf