### PR TITLE
Fix #1404 - array filter example is not inline with the browser compatibility table

### DIFF
--- a/live-examples/js-examples/array/array-filter.html
+++ b/live-examples/js-examples/array/array-filter.html
@@ -1,7 +1,9 @@
 <pre>
 <code id="static-js">var words = ['spray', 'limit', 'elite', 'exuberant', 'destruction', 'present'];
 
-const result = words.filter(word => word.length > 6);
+var result = words.filter(function(word) {
+  return word.length > 6;
+});
 
 console.log(result);
 // expected output: Array ["exuberant", "destruction", "present"]

--- a/live-examples/js-examples/array/array-map.html
+++ b/live-examples/js-examples/array/array-map.html
@@ -2,7 +2,9 @@
 <code id="static-js">var array1 = [1, 4, 9, 16];
 
 // pass a function to map
-const map1 = array1.map(x => x * 2);
+var map1 = array1.map(function(x) {
+  return x * 2;
+});
 
 console.log(map1);
 // expected output: Array [2, 8, 18, 32]

--- a/live-examples/js-examples/array/array-reduce-right.html
+++ b/live-examples/js-examples/array/array-reduce-right.html
@@ -1,7 +1,7 @@
 <pre>
-<code id="static-js">const array1 = [[0, 1], [2, 3], [4, 5]].reduceRight(
-  (accumulator, currentValue) => accumulator.concat(currentValue)
-);
+<code id="static-js">var array1 = [[0, 1], [2, 3], [4, 5]].reduceRight(function(accumulator, currentValue) {
+  return accumulator.concat(currentValue);
+});
 
 console.log(array1);
 // expected output: Array [4, 5, 2, 3, 0, 1]

--- a/live-examples/js-examples/array/array-reduce.html
+++ b/live-examples/js-examples/array/array-reduce.html
@@ -1,6 +1,8 @@
 <pre>
-<code id="static-js">const array1 = [1, 2, 3, 4];
-const reducer = (accumulator, currentValue) => accumulator + currentValue;
+<code id="static-js">var array1 = [1, 2, 3, 4];
+function reducer(accumulator, currentValue) {
+  return accumulator + currentValue;
+}
 
 // 1 + 2 + 3 + 4
 console.log(array1.reduce(reducer));


### PR DESCRIPTION
Fixes #1404

According to https://github.com/mdn/interactive-examples/blob/master/JS-Example-Style-Guide.md#language-choice-es5es6

> For more established example content, such as Arrays, it is recommended that we stick with ES5.

This patch downgrades 4 array examples to ES5 to align with the compatibility chart for each of the APIs. 