### PR TITLE
Adding examples overflow-block and overflow-inline

### DIFF
--- a/live-examples/css-examples/basic-box-model/meta.json
+++ b/live-examples/css-examples/basic-box-model/meta.json
@@ -126,6 +126,20 @@
             "title": "CSS Demo: overflow",
             "type": "css"
         },
+        "overflowBlock": {
+            "cssExampleSrc": "./live-examples/css-examples/basic-box-model/overflow.css",
+            "exampleCode": "./live-examples/css-examples/basic-box-model/overflow-block.html",
+            "fileName": "overflow-block.html",
+            "title": "CSS Demo: overflow-block",
+            "type": "css"
+        },
+        "overflowInline": {
+            "cssExampleSrc": "./live-examples/css-examples/basic-box-model/overflow.css",
+            "exampleCode": "./live-examples/css-examples/basic-box-model/overflow-inline.html",
+            "fileName": "overflow-inline.html",
+            "title": "CSS Demo: overflow-inline",
+            "type": "css"
+        },
         "overflowX": {
             "cssExampleSrc": "./live-examples/css-examples/basic-box-model/overflow.css",
             "exampleCode": "./live-examples/css-examples/basic-box-model/overflow-x.html",

--- a/live-examples/css-examples/basic-box-model/overflow-block.html
+++ b/live-examples/css-examples/basic-box-model/overflow-block.html
@@ -1,0 +1,37 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="overflow-block">
+
+    <div class="example-choice">
+        <pre><code class="language-css">overflow-block: visible;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">overflow-block: hidden;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">overflow-block: scroll;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">overflow-block: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <p id="example-element">Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather. As much mud in the streets as if the waters had but newly retired from the face of the earth.</p>
+    </section>
+</div>

--- a/live-examples/css-examples/basic-box-model/overflow-inline.html
+++ b/live-examples/css-examples/basic-box-model/overflow-inline.html
@@ -1,0 +1,39 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="overflow-inline">
+
+    <div class="example-choice">
+        <pre><code class="language-css">overflow-inline: visible;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">overflow-inline: hidden;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">overflow-inline: scroll;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">overflow-inline: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <div id="example-element">The value of Pi is
+          3.1415926535897932384626433832795029. The value of e is
+          2.7182818284590452353602874713526625.</div>
+    </section>
+</div>


### PR DESCRIPTION
These properties are shipping in Firefox 69, and the examples are essentially a copy of `overflow-x` and `overflow-y` as the flow relative properties map to these.

https://bugzilla.mozilla.org/show_bug.cgi?id=1470695