### PR TITLE
Fix #1351 - <meter> example has name attribute, but name attribute not listed in docs

### DIFF
--- a/live-examples/html-examples/forms/meter.html
+++ b/live-examples/html-examples/forms/meter.html
@@ -1,6 +1,6 @@
 <label for="fuel">Fuel level:</label>
 
-<meter id="fuel" name="fuel"
+<meter id="fuel"
        min="0" max="100"
        low="33" high="66" optimum="80"
        value="50">


### PR DESCRIPTION
The `<meter>` element is an output, not an input type element that can POST to a form. The `[name]` attribute is not valid on this element.