### PR TITLE
Fix #1240 - [HTML Examples] input ~ <input type="time">

### DIFF
--- a/live-examples/html-examples/input/time.html
+++ b/live-examples/html-examples/input/time.html
@@ -1,6 +1,6 @@
 <label for="appt">Choose a time for your meeting:</label>
 
 <input type="time" id="appt" name="appt"
-       min="9:00" max="18:00" required>
+       min="09:00" max="18:00" required>
 
 <small>Office hours are 9am to 6pm</small>


### PR DESCRIPTION
Fixes issue where the `[min]` attribute of the `<input type="time">` element was not in proper time value format.