### PR TITLE
Build script now will now set HOME variable to /mdn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ jspm_packages
 
 # project specific
 /docs/
+
+# config directory output from docker build
+.config

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 cd "$(dirname ${BASH_SOURCE[0]})"/..
 echo "Starting build"
-docker run -v "$PWD":/mdn -w /mdn node:latest bash -c "rm -rf node_modules && /usr/local/bin/npm install && /usr/local/bin/npm run build"
+docker run -v "$PWD":/mdn -w /mdn -e HOME=/mdn node:latest bash -c "rm -rf node_modules && /usr/local/bin/npm install && /usr/local/bin/npm run build"
 if [ $? -eq 0 ]; then
     echo "Build finished"
     exit 0


### PR DESCRIPTION
Update build script to have docker pass the HOME environment variable.
This ensures all the directories node creates has the right permissions
which will allow the jenkins workspace cleaner to work properly.