### PR TITLE
encodeURI() Example Removed Extra Quotation Mark

### DIFF
--- a/live-examples/js-examples/globalprops/globalprops-encodeuri.html
+++ b/live-examples/js-examples/globalprops/globalprops-encodeuri.html
@@ -6,7 +6,7 @@ console.log(encoded);
 
 try {
   console.log(decodeURI(encoded));
-  // expected output: "https://mozilla.org/?x=шеллы""
+  // expected output: "https://mozilla.org/?x=шеллы"
 } catch(e) { // catches a malformed URI
   console.error(e);
 }


### PR DESCRIPTION
I was reading the documentation for encodeURI() and noticed that the example had an extra quotation mark in the comment. This edit fixes it.