### PR TITLE
Offset Path (CSS Motion Path) properties

### DIFF
--- a/live-examples/css-examples/motion-path/meta.json
+++ b/live-examples/css-examples/motion-path/meta.json
@@ -3,6 +3,7 @@
     "offsetPath": {
         "cssExampleSrc": "./live-examples/css-examples/motion-path/offset-path.css",
         "exampleCode": "./live-examples/css-examples/motion-path/offset-path.html",
+        "jsExampleSrc": "./live-examples/css-examples/motion-path/offset-playback.js",
         "fileName": "offset-path.html",
         "title": "CSS Demo: offset-path",
         "type": "css"
@@ -17,6 +18,7 @@
     "offsetRotate": {
         "cssExampleSrc": "./live-examples/css-examples/motion-path/offset-rotate.css",
         "exampleCode": "./live-examples/css-examples/motion-path/offset-rotate.html",
+        "jsExampleSrc": "./live-examples/css-examples/motion-path/offset-playback.js",
         "fileName": "offset-rotate.html",
         "title": "CSS Demo: offset-rotate",
         "type": "css"

--- a/live-examples/css-examples/motion-path/meta.json
+++ b/live-examples/css-examples/motion-path/meta.json
@@ -1,0 +1,25 @@
+{
+  "pages": {
+    "offsetPath": {
+        "cssExampleSrc": "./live-examples/css-examples/motion-path/offset-path.css",
+        "exampleCode": "./live-examples/css-examples/motion-path/offset-path.html",
+        "fileName": "offset-path.html",
+        "title": "CSS Demo: offset-path",
+        "type": "css"
+    },
+    "offsetDistance": {
+        "cssExampleSrc": "./live-examples/css-examples/motion-path/offset-distance.css",
+        "exampleCode": "./live-examples/css-examples/motion-path/offset-distance.html",
+        "fileName": "offset-distance.html",
+        "title": "CSS Demo: offset-distance",
+        "type": "css"
+    },
+    "offsetRotate": {
+        "cssExampleSrc": "./live-examples/css-examples/motion-path/offset-rotate.css",
+        "exampleCode": "./live-examples/css-examples/motion-path/offset-rotate.html",
+        "fileName": "offset-rotate.html",
+        "title": "CSS Demo: offset-rotate",
+        "type": "css"
+    }
+  }
+}

--- a/live-examples/css-examples/motion-path/offset-distance.css
+++ b/live-examples/css-examples/motion-path/offset-distance.css
@@ -1,0 +1,12 @@
+#example-element {
+  width: 20px;
+  height: 20px;
+  background: #2BC4A2;
+  offset-path: path('M-40,-20 C-40,70 40,70 40,-20');
+  clip-path: polygon(0% 0%, 70% 0%, 100% 50%, 70% 100%, 0% 100%, 30% 50%);
+}
+#default-example {
+  background-position: calc(50% - 8px) calc(50% + 18px);
+  background-repeat: no-repeat;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-45 -25 90 100" width="90" height="100"><path d="M-40,-20 C-40,70 40,70 40,-20" fill="none" stroke="lightgrey" stroke-width="3" stroke-dasharray="4"/></svg>');
+}

--- a/live-examples/css-examples/motion-path/offset-distance.css
+++ b/live-examples/css-examples/motion-path/offset-distance.css
@@ -1,12 +1,14 @@
 #example-element {
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
   background: #2BC4A2;
-  offset-path: path('M-40,-20 C-40,70 40,70 40,-20');
+  offset-path: path('M-70,-40 C-70,70 70,70 70,-40');
   clip-path: polygon(0% 0%, 70% 0%, 100% 50%, 70% 100%, 0% 100%, 30% 50%);
 }
+
+/* Provides a reference image of what path the element is following */
 #default-example {
-  background-position: calc(50% - 8px) calc(50% + 18px);
+  background-position: calc(50% - 12px) calc(50% + 14px);
   background-repeat: no-repeat;
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-45 -25 90 100" width="90" height="100"><path d="M-40,-20 C-40,70 40,70 40,-20" fill="none" stroke="lightgrey" stroke-width="3" stroke-dasharray="4"/></svg>');
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-75 -45 150 140" width="150" height="140"><path d="M-70,-40 C-70,70 70,70 70,-40" fill="none" stroke="lightgrey" stroke-width="2" stroke-dasharray="4.5"/></svg>');
 }

--- a/live-examples/css-examples/motion-path/offset-distance.html
+++ b/live-examples/css-examples/motion-path/offset-distance.html
@@ -1,0 +1,30 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="offset-distance">
+
+  <div class="example-choice" initial-choice="true">
+    <pre><code class="language-css">offset-distance: 0%</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">offset-distance: 80%</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">offset-distance: 50px</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+</section>
+
+<div id="output" class="output large hidden">
+  <section id="default-example" class="default-example">
+    <div id="example-element" class="transition-all"></div>
+  </section>
+</div>

--- a/live-examples/css-examples/motion-path/offset-distance.html
+++ b/live-examples/css-examples/motion-path/offset-distance.html
@@ -1,21 +1,21 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="offset-distance">
 
   <div class="example-choice" initial-choice="true">
-    <pre><code class="language-css">offset-distance: 0%</code></pre>
+    <pre><code class="language-css">offset-distance: 0%;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">offset-distance: 80%</code></pre>
+    <pre><code class="language-css">offset-distance: 80%;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">offset-distance: 50px</code></pre>
+    <pre><code class="language-css">offset-distance: 50px;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>

--- a/live-examples/css-examples/motion-path/offset-path.css
+++ b/live-examples/css-examples/motion-path/offset-path.css
@@ -1,9 +1,20 @@
 #example-element {
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
   background: #2BC4A2;
-  animation: distance 10000ms infinite linear;
+  animation: distance 8000ms infinite linear;
+  animation-play-state: paused;
   clip-path: polygon(0% 0%, 70% 0%, 100% 50%, 70% 100%, 0% 100%, 30% 50%);
+}
+#example-element.running {
+  animation-play-state: running;
+}
+
+#playback {
+  position: absolute;
+  top: 0;
+  left: 0;
+  font-size: 1em;
 }
 
 @keyframes distance {
@@ -13,4 +24,8 @@
   100% {
     offset-distance: 100%;
   }
+}
+
+#default-example {
+  position: relative;
 }

--- a/live-examples/css-examples/motion-path/offset-path.css
+++ b/live-examples/css-examples/motion-path/offset-path.css
@@ -1,0 +1,16 @@
+#example-element {
+  width: 20px;
+  height: 20px;
+  background: #2BC4A2;
+  animation: distance 10000ms infinite linear;
+  clip-path: polygon(0% 0%, 70% 0%, 100% 50%, 70% 100%, 0% 100%, 30% 50%);
+}
+
+@keyframes distance {
+  0% {
+    offset-distance: 0%;
+  }
+  100% {
+    offset-distance: 100%;
+  }
+}

--- a/live-examples/css-examples/motion-path/offset-path.html
+++ b/live-examples/css-examples/motion-path/offset-path.html
@@ -1,14 +1,14 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="offset-path">
 
   <div class="example-choice" initial-choice="true">
-    <pre><code class="language-css">offset-path: path('M-70,-40 C-70,70 70,70 70,-40')</code></pre>
+    <pre><code class="language-css">offset-path: path('M-70,-40 C-70,70 70,70 70,-40');</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">offset-path: path('M0,0 L60,70 L-60,30z')</code></pre>
+    <pre><code class="language-css">offset-path: path('M0,0 L60,70 L-60,30z');</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>

--- a/live-examples/css-examples/motion-path/offset-path.html
+++ b/live-examples/css-examples/motion-path/offset-path.html
@@ -8,7 +8,7 @@
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">offset-path: path('M0,0 L60,-40 L-40,-20z')</code></pre>
+    <pre><code class="language-css">offset-path: path('M0,0 L60,70 L-60,30z')</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
@@ -19,5 +19,6 @@
 <div id="output" class="output large hidden">
   <section id="default-example" class="default-example">
     <div id="example-element" class="transition-all"></div>
+    <button type="button" id="playback">Play</button>
   </section>
 </div>

--- a/live-examples/css-examples/motion-path/offset-path.html
+++ b/live-examples/css-examples/motion-path/offset-path.html
@@ -1,0 +1,23 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="offset-path">
+
+  <div class="example-choice" initial-choice="true">
+    <pre><code class="language-css">offset-path: path('M-70,-40 C-70,70 70,70 70,-40')</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">offset-path: path('M0,0 L60,-40 L-40,-20z')</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+</section>
+
+<div id="output" class="output large hidden">
+  <section id="default-example" class="default-example">
+    <div id="example-element" class="transition-all"></div>
+  </section>
+</div>

--- a/live-examples/css-examples/motion-path/offset-playback.js
+++ b/live-examples/css-examples/motion-path/offset-playback.js
@@ -1,0 +1,14 @@
+window.addEventListener('load', function() {
+  var example = document.getElementById('example-element');
+  var button = document.getElementById('playback');
+
+  button.addEventListener('click', function() {
+    if (example.classList.contains('running')) {
+      example.classList.remove('running');
+      button.textContent = 'Play';
+    } else {
+      example.classList.add('running');
+      button.textContent = 'Pause';
+    }
+  });
+});

--- a/live-examples/css-examples/motion-path/offset-rotate.css
+++ b/live-examples/css-examples/motion-path/offset-rotate.css
@@ -1,10 +1,21 @@
 #example-element {
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
   background: #2BC4A2;
-  offset-path: path('M-40,-20 C-40,70 40,70 40,-20');
-  animation: distance 10000ms infinite linear;
+  offset-path: path('M-70,-40 C-70,70 70,70 70,-40');
+  animation: distance 8000ms infinite linear;
+  animation-play-state: paused;
   clip-path: polygon(0% 0%, 70% 0%, 100% 50%, 70% 100%, 0% 100%, 30% 50%);
+}
+#example-element.running {
+  animation-play-state: running;
+}
+
+#playback {
+  position: absolute;
+  top: 0;
+  left: 0;
+  font-size: 1em;
 }
 
 @keyframes distance {
@@ -16,8 +27,10 @@
   }
 }
 
+/* Provides a reference image of what path the element is following */
 #default-example {
-  background-position: calc(50% - 8px) calc(50% + 18px);
+  position: relative;
+  background-position: calc(50% - 12px) calc(50% + 14px);
   background-repeat: no-repeat;
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-45 -25 90 100" width="90" height="100"><path d="M-40,-20 C-40,70 40,70 40,-20" fill="none" stroke="lightgrey" stroke-width="3" stroke-dasharray="4"/></svg>');
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-75 -45 150 140" width="150" height="140"><path d="M-70,-40 C-70,70 70,70 70,-40" fill="none" stroke="lightgrey" stroke-width="2" stroke-dasharray="4.5"/></svg>');
 }

--- a/live-examples/css-examples/motion-path/offset-rotate.css
+++ b/live-examples/css-examples/motion-path/offset-rotate.css
@@ -1,0 +1,23 @@
+#example-element {
+  width: 20px;
+  height: 20px;
+  background: #2BC4A2;
+  offset-path: path('M-40,-20 C-40,70 40,70 40,-20');
+  animation: distance 10000ms infinite linear;
+  clip-path: polygon(0% 0%, 70% 0%, 100% 50%, 70% 100%, 0% 100%, 30% 50%);
+}
+
+@keyframes distance {
+  0% {
+    offset-distance: 0%;
+  }
+  100% {
+    offset-distance: 100%;
+  }
+}
+
+#default-example {
+  background-position: calc(50% - 8px) calc(50% + 18px);
+  background-repeat: no-repeat;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-45 -25 90 100" width="90" height="100"><path d="M-40,-20 C-40,70 40,70 40,-20" fill="none" stroke="lightgrey" stroke-width="3" stroke-dasharray="4"/></svg>');
+}

--- a/live-examples/css-examples/motion-path/offset-rotate.html
+++ b/live-examples/css-examples/motion-path/offset-rotate.html
@@ -1,0 +1,37 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="offset-rotate">
+
+  <div class="example-choice" initial-choice="true">
+    <pre><code class="language-css">offset-rotate: auto</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">offset-rotate: 90deg</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">offset-rotate: auto 90deg</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">offset-rotate: reverse</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+</section>
+  
+<div id="output" class="output large hidden">
+  <section id="default-example" class="default-example">
+    <div id="example-element" class="transition-all"></div>
+  </section>
+</div>

--- a/live-examples/css-examples/motion-path/offset-rotate.html
+++ b/live-examples/css-examples/motion-path/offset-rotate.html
@@ -33,5 +33,6 @@
 <div id="output" class="output large hidden">
   <section id="default-example" class="default-example">
     <div id="example-element" class="transition-all"></div>
+    <button type="button" id="playback">Play</button>
   </section>
 </div>

--- a/live-examples/css-examples/motion-path/offset-rotate.html
+++ b/live-examples/css-examples/motion-path/offset-rotate.html
@@ -1,28 +1,28 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="offset-rotate">
 
   <div class="example-choice" initial-choice="true">
-    <pre><code class="language-css">offset-rotate: auto</code></pre>
+    <pre><code class="language-css">offset-rotate: auto;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">offset-rotate: 90deg</code></pre>
+    <pre><code class="language-css">offset-rotate: 90deg;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">offset-rotate: auto 90deg</code></pre>
+    <pre><code class="language-css">offset-rotate: auto 90deg;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">offset-rotate: reverse</code></pre>
+    <pre><code class="language-css">offset-rotate: reverse;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>


### PR DESCRIPTION
This PR adds demos for `offset-path` (only showing the `path()` syntax for now since that is the only supported function in browsers currently (Blink and Firefox Nightly)), `offset-rotate`, and `offset-distance`.

The offset properties are interesting that by themselves they don't really show much. For example, defining an `offset-path` but nothing else shows very little, as it simply defines a path that it will follow when adjusted by the other `offset` properties. Similarly `offset-distance` and `offset-rotate` are meaningless without an `offset-path` defined.

For `offset-distance` and `offset-rotate`, I added a background image that represents a common `offset-path` that the examples all use. I'm concerned that could be confusing since the path is technically invisible, but it felt more important to have a visual reference for the path it is following in those contexts.

For `offset-path` and `offset-rotate` I added a playback control, since they are easier to understand if you animate the `offset-distance` from `0%` to `100%`. I did not want to have the animation auto playing for accessibility reasons, and that followed a pattern I saw with other animating demos in this repository.