### PR TITLE
Fix #1409 - Make interactive examples style guide consistent with MDN examples style guide

### DIFF
--- a/JS-Example-Style-Guide.md
+++ b/JS-Example-Style-Guide.md
@@ -123,9 +123,9 @@ try {
 
 ## JavaScript coding style
 
-### Language choice (ES5/ES6)
+### Language choice (ES6)
 
-For more established example content, such as Arrays, it is recommended that we stick with ES5. Where examples are required for APIs standardized after ES6, aim to use ES6 to illustrate these examples.
+According to the general [MDN JS guideline](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Guidelines/Code_guidelines/JavaScript#Use_ES6_features), aim to use ES6 to illustrate examples.
 
 ES6 examples should use:
 


### PR DESCRIPTION
Referencing #1404, this should resolve the discrepancy of when to use ES5/ES6 by updating the style guide to reflect that MDN guidelines specify to use ES6 for examples when possible.