### PR TITLE
Adding optional chaining operator example

### DIFF
--- a/live-examples/js-examples/expressions/expressions-optionalchainingoperator.html
+++ b/live-examples/js-examples/expressions/expressions-optionalchainingoperator.html
@@ -2,7 +2,7 @@
 <code id="static-js">const adventurer = {
   name: 'Alice',
   cat: {
-    name:'Dinah'
+    name: 'Dinah'
   }
 };
 
@@ -10,7 +10,7 @@ const dogName = adventurer.dog?.name;
 console.log(dogName);
 // expected output: undefined
 
-console.log(adventurer.someNonExistingMethod?.())
+console.log(adventurer.someNonExistentMethod?.())
 // expected output: undefined
 </code>
 </pre>

--- a/live-examples/js-examples/expressions/expressions-optionalchainingoperator.html
+++ b/live-examples/js-examples/expressions/expressions-optionalchainingoperator.html
@@ -1,0 +1,16 @@
+<pre>
+<code id="static-js">const adventurer = {
+  name: 'Alice',
+  cat: {
+    name:'Dinah'
+  }
+};
+
+const dogName = adventurer.dog?.name;
+console.log(dogName);
+// expected output: undefined
+
+console.log(adventurer.someNonExistingMethod?.())
+// expected output: undefined
+</code>
+</pre>

--- a/live-examples/js-examples/expressions/meta.json
+++ b/live-examples/js-examples/expressions/meta.json
@@ -114,7 +114,7 @@
             "title": "JavaScript Demo: Expressions - Operator precedence",
             "type": "js"
         },
-        "expressionsOtionalChainingOperator": {
+        "expressionsOptionalChainingOperator": {
             "exampleCode": "./live-examples/js-examples/expressions/expressions-optionalchainingoperator.html",
             "fileName": "expressions-optionalchainingoperator.html",
             "title": "JavaScript Demo: Expressions - Optional chaining operator",

--- a/live-examples/js-examples/expressions/meta.json
+++ b/live-examples/js-examples/expressions/meta.json
@@ -114,6 +114,12 @@
             "title": "JavaScript Demo: Expressions - Operator precedence",
             "type": "js"
         },
+        "expressionsOtionalChainingOperator": {
+            "exampleCode": "./live-examples/js-examples/expressions/expressions-optionalchainingoperator.html",
+            "fileName": "expressions-optionalchainingoperator.html",
+            "title": "JavaScript Demo: Expressions - Optional chaining operator",
+            "type": "js"
+        },
         "expressionsPropertyAccessors": {
             "exampleCode": "./live-examples/js-examples/expressions/expressions-propertyaccessors.html",
             "fileName": "expressions-propertyaccessors.html",


### PR DESCRIPTION
This adds a basic interactive example for a new (stage 3) operator

- Spec: https://github.com/tc39/proposal-optional-chaining/
- Target page on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining
- Bug for implementation with DDN: https://bugzilla.mozilla.org/show_bug.cgi?id=1566143