### PR TITLE
console method changed to console.error()

### DIFF
--- a/live-examples/js-examples/promise/promise-reject.html
+++ b/live-examples/js-examples/promise/promise-reject.html
@@ -4,7 +4,7 @@
 }
 
 function rejected(result) {
-  console.log(result);
+  console.error(result);
 }
 
 Promise.reject(new Error('fail')).then(resolved, rejected);


### PR DESCRIPTION
Current practice is to emit errors through console.error() not console.log()