### PR TITLE
Updated img example to HTML5

### DIFF
--- a/live-examples/html-examples/image-and-multimedia/img.html
+++ b/live-examples/html-examples/image-and-multimedia/img.html
@@ -1,3 +1,3 @@
 <img class="fit-picture"
      src="/media/examples/grapefruit-slice-332-332.jpg"
-     alt="Grapefruit slice atop a pile of other slices" />
+     alt="Grapefruit slice atop a pile of other slices">


### PR DESCRIPTION
The example used '/>' which was used in XHTML.
Now it uses proper HTML5. i.e. '>'