### PR TITLE
More up-to-date method on console

### DIFF
--- a/live-examples/js-examples/statement/statement-throw.html
+++ b/live-examples/js-examples/statement/statement-throw.html
@@ -9,7 +9,7 @@ try {
   getRectArea(3, 'A');
 }
 catch(e) {
-  console.log(e);
+  console.error(e);
   // expected output: "Parameter is not a number!"
 }
 </code>


### PR DESCRIPTION
Throw's generating error message so it should go to console.error() not console.log().