### PR TITLE
Apply npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "7.0.0"
+                "@babel/highlight": "^7.0.0"
             }
         },
         "@babel/core": {
@@ -125,6 +125,12 @@
                     "requires": {
                         "minimist": "^1.2.0"
                     }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
                 },
                 "minimist": {
                     "version": "1.2.0",
@@ -279,9 +285,9 @@
             "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "esutils": "2.0.2",
-                "js-tokens": "4.0.0"
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
             }
         },
         "@babel/parser": {
@@ -685,7 +691,7 @@
             "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
             "dev": true,
             "requires": {
-                "string-width": "2.1.1"
+                "string-width": "^2.0.0"
             }
         },
         "ansi-escapes": {
@@ -706,7 +712,7 @@
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
             "requires": {
-                "color-convert": "1.9.3"
+                "color-convert": "^1.9.0"
             }
         },
         "aproba": {
@@ -737,7 +743,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -749,7 +755,7 @@
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
             "dev": true
         },
         "arr-union": {
@@ -788,7 +794,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -815,7 +821,7 @@
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "dev": true,
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": "~2.1.0"
             }
         },
         "asn1.js": {
@@ -897,12 +903,12 @@
             "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
             "dev": true,
             "requires": {
-                "browserslist": "2.11.3",
-                "caniuse-lite": "1.0.30000900",
-                "normalize-range": "0.1.2",
-                "num2fraction": "1.2.2",
-                "postcss": "6.0.23",
-                "postcss-value-parser": "3.3.1"
+                "browserslist": "^2.11.3",
+                "caniuse-lite": "^1.0.30000805",
+                "normalize-range": "^0.1.2",
+                "num2fraction": "^1.2.2",
+                "postcss": "^6.0.17",
+                "postcss-value-parser": "^3.2.3"
             },
             "dependencies": {
                 "browserslist": {
@@ -911,8 +917,8 @@
                     "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
                     "dev": true,
                     "requires": {
-                        "caniuse-lite": "1.0.30000900",
-                        "electron-to-chromium": "1.3.82"
+                        "caniuse-lite": "^1.0.30000792",
+                        "electron-to-chromium": "^1.3.30"
                     }
                 }
             }
@@ -1207,13 +1213,13 @@
         },
         "babel-plugin-syntax-async-functions": {
             "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+            "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
             "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
             "dev": true
         },
         "babel-plugin-syntax-exponentiation-operator": {
             "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+            "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
             "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
             "dev": true
         },
@@ -1575,7 +1581,7 @@
                 "regenerator-runtime": {
                     "version": "0.11.1",
                     "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-                    "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+                    "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
                     "dev": true
                 }
             }
@@ -1633,7 +1639,7 @@
         "babylon": {
             "version": "6.18.0",
             "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-            "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+            "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
             "dev": true
         },
         "bail": {
@@ -1654,13 +1660,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -1669,7 +1675,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -1678,7 +1684,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -1687,7 +1693,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -1696,9 +1702,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -1724,7 +1730,7 @@
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "dev": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "bluebird": {
@@ -1736,7 +1742,7 @@
         "bn.js": {
             "version": "4.11.8",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+            "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
             "dev": true
         },
         "boxen": {
@@ -1745,13 +1751,13 @@
             "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
             "dev": true,
             "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "2.4.1",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.1",
-                "term-size": "1.2.0",
-                "widest-line": "2.0.1"
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^2.0.0"
             }
         },
         "brace-expansion": {
@@ -1760,7 +1766,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -1770,16 +1776,16 @@
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "repeat-element": "1.1.3",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -1788,7 +1794,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -1984,7 +1990,7 @@
         "browserify-zlib": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-            "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+            "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
             "dev": true,
             "requires": {
                 "pako": "~1.0.5"
@@ -2115,15 +2121,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             }
         },
         "cacheable-request": {
@@ -2211,8 +2217,8 @@
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
             "dev": true,
             "requires": {
-                "camelcase": "2.1.1",
-                "map-obj": "1.0.1"
+                "camelcase": "^2.0.0",
+                "map-obj": "^1.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -2253,9 +2259,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.5.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             }
         },
         "character-entities": {
@@ -2443,7 +2449,7 @@
         "cipher-base": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
             "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
@@ -2462,10 +2468,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -2474,7 +2480,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -2508,7 +2514,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "2.0.0"
+                "restore-cursor": "^2.0.0"
             }
         },
         "cli-width": {
@@ -2611,8 +2617,8 @@
             "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
             "dev": true,
             "requires": {
-                "is-regexp": "1.0.0",
-                "is-supported-regexp-flag": "1.0.1"
+                "is-regexp": "^1.0.0",
+                "is-supported-regexp-flag": "^1.0.0"
             }
         },
         "clone-response": {
@@ -2648,8 +2654,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color-convert": {
@@ -2691,7 +2697,7 @@
             "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -2733,10 +2739,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             }
         },
         "configstore": {
@@ -2745,12 +2751,12 @@
             "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
             "dev": true,
             "requires": {
-                "dot-prop": "4.2.0",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.3.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.3.0",
-                "xdg-basedir": "3.0.0"
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
             }
         },
         "console-browserify": {
@@ -2866,7 +2872,7 @@
             "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
             "dev": true,
             "requires": {
-                "capture-stack-trace": "1.0.1"
+                "capture-stack-trace": "^1.0.0"
             }
         },
         "create-hash": {
@@ -2902,15 +2908,15 @@
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.3",
-                "shebang-command": "1.2.0",
-                "which": "1.3.1"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "crypto-browserify": {
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+            "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
             "dev": true,
             "requires": {
                 "browserify-cipher": "^1.0.0",
@@ -2938,7 +2944,7 @@
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
             "dev": true,
             "requires": {
-                "array-find-index": "1.0.2"
+                "array-find-index": "^1.0.1"
             }
         },
         "cyclist": {
@@ -2959,7 +2965,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "date-now": {
@@ -2989,8 +2995,8 @@
             "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
             "dev": true,
             "requires": {
-                "decamelize": "1.2.0",
-                "map-obj": "1.0.1"
+                "decamelize": "^1.1.0",
+                "map-obj": "^1.0.0"
             }
         },
         "decode-uri-component": {
@@ -3041,8 +3047,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -3051,7 +3057,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -3060,7 +3066,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -3069,9 +3075,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -3088,18 +3094,18 @@
             "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
             "dev": true,
             "requires": {
-                "globby": "5.0.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.1",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "rimraf": "2.6.2"
+                "globby": "^5.0.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "rimraf": "^2.2.8"
             },
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 }
@@ -3190,8 +3196,8 @@
             "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "path-type": "3.0.0"
+                "arrify": "^1.0.1",
+                "path-type": "^3.0.0"
             }
         },
         "dlv": {
@@ -3206,13 +3212,13 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.2"
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
                     "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
                     "dev": true
                 }
@@ -3226,7 +3232,7 @@
         },
         "domelementtype": {
             "version": "1.3.0",
-            "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
             "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
             "dev": true
         },
@@ -3236,7 +3242,7 @@
             "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
             }
         },
         "domutils": {
@@ -3245,8 +3251,8 @@
             "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
             "dev": true,
             "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "dot-prop": {
@@ -3255,7 +3261,7 @@
             "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "duplexer2": {
@@ -3291,25 +3297,25 @@
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "dev": true,
             "requires": {
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "ecstatic": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.0.tgz",
-            "integrity": "sha512-EblWYTd+wPIAMQ0U4oYJZ7QBypT9ZUIwpqli0bKDjeIIQnXDBK2dXtZ9yzRCOlkW1HkO8gn7/FxLK1yPIW17pw==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+            "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
             "dev": true,
             "requires": {
-                "he": "1.2.0",
-                "mime": "1.6.0",
-                "minimist": "1.2.0",
-                "url-join": "2.0.5"
+                "he": "^1.1.1",
+                "mime": "^1.6.0",
+                "minimist": "^1.1.0",
+                "url-join": "^2.0.5"
             },
             "dependencies": {
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                     "dev": true
                 }
@@ -3378,7 +3384,7 @@
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es-abstract": {
@@ -3713,12 +3719,6 @@
                 "estraverse": "^4.1.1"
             }
         },
-        "eslint-utils": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-            "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-            "dev": true
-        },
         "eslint-visitor-keys": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -3768,7 +3768,7 @@
             "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.0.0"
             }
         },
         "esrecurse": {
@@ -3777,7 +3777,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.1.0"
             }
         },
         "estraverse": {
@@ -3807,7 +3807,7 @@
         "evp_bytestokey": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
             "dev": true,
             "requires": {
                 "md5.js": "^1.3.4",
@@ -3820,13 +3820,13 @@
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
             "dev": true,
             "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
             }
         },
         "execall": {
@@ -3835,7 +3835,7 @@
             "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
             "dev": true,
             "requires": {
-                "clone-regexp": "1.0.1"
+                "clone-regexp": "^1.0.0"
             }
         },
         "expand-brackets": {
@@ -3844,13 +3844,13 @@
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -3859,7 +3859,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -3868,7 +3868,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -3879,7 +3879,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.4"
+                "fill-range": "^2.1.0"
             },
             "dependencies": {
                 "fill-range": {
@@ -3888,11 +3888,11 @@
                     "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
                     "dev": true,
                     "requires": {
-                        "is-number": "2.1.0",
-                        "isobject": "2.1.0",
-                        "randomatic": "3.1.1",
-                        "repeat-element": "1.1.3",
-                        "repeat-string": "1.6.1"
+                        "is-number": "^2.1.0",
+                        "isobject": "^2.0.0",
+                        "randomatic": "^3.0.0",
+                        "repeat-element": "^1.1.2",
+                        "repeat-string": "^1.5.2"
                     }
                 },
                 "is-number": {
@@ -3901,7 +3901,7 @@
                     "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "isobject": {
@@ -3919,7 +3919,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -3936,8 +3936,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -3946,7 +3946,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -3968,14 +3968,14 @@
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -3984,7 +3984,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -3993,7 +3993,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -4002,7 +4002,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -4011,7 +4011,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -4020,9 +4020,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -4077,7 +4077,7 @@
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "1.0.5"
+                "escape-string-regexp": "^1.0.5"
             }
         },
         "file-entry-cache": {
@@ -4086,8 +4086,8 @@
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
             "dev": true,
             "requires": {
-                "flat-cache": "1.3.0",
-                "object-assign": "4.1.1"
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
             }
         },
         "filename-regex": {
@@ -4102,10 +4102,10 @@
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -4114,7 +4114,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -4125,7 +4125,7 @@
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "dev": true,
             "requires": {
-                "locate-path": "2.0.0"
+                "locate-path": "^2.0.0"
             }
         },
         "flat-cache": {
@@ -4134,10 +4134,10 @@
             "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
             "dev": true,
             "requires": {
-                "circular-json": "0.3.3",
-                "del": "2.2.2",
-                "graceful-fs": "4.1.11",
-                "write": "0.2.1"
+                "circular-json": "^0.3.1",
+                "del": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "write": "^0.2.1"
             }
         },
         "flatted": {
@@ -4162,7 +4162,7 @@
             "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0"
+                "debug": "=3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -4188,7 +4188,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -4203,9 +4203,9 @@
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.7",
-                "mime-types": "2.1.21"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
             }
         },
         "fragment-cache": {
@@ -4214,7 +4214,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "from2": {
@@ -4267,7 +4267,7 @@
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
             "dev": true
         },
         "functional-red-black-tree": {
@@ -4371,7 +4371,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "git-config-path": {
@@ -4398,12 +4398,12 @@
             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -4412,8 +4412,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -4422,7 +4422,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -4437,7 +4437,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -4448,8 +4448,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             },
             "dependencies": {
                 "is-glob": {
@@ -4458,7 +4458,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 }
             }
@@ -4475,7 +4475,7 @@
             "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
             "dev": true,
             "requires": {
-                "ini": "1.3.5"
+                "ini": "^1.3.4"
             }
         },
         "global-modules": {
@@ -4510,17 +4510,17 @@
             "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "glob": "7.1.3",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 }
@@ -4538,12 +4538,12 @@
             "integrity": "sha512-Kjhohco0esHQnOiqqdJeNz/5fyPkOMD/d6XVjwTAoPGUFh0mCollPUTUTa2OZy4dYNAqlPIQdTiNzJTWdd9Htw==",
             "dev": true,
             "requires": {
-                "minimist": "1.1.3"
+                "minimist": "1.1.x"
             },
             "dependencies": {
                 "minimist": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
                     "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
                     "dev": true
                 }
@@ -4551,21 +4551,21 @@
         },
         "got": {
             "version": "6.7.1",
-            "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+            "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
             "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
             "dev": true,
             "requires": {
-                "create-error-class": "3.0.2",
-                "duplexer3": "0.1.4",
-                "get-stream": "3.0.0",
-                "is-redirect": "1.0.0",
-                "is-retry-allowed": "1.1.0",
-                "is-stream": "1.1.0",
-                "lowercase-keys": "1.0.1",
-                "safe-buffer": "5.1.2",
-                "timed-out": "4.0.1",
-                "unzip-response": "2.0.1",
-                "url-parse-lax": "1.0.0"
+                "create-error-class": "^3.0.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-redirect": "^1.0.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "lowercase-keys": "^1.0.0",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "unzip-response": "^2.0.1",
+                "url-parse-lax": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -4586,8 +4586,8 @@
             "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+                "ajv": "^5.3.0",
+                "har-schema": "^2.0.0"
             },
             "dependencies": {
                 "ajv": {
@@ -4596,15 +4596,15 @@
                     "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
                     "dev": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "fast-deep-equal": "1.1.0",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1"
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
                     }
                 },
                 "fast-deep-equal": {
                     "version": "1.1.0",
-                    "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
                     "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
                     "dev": true
                 },
@@ -4622,7 +4622,7 @@
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.1.1"
             }
         },
         "has-ansi": {
@@ -4631,7 +4631,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -4666,9 +4666,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "has-values": {
@@ -4677,8 +4677,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -4687,7 +4687,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -4769,12 +4769,12 @@
             "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0",
-                "domhandler": "2.4.2",
-                "domutils": "1.7.0",
-                "entities": "1.1.2",
-                "inherits": "2.0.3",
-                "readable-stream": "3.0.6"
+                "domelementtype": "^1.3.0",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^3.0.6"
             },
             "dependencies": {
                 "readable-stream": {
@@ -4783,9 +4783,9 @@
                     "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
                     }
                 }
             }
@@ -4802,9 +4802,9 @@
             "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
             "dev": true,
             "requires": {
-                "eventemitter3": "3.1.0",
-                "follow-redirects": "1.5.9",
-                "requires-port": "1.0.0"
+                "eventemitter3": "^3.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "http-proxy-agent": {
@@ -4835,13 +4835,13 @@
             "dev": true,
             "requires": {
                 "colors": "1.0.3",
-                "corser": "2.0.1",
-                "ecstatic": "3.3.0",
-                "http-proxy": "1.17.0",
-                "opener": "1.4.3",
-                "optimist": "0.6.1",
-                "portfinder": "1.0.19",
-                "union": "0.4.6"
+                "corser": "~2.0.0",
+                "ecstatic": "^3.0.0",
+                "http-proxy": "^1.8.1",
+                "opener": "~1.4.0",
+                "optimist": "0.6.x",
+                "portfinder": "^1.0.13",
+                "union": "~0.4.3"
             }
         },
         "http-signature": {
@@ -4850,9 +4850,9 @@
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.15.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "https-browserify": {
@@ -4903,7 +4903,7 @@
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "dev": true,
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
             }
         },
         "ieee754": {
@@ -4963,8 +4963,8 @@
             "integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
             "dev": true,
             "requires": {
-                "pkg-dir": "2.0.0",
-                "resolve-cwd": "2.0.0"
+                "pkg-dir": "^2.0.0",
+                "resolve-cwd": "^2.0.0"
             }
         },
         "imurmurhash": {
@@ -4997,8 +4997,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -5116,7 +5116,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -5125,7 +5125,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -5148,8 +5148,8 @@
             "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
             "dev": true,
             "requires": {
-                "is-alphabetical": "1.0.2",
-                "is-decimal": "1.0.2"
+                "is-alphabetical": "^1.0.0",
+                "is-decimal": "^1.0.0"
             }
         },
         "is-arrayish": {
@@ -5161,7 +5161,7 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
             "dev": true
         },
         "is-builtin-module": {
@@ -5185,7 +5185,7 @@
             "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
             "dev": true,
             "requires": {
-                "ci-info": "1.6.0"
+                "ci-info": "^1.5.0"
             }
         },
         "is-data-descriptor": {
@@ -5194,7 +5194,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -5203,7 +5203,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -5226,9 +5226,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -5257,7 +5257,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -5278,7 +5278,7 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-fullwidth-code-point": {
@@ -5293,7 +5293,7 @@
             "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.1"
             }
         },
         "is-hexadecimal": {
@@ -5308,8 +5308,8 @@
             "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
             "dev": true,
             "requires": {
-                "global-dirs": "0.1.1",
-                "is-path-inside": "1.0.1"
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-npm": {
@@ -5324,7 +5324,7 @@
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -5333,14 +5333,14 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
         },
         "is-obj": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
             "dev": true
         },
@@ -5356,7 +5356,7 @@
             "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -5365,7 +5365,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-obj": {
@@ -5380,7 +5380,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "is-posix-bracket": {
@@ -5522,13 +5522,13 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.12.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-            "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.1"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "jsbn": {
@@ -5688,7 +5688,7 @@
             "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
             "dev": true,
             "requires": {
-                "package-json": "4.0.1"
+                "package-json": "^4.0.0"
             }
         },
         "leven": {
@@ -5713,10 +5713,10 @@
             "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "4.0.0",
-                "pify": "3.0.0",
-                "strip-bom": "3.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
             }
         },
         "locate-path": {
@@ -5725,14 +5725,14 @@
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             }
         },
         "lodash": {
-            "version": "4.17.11",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
             "dev": true
         },
         "lodash.memoize": {
@@ -5742,9 +5742,9 @@
             "dev": true
         },
         "lodash.merge": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-            "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
         },
         "lodash.unescape": {
@@ -5759,7 +5759,7 @@
             "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1"
+                "chalk": "^2.0.1"
             }
         },
         "loglevel": {
@@ -5841,8 +5841,8 @@
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
             "dev": true,
             "requires": {
-                "currently-unhandled": "0.4.1",
-                "signal-exit": "3.0.2"
+                "currently-unhandled": "^0.4.1",
+                "signal-exit": "^3.0.0"
             }
         },
         "lowercase-keys": {
@@ -5857,8 +5857,8 @@
             "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "dev": true,
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "make-dir": {
@@ -5867,7 +5867,7 @@
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "make-fetch-happen": {
@@ -5924,7 +5924,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "markdown-escapes": {
@@ -5968,7 +5968,7 @@
             "integrity": "sha512-d2WS98JSDVbpSsBfVvD9TaDMlqPRz7ohM/11G0rp5jOBb5q96RJ6YLszQ/09AAixyzh23FeIpCGqfaamEADtWg==",
             "dev": true,
             "requires": {
-                "unist-util-visit": "1.4.0"
+                "unist-util-visit": "^1.1.0"
             }
         },
         "mdn-bob": {
@@ -6017,16 +6017,16 @@
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
             "dev": true,
             "requires": {
-                "camelcase-keys": "2.1.0",
-                "decamelize": "1.2.0",
-                "loud-rejection": "1.6.0",
-                "map-obj": "1.0.1",
-                "minimist": "1.2.0",
-                "normalize-package-data": "2.4.0",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "redent": "1.0.0",
-                "trim-newlines": "1.0.0"
+                "camelcase-keys": "^2.0.0",
+                "decamelize": "^1.1.2",
+                "loud-rejection": "^1.0.0",
+                "map-obj": "^1.0.1",
+                "minimist": "^1.1.3",
+                "normalize-package-data": "^2.3.4",
+                "object-assign": "^4.0.1",
+                "read-pkg-up": "^1.0.1",
+                "redent": "^1.0.0",
+                "trim-newlines": "^1.0.0"
             },
             "dependencies": {
                 "minimist": {
@@ -6049,25 +6049,25 @@
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.2",
-                "nanomatch": "1.2.13",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
             }
         },
         "miller-rabin": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+            "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
             "dev": true,
             "requires": {
                 "bn.js": "^4.0.0",
@@ -6077,7 +6077,7 @@
         "mime": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
             "dev": true
         },
         "mime-db": {
@@ -6092,7 +6092,7 @@
             "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
             "dev": true,
             "requires": {
-                "mime-db": "1.37.0"
+                "mime-db": "~1.37.0"
             }
         },
         "mimic-fn": {
@@ -6122,10 +6122,10 @@
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -6140,8 +6140,8 @@
             "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "is-plain-obj": "1.1.0"
+                "arrify": "^1.0.1",
+                "is-plain-obj": "^1.1.0"
             }
         },
         "mississippi": {
@@ -6163,13 +6163,13 @@
             }
         },
         "mixin-deep": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+            "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -6178,7 +6178,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -6255,17 +6255,17 @@
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             }
         },
         "natural-compare": {
@@ -6322,13 +6322,13 @@
         "normalize-package-data": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-            "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+            "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.7.1",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.6.0",
-                "validate-npm-package-license": "3.0.4"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -6337,7 +6337,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "normalize-range": {
@@ -6359,9 +6359,9 @@
             "dev": true
         },
         "npm": {
-            "version": "6.6.0",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-6.6.0.tgz",
-            "integrity": "sha512-Q6Lb4YPWIGsyVzfxcZrTu6VQcMEvCHOBlSE0fbuNHj6CYCUuanMUf6HgNyj4QekWTORxQpOgOgaca2YEQ721Ug==",
+            "version": "6.11.3",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-6.11.3.tgz",
+            "integrity": "sha512-K2h+MPzZiY39Xf6eHEdECe/LKoJXam4UCflz5kIxoskN3LQFeYs5fqBGT5i4TtM/aBk+86Mcf+jgXs/WuWAutQ==",
             "requires": {
                 "JSONStream": "^1.3.5",
                 "abbrev": "~1.1.1",
@@ -6369,16 +6369,16 @@
                 "ansistyles": "~0.1.3",
                 "aproba": "^2.0.0",
                 "archy": "~1.0.0",
-                "bin-links": "^1.1.2",
-                "bluebird": "^3.5.3",
+                "bin-links": "^1.1.3",
+                "bluebird": "^3.5.5",
                 "byte-size": "^5.0.1",
-                "cacache": "^11.3.2",
-                "call-limit": "~1.1.0",
-                "chownr": "^1.1.1",
+                "cacache": "^12.0.3",
+                "call-limit": "^1.1.1",
+                "chownr": "^1.1.2",
                 "ci-info": "^2.0.0",
                 "cli-columns": "^3.1.2",
                 "cli-table3": "^0.5.1",
-                "cmd-shim": "~2.0.2",
+                "cmd-shim": "^3.0.3",
                 "columnify": "~1.5.4",
                 "config-chain": "^1.1.12",
                 "debuglog": "*",
@@ -6390,29 +6390,30 @@
                 "find-npm-prefix": "^1.0.2",
                 "fs-vacuum": "~1.2.10",
                 "fs-write-stream-atomic": "~1.0.10",
-                "gentle-fs": "^2.0.1",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.1.15",
+                "gentle-fs": "^2.2.1",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.2",
                 "has-unicode": "~2.0.1",
-                "hosted-git-info": "^2.7.1",
+                "hosted-git-info": "^2.8.2",
                 "iferr": "^1.0.2",
                 "imurmurhash": "*",
+                "infer-owner": "^1.0.4",
                 "inflight": "~1.0.6",
-                "inherits": "~2.0.3",
+                "inherits": "^2.0.4",
                 "ini": "^1.3.5",
                 "init-package-json": "^1.10.3",
                 "is-cidr": "^3.0.0",
                 "json-parse-better-errors": "^1.0.2",
                 "lazy-property": "~1.0.0",
-                "libcipm": "^3.0.2",
-                "libnpm": "^2.0.1",
-                "libnpmaccess": "*",
-                "libnpmhook": "^5.0.2",
-                "libnpmorg": "*",
-                "libnpmsearch": "*",
-                "libnpmteam": "*",
+                "libcipm": "^4.0.3",
+                "libnpm": "^3.0.1",
+                "libnpmaccess": "^3.0.2",
+                "libnpmhook": "^5.0.3",
+                "libnpmorg": "^1.0.1",
+                "libnpmsearch": "^2.0.2",
+                "libnpmteam": "^1.0.2",
                 "libnpx": "^10.2.0",
-                "lock-verify": "^2.0.2",
+                "lock-verify": "^2.1.0",
                 "lockfile": "^1.0.4",
                 "lodash._baseindexof": "*",
                 "lodash._baseuniq": "~4.6.0",
@@ -6425,53 +6426,53 @@
                 "lodash.union": "~4.6.0",
                 "lodash.uniq": "~4.5.0",
                 "lodash.without": "~4.4.0",
-                "lru-cache": "^4.1.5",
+                "lru-cache": "^5.1.1",
                 "meant": "~1.0.1",
                 "mississippi": "^3.0.0",
                 "mkdirp": "~0.5.1",
                 "move-concurrently": "^1.0.1",
-                "node-gyp": "^3.8.0",
+                "node-gyp": "^5.0.3",
                 "nopt": "~4.0.1",
-                "normalize-package-data": "~2.4.0",
+                "normalize-package-data": "^2.5.0",
                 "npm-audit-report": "^1.3.2",
                 "npm-cache-filename": "~1.0.2",
                 "npm-install-checks": "~3.0.0",
-                "npm-lifecycle": "^2.1.0",
-                "npm-package-arg": "^6.1.0",
-                "npm-packlist": "^1.2.0",
-                "npm-pick-manifest": "^2.2.3",
-                "npm-profile": "*",
-                "npm-registry-fetch": "^3.8.0",
+                "npm-lifecycle": "^3.1.3",
+                "npm-package-arg": "^6.1.1",
+                "npm-packlist": "^1.4.4",
+                "npm-pick-manifest": "^3.0.2",
+                "npm-profile": "^4.0.2",
+                "npm-registry-fetch": "^4.0.0",
                 "npm-user-validate": "~1.0.0",
                 "npmlog": "~4.1.2",
                 "once": "~1.4.0",
                 "opener": "^1.5.1",
                 "osenv": "^0.1.5",
-                "pacote": "^9.3.0",
+                "pacote": "^9.5.8",
                 "path-is-inside": "~1.0.2",
                 "promise-inflight": "~1.0.1",
                 "qrcode-terminal": "^0.12.0",
-                "query-string": "^6.2.0",
+                "query-string": "^6.8.2",
                 "qw": "~1.0.1",
                 "read": "~1.0.7",
-                "read-cmd-shim": "~1.0.1",
+                "read-cmd-shim": "^1.0.4",
                 "read-installed": "~4.0.3",
-                "read-package-json": "^2.0.13",
-                "read-package-tree": "^5.2.1",
-                "readable-stream": "^3.1.1",
-                "readdir-scoped-modules": "*",
+                "read-package-json": "^2.1.0",
+                "read-package-tree": "^5.3.1",
+                "readable-stream": "^3.4.0",
+                "readdir-scoped-modules": "^1.1.0",
                 "request": "^2.88.0",
                 "retry": "^0.12.0",
                 "rimraf": "^2.6.3",
                 "safe-buffer": "^5.1.2",
-                "semver": "^5.6.0",
-                "sha": "~2.0.1",
+                "semver": "^5.7.1",
+                "sha": "^3.0.0",
                 "slide": "~1.1.6",
                 "sorted-object": "~2.0.1",
                 "sorted-union-stream": "~2.1.3",
                 "ssri": "^6.0.1",
                 "stringify-package": "^1.0.0",
-                "tar": "^4.4.8",
+                "tar": "^4.4.10",
                 "text-table": "~0.2.0",
                 "tiny-relative-date": "^1.3.0",
                 "uid-number": "0.0.6",
@@ -6483,8 +6484,8 @@
                 "validate-npm-package-license": "^3.0.4",
                 "validate-npm-package-name": "~3.0.0",
                 "which": "^1.3.1",
-                "worker-farm": "^1.6.0",
-                "write-file-atomic": "^2.3.0"
+                "worker-farm": "^1.7.0",
+                "write-file-atomic": "^2.4.3"
             },
             "dependencies": {
                 "JSONStream": {
@@ -6500,14 +6501,14 @@
                     "bundled": true
                 },
                 "agent-base": {
-                    "version": "4.2.0",
+                    "version": "4.3.0",
                     "bundled": true,
                     "requires": {
                         "es6-promisify": "^5.0.0"
                     }
                 },
                 "agentkeepalive": {
-                    "version": "3.4.1",
+                    "version": "3.5.2",
                     "bundled": true,
                     "requires": {
                         "humanize-ms": "^1.2.1"
@@ -6627,25 +6628,18 @@
                     }
                 },
                 "bin-links": {
-                    "version": "1.1.2",
+                    "version": "1.1.3",
                     "bundled": true,
                     "requires": {
-                        "bluebird": "^3.5.0",
-                        "cmd-shim": "^2.0.2",
-                        "gentle-fs": "^2.0.0",
-                        "graceful-fs": "^4.1.11",
+                        "bluebird": "^3.5.3",
+                        "cmd-shim": "^3.0.0",
+                        "gentle-fs": "^2.0.1",
+                        "graceful-fs": "^4.1.15",
                         "write-file-atomic": "^2.3.0"
                     }
                 },
-                "block-stream": {
-                    "version": "0.0.9",
-                    "bundled": true,
-                    "requires": {
-                        "inherits": "~2.0.0"
-                    }
-                },
                 "bluebird": {
-                    "version": "3.5.3",
+                    "version": "3.5.5",
                     "bundled": true
                 },
                 "boxen": {
@@ -6673,10 +6667,6 @@
                     "version": "1.0.0",
                     "bundled": true
                 },
-                "builtin-modules": {
-                    "version": "1.1.1",
-                    "bundled": true
-                },
                 "builtins": {
                     "version": "1.0.3",
                     "bundled": true
@@ -6690,51 +6680,28 @@
                     "bundled": true
                 },
                 "cacache": {
-                    "version": "11.3.2",
+                    "version": "12.0.3",
                     "bundled": true,
                     "requires": {
-                        "bluebird": "^3.5.3",
+                        "bluebird": "^3.5.5",
                         "chownr": "^1.1.1",
                         "figgy-pudding": "^3.5.1",
-                        "glob": "^7.1.3",
+                        "glob": "^7.1.4",
                         "graceful-fs": "^4.1.15",
+                        "infer-owner": "^1.0.3",
                         "lru-cache": "^5.1.1",
                         "mississippi": "^3.0.0",
                         "mkdirp": "^0.5.1",
                         "move-concurrently": "^1.0.1",
                         "promise-inflight": "^1.0.1",
-                        "rimraf": "^2.6.2",
+                        "rimraf": "^2.6.3",
                         "ssri": "^6.0.1",
                         "unique-filename": "^1.1.1",
                         "y18n": "^4.0.0"
-                    },
-                    "dependencies": {
-                        "chownr": {
-                            "version": "1.1.1",
-                            "bundled": true
-                        },
-                        "lru-cache": {
-                            "version": "5.1.1",
-                            "bundled": true,
-                            "requires": {
-                                "yallist": "^3.0.2"
-                            }
-                        },
-                        "unique-filename": {
-                            "version": "1.1.1",
-                            "bundled": true,
-                            "requires": {
-                                "unique-slug": "^2.0.0"
-                            }
-                        },
-                        "yallist": {
-                            "version": "3.0.3",
-                            "bundled": true
-                        }
                     }
                 },
                 "call-limit": {
-                    "version": "1.1.0",
+                    "version": "1.1.1",
                     "bundled": true
                 },
                 "camelcase": {
@@ -6759,7 +6726,7 @@
                     }
                 },
                 "chownr": {
-                    "version": "1.1.1",
+                    "version": "1.1.2",
                     "bundled": true
                 },
                 "ci-info": {
@@ -6821,7 +6788,7 @@
                     "bundled": true
                 },
                 "cmd-shim": {
-                    "version": "2.0.2",
+                    "version": "3.0.3",
                     "bundled": true,
                     "requires": {
                         "graceful-fs": "^4.1.2",
@@ -6967,6 +6934,20 @@
                         "lru-cache": "^4.0.1",
                         "shebang-command": "^1.2.0",
                         "which": "^1.2.9"
+                    },
+                    "dependencies": {
+                        "lru-cache": {
+                            "version": "4.1.5",
+                            "bundled": true,
+                            "requires": {
+                                "pseudomap": "^1.0.2",
+                                "yallist": "^2.1.2"
+                            }
+                        },
+                        "yallist": {
+                            "version": "2.1.2",
+                            "bundled": true
+                        }
                     }
                 },
                 "crypto-random-string": {
@@ -7018,6 +6999,13 @@
                     "bundled": true,
                     "requires": {
                         "clone": "^1.0.2"
+                    }
+                },
+                "define-properties": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "requires": {
+                        "object-keys": "^1.0.12"
                     }
                 },
                 "delayed-stream": {
@@ -7118,6 +7106,10 @@
                         "once": "^1.4.0"
                     }
                 },
+                "env-paths": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
                 "err-code": {
                     "version": "1.1.2",
                     "bundled": true
@@ -7129,8 +7121,28 @@
                         "prr": "~1.0.1"
                     }
                 },
+                "es-abstract": {
+                    "version": "1.12.0",
+                    "bundled": true,
+                    "requires": {
+                        "es-to-primitive": "^1.1.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.1",
+                        "is-callable": "^1.1.3",
+                        "is-regex": "^1.0.4"
+                    }
+                },
+                "es-to-primitive": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "is-callable": "^1.1.4",
+                        "is-date-object": "^1.0.1",
+                        "is-symbol": "^1.0.2"
+                    }
+                },
                 "es6-promise": {
-                    "version": "4.2.4",
+                    "version": "4.2.8",
                     "bundled": true
                 },
                 "es6-promisify": {
@@ -7268,7 +7280,7 @@
                     }
                 },
                 "fs-minipass": {
-                    "version": "1.2.5",
+                    "version": "1.2.6",
                     "bundled": true,
                     "requires": {
                         "minipass": "^2.2.1"
@@ -7323,15 +7335,9 @@
                     "version": "1.0.0",
                     "bundled": true
                 },
-                "fstream": {
-                    "version": "1.0.11",
-                    "bundled": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "inherits": "~2.0.0",
-                        "mkdirp": ">=0.5 0",
-                        "rimraf": "2"
-                    }
+                "function-bind": {
+                    "version": "1.1.1",
+                    "bundled": true
                 },
                 "gauge": {
                     "version": "2.7.4",
@@ -7367,13 +7373,15 @@
                     "bundled": true
                 },
                 "gentle-fs": {
-                    "version": "2.0.1",
+                    "version": "2.2.1",
                     "bundled": true,
                     "requires": {
                         "aproba": "^1.1.2",
+                        "chownr": "^1.1.2",
                         "fs-vacuum": "^1.2.10",
                         "graceful-fs": "^4.1.11",
                         "iferr": "^0.1.5",
+                        "infer-owner": "^1.0.4",
                         "mkdirp": "^0.5.1",
                         "path-is-inside": "^1.0.2",
                         "read-cmd-shim": "^1.0.1",
@@ -7409,7 +7417,7 @@
                     }
                 },
                 "glob": {
-                    "version": "7.1.3",
+                    "version": "7.1.4",
                     "bundled": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -7451,7 +7459,7 @@
                     }
                 },
                 "graceful-fs": {
-                    "version": "4.1.15",
+                    "version": "4.2.2",
                     "bundled": true
                 },
                 "har-schema": {
@@ -7466,8 +7474,19 @@
                         "har-schema": "^2.0.0"
                     }
                 },
+                "has": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "function-bind": "^1.1.1"
+                    }
+                },
                 "has-flag": {
                     "version": "3.0.0",
+                    "bundled": true
+                },
+                "has-symbols": {
+                    "version": "1.0.0",
                     "bundled": true
                 },
                 "has-unicode": {
@@ -7475,8 +7494,11 @@
                     "bundled": true
                 },
                 "hosted-git-info": {
-                    "version": "2.7.1",
-                    "bundled": true
+                    "version": "2.8.2",
+                    "bundled": true,
+                    "requires": {
+                        "lru-cache": "^5.1.1"
+                    }
                 },
                 "http-cache-semantics": {
                     "version": "3.8.1",
@@ -7500,10 +7522,10 @@
                     }
                 },
                 "https-proxy-agent": {
-                    "version": "2.2.1",
+                    "version": "2.2.2",
                     "bundled": true,
                     "requires": {
-                        "agent-base": "^4.1.0",
+                        "agent-base": "^4.3.0",
                         "debug": "^3.1.0"
                     }
                 },
@@ -7540,6 +7562,10 @@
                     "version": "0.1.4",
                     "bundled": true
                 },
+                "infer-owner": {
+                    "version": "1.0.4",
+                    "bundled": true
+                },
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
@@ -7549,7 +7575,7 @@
                     }
                 },
                 "inherits": {
-                    "version": "2.0.3",
+                    "version": "2.0.4",
                     "bundled": true
                 },
                 "ini": {
@@ -7582,12 +7608,9 @@
                     "version": "2.1.0",
                     "bundled": true
                 },
-                "is-builtin-module": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "builtin-modules": "^1.0.0"
-                    }
+                "is-callable": {
+                    "version": "1.1.4",
+                    "bundled": true
                 },
                 "is-ci": {
                     "version": "1.1.0",
@@ -7608,6 +7631,10 @@
                     "requires": {
                         "cidr-regex": "^2.0.10"
                     }
+                },
+                "is-date-object": {
+                    "version": "1.0.1",
+                    "bundled": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
@@ -7643,6 +7670,13 @@
                     "version": "1.0.0",
                     "bundled": true
                 },
+                "is-regex": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "has": "^1.0.1"
+                    }
+                },
                 "is-retry-allowed": {
                     "version": "1.1.0",
                     "bundled": true
@@ -7650,6 +7684,13 @@
                 "is-stream": {
                     "version": "1.1.0",
                     "bundled": true
+                },
+                "is-symbol": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "has-symbols": "^1.0.0"
+                    }
                 },
                 "is-typedarray": {
                     "version": "1.0.0",
@@ -7721,7 +7762,7 @@
                     }
                 },
                 "libcipm": {
-                    "version": "3.0.2",
+                    "version": "4.0.3",
                     "bundled": true,
                     "requires": {
                         "bin-links": "^1.1.2",
@@ -7732,7 +7773,7 @@
                         "ini": "^1.3.5",
                         "lock-verify": "^2.0.2",
                         "mkdirp": "^0.5.1",
-                        "npm-lifecycle": "^2.0.3",
+                        "npm-lifecycle": "^3.0.0",
                         "npm-logical-tree": "^1.2.1",
                         "npm-package-arg": "^6.1.0",
                         "pacote": "^9.1.0",
@@ -7742,61 +7783,39 @@
                     }
                 },
                 "libnpm": {
-                    "version": "2.0.1",
+                    "version": "3.0.1",
                     "bundled": true,
                     "requires": {
                         "bin-links": "^1.1.2",
                         "bluebird": "^3.5.3",
                         "find-npm-prefix": "^1.0.2",
-                        "libnpmaccess": "^3.0.1",
+                        "libnpmaccess": "^3.0.2",
                         "libnpmconfig": "^1.2.1",
-                        "libnpmhook": "^5.0.2",
-                        "libnpmorg": "^1.0.0",
-                        "libnpmpublish": "^1.1.0",
-                        "libnpmsearch": "^2.0.0",
-                        "libnpmteam": "^1.0.1",
+                        "libnpmhook": "^5.0.3",
+                        "libnpmorg": "^1.0.1",
+                        "libnpmpublish": "^1.1.2",
+                        "libnpmsearch": "^2.0.2",
+                        "libnpmteam": "^1.0.2",
                         "lock-verify": "^2.0.2",
-                        "npm-lifecycle": "^2.1.0",
+                        "npm-lifecycle": "^3.0.0",
                         "npm-logical-tree": "^1.2.1",
                         "npm-package-arg": "^6.1.0",
-                        "npm-profile": "^4.0.1",
-                        "npm-registry-fetch": "^3.8.0",
+                        "npm-profile": "^4.0.2",
+                        "npm-registry-fetch": "^4.0.0",
                         "npmlog": "^4.1.2",
-                        "pacote": "^9.2.3",
+                        "pacote": "^9.5.3",
                         "read-package-json": "^2.0.13",
                         "stringify-package": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "aproba": {
-                            "version": "2.0.0",
-                            "bundled": true
-                        },
-                        "libnpmhook": {
-                            "version": "5.0.2",
-                            "bundled": true,
-                            "requires": {
-                                "aproba": "^2.0.0",
-                                "figgy-pudding": "^3.4.1",
-                                "get-stream": "^4.0.0",
-                                "npm-registry-fetch": "^3.8.0"
-                            }
-                        }
                     }
                 },
                 "libnpmaccess": {
-                    "version": "3.0.1",
+                    "version": "3.0.2",
                     "bundled": true,
                     "requires": {
                         "aproba": "^2.0.0",
                         "get-stream": "^4.0.0",
                         "npm-package-arg": "^6.1.0",
-                        "npm-registry-fetch": "^3.8.0"
-                    },
-                    "dependencies": {
-                        "aproba": {
-                            "version": "2.0.0",
-                            "bundled": true
-                        }
+                        "npm-registry-fetch": "^4.0.0"
                     }
                 },
                 "libnpmconfig": {
@@ -7824,7 +7843,7 @@
                             }
                         },
                         "p-limit": {
-                            "version": "2.0.0",
+                            "version": "2.2.0",
                             "bundled": true,
                             "requires": {
                                 "p-try": "^2.0.0"
@@ -7838,39 +7857,33 @@
                             }
                         },
                         "p-try": {
-                            "version": "2.0.0",
+                            "version": "2.2.0",
                             "bundled": true
                         }
                     }
                 },
                 "libnpmhook": {
-                    "version": "5.0.2",
+                    "version": "5.0.3",
                     "bundled": true,
                     "requires": {
                         "aproba": "^2.0.0",
                         "figgy-pudding": "^3.4.1",
                         "get-stream": "^4.0.0",
-                        "npm-registry-fetch": "^3.8.0"
+                        "npm-registry-fetch": "^4.0.0"
                     }
                 },
                 "libnpmorg": {
-                    "version": "1.0.0",
+                    "version": "1.0.1",
                     "bundled": true,
                     "requires": {
                         "aproba": "^2.0.0",
                         "figgy-pudding": "^3.4.1",
                         "get-stream": "^4.0.0",
-                        "npm-registry-fetch": "^3.8.0"
-                    },
-                    "dependencies": {
-                        "aproba": {
-                            "version": "2.0.0",
-                            "bundled": true
-                        }
+                        "npm-registry-fetch": "^4.0.0"
                     }
                 },
                 "libnpmpublish": {
-                    "version": "1.1.0",
+                    "version": "1.1.2",
                     "bundled": true,
                     "requires": {
                         "aproba": "^2.0.0",
@@ -7879,40 +7892,28 @@
                         "lodash.clonedeep": "^4.5.0",
                         "normalize-package-data": "^2.4.0",
                         "npm-package-arg": "^6.1.0",
-                        "npm-registry-fetch": "^3.8.0",
+                        "npm-registry-fetch": "^4.0.0",
                         "semver": "^5.5.1",
                         "ssri": "^6.0.1"
-                    },
-                    "dependencies": {
-                        "aproba": {
-                            "version": "2.0.0",
-                            "bundled": true
-                        }
                     }
                 },
                 "libnpmsearch": {
-                    "version": "2.0.0",
+                    "version": "2.0.2",
                     "bundled": true,
                     "requires": {
                         "figgy-pudding": "^3.5.1",
                         "get-stream": "^4.0.0",
-                        "npm-registry-fetch": "^3.8.0"
+                        "npm-registry-fetch": "^4.0.0"
                     }
                 },
                 "libnpmteam": {
-                    "version": "1.0.1",
+                    "version": "1.0.2",
                     "bundled": true,
                     "requires": {
                         "aproba": "^2.0.0",
                         "figgy-pudding": "^3.4.1",
                         "get-stream": "^4.0.0",
-                        "npm-registry-fetch": "^3.8.0"
-                    },
-                    "dependencies": {
-                        "aproba": {
-                            "version": "2.0.0",
-                            "bundled": true
-                        }
+                        "npm-registry-fetch": "^4.0.0"
                     }
                 },
                 "libnpx": {
@@ -7938,10 +7939,10 @@
                     }
                 },
                 "lock-verify": {
-                    "version": "2.0.2",
+                    "version": "2.1.0",
                     "bundled": true,
                     "requires": {
-                        "npm-package-arg": "^5.1.2 || 6",
+                        "npm-package-arg": "^6.1.0",
                         "semver": "^5.4.1"
                     }
                 },
@@ -8016,11 +8017,10 @@
                     "bundled": true
                 },
                 "lru-cache": {
-                    "version": "4.1.5",
+                    "version": "5.1.1",
                     "bundled": true,
                     "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
+                        "yallist": "^3.0.2"
                     }
                 },
                 "make-dir": {
@@ -8031,15 +8031,15 @@
                     }
                 },
                 "make-fetch-happen": {
-                    "version": "4.0.1",
+                    "version": "5.0.0",
                     "bundled": true,
                     "requires": {
                         "agentkeepalive": "^3.4.1",
-                        "cacache": "^11.0.1",
+                        "cacache": "^12.0.0",
                         "http-cache-semantics": "^3.8.1",
                         "http-proxy-agent": "^2.1.0",
                         "https-proxy-agent": "^2.2.1",
-                        "lru-cache": "^4.1.2",
+                        "lru-cache": "^5.1.1",
                         "mississippi": "^3.0.0",
                         "node-fetch-npm": "^2.0.2",
                         "promise-retry": "^1.1.1",
@@ -8099,7 +8099,7 @@
                     }
                 },
                 "minizlib": {
-                    "version": "1.1.1",
+                    "version": "1.2.1",
                     "bundled": true,
                     "requires": {
                         "minipass": "^2.2.1"
@@ -8164,20 +8164,19 @@
                     }
                 },
                 "node-gyp": {
-                    "version": "3.8.0",
+                    "version": "5.0.3",
                     "bundled": true,
                     "requires": {
-                        "fstream": "^1.0.0",
+                        "env-paths": "^1.0.0",
                         "glob": "^7.0.3",
                         "graceful-fs": "^4.1.2",
                         "mkdirp": "^0.5.0",
                         "nopt": "2 || 3",
                         "npmlog": "0 || 1 || 2 || 3 || 4",
-                        "osenv": "0",
                         "request": "^2.87.0",
                         "rimraf": "2",
                         "semver": "~5.3.0",
-                        "tar": "^2.0.0",
+                        "tar": "^4.4.8",
                         "which": "1"
                     },
                     "dependencies": {
@@ -8191,15 +8190,6 @@
                         "semver": {
                             "version": "5.3.0",
                             "bundled": true
-                        },
-                        "tar": {
-                            "version": "2.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "block-stream": "*",
-                                "fstream": "^1.0.2",
-                                "inherits": "2"
-                            }
                         }
                     }
                 },
@@ -8212,13 +8202,22 @@
                     }
                 },
                 "normalize-package-data": {
-                    "version": "2.4.0",
+                    "version": "2.5.0",
                     "bundled": true,
                     "requires": {
                         "hosted-git-info": "^2.1.4",
-                        "is-builtin-module": "^1.0.0",
+                        "resolve": "^1.10.0",
                         "semver": "2 || 3 || 4 || 5",
                         "validate-npm-package-license": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "resolve": {
+                            "version": "1.10.0",
+                            "bundled": true,
+                            "requires": {
+                                "path-parse": "^1.0.6"
+                            }
+                        }
                     }
                 },
                 "npm-audit-report": {
@@ -8230,7 +8229,7 @@
                     }
                 },
                 "npm-bundled": {
-                    "version": "1.0.5",
+                    "version": "1.0.6",
                     "bundled": true
                 },
                 "npm-cache-filename": {
@@ -8245,12 +8244,12 @@
                     }
                 },
                 "npm-lifecycle": {
-                    "version": "2.1.0",
+                    "version": "3.1.3",
                     "bundled": true,
                     "requires": {
                         "byline": "^5.0.0",
-                        "graceful-fs": "^4.1.11",
-                        "node-gyp": "^3.8.0",
+                        "graceful-fs": "^4.1.15",
+                        "node-gyp": "^5.0.2",
                         "resolve-from": "^4.0.0",
                         "slide": "^1.1.6",
                         "uid-number": "0.0.6",
@@ -8263,17 +8262,17 @@
                     "bundled": true
                 },
                 "npm-package-arg": {
-                    "version": "6.1.0",
+                    "version": "6.1.1",
                     "bundled": true,
                     "requires": {
-                        "hosted-git-info": "^2.6.0",
+                        "hosted-git-info": "^2.7.1",
                         "osenv": "^0.1.5",
-                        "semver": "^5.5.0",
+                        "semver": "^5.6.0",
                         "validate-npm-package-name": "^3.0.0"
                     }
                 },
                 "npm-packlist": {
-                    "version": "1.2.0",
+                    "version": "1.4.4",
                     "bundled": true,
                     "requires": {
                         "ignore-walk": "^3.0.1",
@@ -8281,7 +8280,7 @@
                     }
                 },
                 "npm-pick-manifest": {
-                    "version": "2.2.3",
+                    "version": "3.0.2",
                     "bundled": true,
                     "requires": {
                         "figgy-pudding": "^3.5.1",
@@ -8290,23 +8289,23 @@
                     }
                 },
                 "npm-profile": {
-                    "version": "4.0.1",
+                    "version": "4.0.2",
                     "bundled": true,
                     "requires": {
                         "aproba": "^1.1.2 || 2",
                         "figgy-pudding": "^3.4.1",
-                        "npm-registry-fetch": "^3.8.0"
+                        "npm-registry-fetch": "^4.0.0"
                     }
                 },
                 "npm-registry-fetch": {
-                    "version": "3.8.0",
+                    "version": "4.0.0",
                     "bundled": true,
                     "requires": {
                         "JSONStream": "^1.3.4",
                         "bluebird": "^3.5.1",
                         "figgy-pudding": "^3.4.1",
-                        "lru-cache": "^4.1.3",
-                        "make-fetch-happen": "^4.0.1",
+                        "lru-cache": "^5.1.1",
+                        "make-fetch-happen": "^5.0.0",
                         "npm-package-arg": "^6.1.0"
                     }
                 },
@@ -8342,6 +8341,18 @@
                 "object-assign": {
                     "version": "4.1.1",
                     "bundled": true
+                },
+                "object-keys": {
+                    "version": "1.0.12",
+                    "bundled": true
+                },
+                "object.getownpropertydescriptors": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "define-properties": "^1.1.2",
+                        "es-abstract": "^1.5.1"
+                    }
                 },
                 "once": {
                     "version": "1.4.0",
@@ -8412,16 +8423,18 @@
                     }
                 },
                 "pacote": {
-                    "version": "9.3.0",
+                    "version": "9.5.8",
                     "bundled": true,
                     "requires": {
                         "bluebird": "^3.5.3",
-                        "cacache": "^11.3.2",
+                        "cacache": "^12.0.2",
+                        "chownr": "^1.1.2",
                         "figgy-pudding": "^3.5.1",
                         "get-stream": "^4.1.0",
                         "glob": "^7.1.3",
+                        "infer-owner": "^1.0.4",
                         "lru-cache": "^5.1.1",
-                        "make-fetch-happen": "^4.0.1",
+                        "make-fetch-happen": "^5.0.0",
                         "minimatch": "^3.0.4",
                         "minipass": "^2.3.5",
                         "mississippi": "^3.0.0",
@@ -8429,8 +8442,8 @@
                         "normalize-package-data": "^2.4.0",
                         "npm-package-arg": "^6.1.0",
                         "npm-packlist": "^1.1.12",
-                        "npm-pick-manifest": "^2.2.3",
-                        "npm-registry-fetch": "^3.8.0",
+                        "npm-pick-manifest": "^3.0.0",
+                        "npm-registry-fetch": "^4.0.0",
                         "osenv": "^0.1.5",
                         "promise-inflight": "^1.0.1",
                         "promise-retry": "^1.1.1",
@@ -8439,18 +8452,11 @@
                         "safe-buffer": "^5.1.2",
                         "semver": "^5.6.0",
                         "ssri": "^6.0.1",
-                        "tar": "^4.4.8",
+                        "tar": "^4.4.10",
                         "unique-filename": "^1.1.1",
                         "which": "^1.3.1"
                     },
                     "dependencies": {
-                        "lru-cache": {
-                            "version": "5.1.1",
-                            "bundled": true,
-                            "requires": {
-                                "yallist": "^3.0.2"
-                            }
-                        },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
@@ -8458,10 +8464,6 @@
                                 "safe-buffer": "^5.1.2",
                                 "yallist": "^3.0.0"
                             }
-                        },
-                        "yallist": {
-                            "version": "3.0.3",
-                            "bundled": true
                         }
                     }
                 },
@@ -8510,6 +8512,10 @@
                 },
                 "path-key": {
                     "version": "2.0.1",
+                    "bundled": true
+                },
+                "path-parse": {
+                    "version": "1.0.6",
                     "bundled": true
                 },
                 "performance-now": {
@@ -8616,10 +8622,11 @@
                     "bundled": true
                 },
                 "query-string": {
-                    "version": "6.2.0",
+                    "version": "6.8.2",
                     "bundled": true,
                     "requires": {
                         "decode-uri-component": "^0.2.0",
+                        "split-on-first": "^1.0.0",
                         "strict-uri-encode": "^2.0.0"
                     }
                 },
@@ -8651,7 +8658,7 @@
                     }
                 },
                 "read-cmd-shim": {
-                    "version": "1.0.1",
+                    "version": "1.0.4",
                     "bundled": true,
                     "requires": {
                         "graceful-fs": "^4.1.2"
@@ -8671,7 +8678,7 @@
                     }
                 },
                 "read-package-json": {
-                    "version": "2.0.13",
+                    "version": "2.1.0",
                     "bundled": true,
                     "requires": {
                         "glob": "^7.1.1",
@@ -8682,18 +8689,16 @@
                     }
                 },
                 "read-package-tree": {
-                    "version": "5.2.1",
+                    "version": "5.3.1",
                     "bundled": true,
                     "requires": {
-                        "debuglog": "^1.0.1",
-                        "dezalgo": "^1.0.0",
-                        "once": "^1.3.0",
                         "read-package-json": "^2.0.0",
-                        "readdir-scoped-modules": "^1.0.0"
+                        "readdir-scoped-modules": "^1.0.0",
+                        "util-promisify": "^2.1.0"
                     }
                 },
                 "readable-stream": {
-                    "version": "3.1.1",
+                    "version": "3.4.0",
                     "bundled": true,
                     "requires": {
                         "inherits": "^2.0.3",
@@ -8702,7 +8707,7 @@
                     }
                 },
                 "readdir-scoped-modules": {
-                    "version": "1.0.2",
+                    "version": "1.1.0",
                     "bundled": true,
                     "requires": {
                         "debuglog": "^1.0.1",
@@ -8797,7 +8802,7 @@
                     "bundled": true
                 },
                 "semver": {
-                    "version": "5.6.0",
+                    "version": "5.7.1",
                     "bundled": true
                 },
                 "semver-diff": {
@@ -8812,33 +8817,10 @@
                     "bundled": true
                 },
                 "sha": {
-                    "version": "2.0.1",
+                    "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "readable-stream": "^2.0.2"
-                    },
-                    "dependencies": {
-                        "readable-stream": {
-                            "version": "2.3.6",
-                            "bundled": true,
-                            "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
-                            }
-                        },
-                        "string_decoder": {
-                            "version": "1.1.1",
-                            "bundled": true,
-                            "requires": {
-                                "safe-buffer": "~5.1.0"
-                            }
-                        }
+                        "graceful-fs": "^4.1.2"
                     }
                 },
                 "shebang-command": {
@@ -8865,23 +8847,32 @@
                     "bundled": true
                 },
                 "smart-buffer": {
-                    "version": "4.0.1",
+                    "version": "4.0.2",
                     "bundled": true
                 },
                 "socks": {
-                    "version": "2.2.0",
+                    "version": "2.3.2",
                     "bundled": true,
                     "requires": {
                         "ip": "^1.1.5",
-                        "smart-buffer": "^4.0.1"
+                        "smart-buffer": "4.0.2"
                     }
                 },
                 "socks-proxy-agent": {
-                    "version": "4.0.1",
+                    "version": "4.0.2",
                     "bundled": true,
                     "requires": {
-                        "agent-base": "~4.2.0",
-                        "socks": "~2.2.0"
+                        "agent-base": "~4.2.1",
+                        "socks": "~2.3.2"
+                    },
+                    "dependencies": {
+                        "agent-base": {
+                            "version": "4.2.1",
+                            "bundled": true,
+                            "requires": {
+                                "es6-promisify": "^5.0.0"
+                            }
+                        }
                     }
                 },
                 "sorted-object": {
@@ -8946,6 +8937,10 @@
                 },
                 "spdx-license-ids": {
                     "version": "3.0.3",
+                    "bundled": true
+                },
+                "split-on-first": {
+                    "version": "1.1.0",
                     "bundled": true
                 },
                 "sshpk": {
@@ -9075,22 +9070,18 @@
                     }
                 },
                 "tar": {
-                    "version": "4.4.8",
+                    "version": "4.4.10",
                     "bundled": true,
                     "requires": {
                         "chownr": "^1.1.1",
                         "fs-minipass": "^1.2.5",
-                        "minipass": "^2.3.4",
-                        "minizlib": "^1.1.1",
+                        "minipass": "^2.3.5",
+                        "minizlib": "^1.2.1",
                         "mkdirp": "^0.5.0",
                         "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.2"
+                        "yallist": "^3.0.3"
                     },
                     "dependencies": {
-                        "chownr": {
-                            "version": "1.1.1",
-                            "bundled": true
-                        },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
@@ -9250,6 +9241,13 @@
                     "version": "1.0.3",
                     "bundled": true
                 },
+                "util-promisify": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "object.getownpropertydescriptors": "^2.0.3"
+                    }
+                },
                 "uuid": {
                     "version": "3.3.2",
                     "bundled": true
@@ -9322,7 +9320,7 @@
                     }
                 },
                 "worker-farm": {
-                    "version": "1.6.0",
+                    "version": "1.7.0",
                     "bundled": true,
                     "requires": {
                         "errno": "~0.1.7"
@@ -9352,7 +9350,7 @@
                     "bundled": true
                 },
                 "write-file-atomic": {
-                    "version": "2.3.0",
+                    "version": "2.4.3",
                     "bundled": true,
                     "requires": {
                         "graceful-fs": "^4.1.11",
@@ -9373,7 +9371,7 @@
                     "bundled": true
                 },
                 "yallist": {
-                    "version": "2.1.2",
+                    "version": "3.0.3",
                     "bundled": true
                 },
                 "yargs": {
@@ -9501,7 +9499,7 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
             }
         },
         "npmlog": {
@@ -9546,9 +9544,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -9557,7 +9555,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "kind-of": {
@@ -9566,7 +9564,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -9583,7 +9581,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             }
         },
         "object.omit": {
@@ -9592,8 +9590,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "object.pick": {
@@ -9602,7 +9600,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "once": {
@@ -9611,7 +9609,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
@@ -9620,7 +9618,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "opener": {
@@ -9635,8 +9633,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "0.0.8",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             },
             "dependencies": {
                 "wordwrap": {
@@ -9707,7 +9705,7 @@
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
             "dev": true,
             "requires": {
-                "p-try": "1.0.0"
+                "p-try": "^1.0.0"
             }
         },
         "p-locate": {
@@ -9716,7 +9714,7 @@
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
-                "p-limit": "1.3.0"
+                "p-limit": "^1.1.0"
             }
         },
         "p-retry": {
@@ -9749,10 +9747,10 @@
             "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
             "dev": true,
             "requires": {
-                "got": "6.7.1",
-                "registry-auth-token": "3.3.2",
-                "registry-url": "3.1.0",
-                "semver": "5.6.0"
+                "got": "^6.7.1",
+                "registry-auth-token": "^3.0.1",
+                "registry-url": "^3.0.3",
+                "semver": "^5.1.0"
             }
         },
         "pako": {
@@ -9810,12 +9808,12 @@
             "integrity": "sha512-XXtDdOPLSB0sHecbEapQi6/58U/ODj/KWfIXmmMCJF/eRn8laX6LZbOyioMoETOOJoWRW8/qTSl5VQkUIfKM5g==",
             "dev": true,
             "requires": {
-                "character-entities": "1.2.2",
-                "character-entities-legacy": "1.1.2",
-                "character-reference-invalid": "1.1.2",
-                "is-alphanumerical": "1.0.2",
-                "is-decimal": "1.0.2",
-                "is-hexadecimal": "1.0.2"
+                "character-entities": "^1.0.0",
+                "character-entities-legacy": "^1.0.0",
+                "character-reference-invalid": "^1.0.0",
+                "is-alphanumerical": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-hexadecimal": "^1.0.0"
             }
         },
         "parse-git-config": {
@@ -9840,10 +9838,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -9858,7 +9856,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -9869,8 +9867,8 @@
             "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.2",
-                "json-parse-better-errors": "1.0.2"
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
             }
         },
         "pascalcase": {
@@ -9933,7 +9931,7 @@
             "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "pbkdf2": {
@@ -9991,7 +9989,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "pkg-dir": {
@@ -10000,7 +9998,7 @@
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0"
+                "find-up": "^2.1.0"
             }
         },
         "portfinder": {
@@ -10009,9 +10007,9 @@
             "integrity": "sha512-23aeQKW9KgHe6citUrG3r9HjeX6vls0h713TAa+CwTKZwNIr/pD2ApaxYF4Um3ZZyq4ar+Siv3+fhoHaIwSOSw==",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "debug": "2.6.9",
-                "mkdirp": "0.5.1"
+                "async": "^1.5.2",
+                "debug": "^2.2.0",
+                "mkdirp": "0.5.x"
             },
             "dependencies": {
                 "async": {
@@ -10034,9 +10032,9 @@
             "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "source-map": "0.6.1",
-                "supports-color": "5.5.0"
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
             },
             "dependencies": {
                 "source-map": {
@@ -10053,9 +10051,9 @@
             "integrity": "sha512-KxKUpj7AY7nlCbLcTOYxdfJnGE7QFAfU2n95ADj1Q90RM/pOLdz8k3n4avOyRFs7MDQHcRzJQWM1dehCwJxisQ==",
             "dev": true,
             "requires": {
-                "htmlparser2": "3.10.0",
-                "remark": "8.0.0",
-                "unist-util-find-all-after": "1.0.2"
+                "htmlparser2": "^3.9.2",
+                "remark": "^8.0.0",
+                "unist-util-find-all-after": "^1.0.1"
             }
         },
         "postcss-jsx": {
@@ -10069,11 +10067,11 @@
         },
         "postcss-less": {
             "version": "1.1.5",
-            "resolved": "http://registry.npmjs.org/postcss-less/-/postcss-less-1.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.5.tgz",
             "integrity": "sha512-QQIiIqgEjNnquc0d4b6HDOSFZxbFQoy4MPpli2lSLpKhMyBkKwwca2HFqu4xzxlKID/F2fxSOowwtKpgczhF7A==",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.2.16"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -10090,15 +10088,15 @@
                 },
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -10121,19 +10119,19 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.9",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -10142,7 +10140,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -10261,10 +10259,10 @@
             "integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "lodash": "4.17.11",
-                "log-symbols": "2.2.0",
-                "postcss": "6.0.23"
+                "chalk": "^2.0.1",
+                "lodash": "^4.17.4",
+                "log-symbols": "^2.0.0",
+                "postcss": "^6.0.8"
             }
         },
         "postcss-resolve-nested-selector": {
@@ -10279,7 +10277,7 @@
             "integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
             "dev": true,
             "requires": {
-                "postcss": "6.0.23"
+                "postcss": "^6.0.6"
             }
         },
         "postcss-sass": {
@@ -10288,8 +10286,8 @@
             "integrity": "sha512-cUmYzkP747fPCQE6d+CH2l1L4VSyIlAzZsok3HPjb5Gzsq3jE+VjpAdGlPsnQ310WKWI42sw+ar0UNN59/f3hg==",
             "dev": true,
             "requires": {
-                "gonzales-pe": "4.2.3",
-                "postcss": "6.0.23"
+                "gonzales-pe": "^4.0.3",
+                "postcss": "^6.0.6"
             }
         },
         "postcss-scss": {
@@ -10298,7 +10296,7 @@
             "integrity": "sha512-4EFYGHcEw+H3E06PT/pQQri06u/1VIIPjeJQaM8skB80vZuXMhp4cSNV5azmdNkontnOID/XYWEvEEELLFB1ww==",
             "dev": true,
             "requires": {
-                "postcss": "6.0.23"
+                "postcss": "^6.0.23"
             }
         },
         "postcss-selector-parser": {
@@ -10307,9 +10305,9 @@
             "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
             "dev": true,
             "requires": {
-                "dot-prop": "4.2.0",
-                "indexes-of": "1.0.1",
-                "uniq": "1.0.1"
+                "dot-prop": "^4.1.1",
+                "indexes-of": "^1.0.1",
+                "uniq": "^1.0.1"
             }
         },
         "postcss-syntax": {
@@ -10460,6 +10458,17 @@
                         "strip-json-comments": "^2.0.1",
                         "table": "^5.2.3",
                         "text-table": "^0.2.0"
+                    },
+                    "dependencies": {
+                        "eslint-utils": {
+                            "version": "1.4.2",
+                            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+                            "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+                            "dev": true,
+                            "requires": {
+                                "eslint-visitor-keys": "^1.0.0"
+                            }
+                        }
                     }
                 },
                 "espree": {
@@ -10603,20 +10612,20 @@
             "integrity": "sha512-CmatjDsW8xKMtWg/Tc6/W02wC59p50kkItrXmkgbhR4b2EKMU5Pm55x1WuCahkkZeZoNVReWRxA8VL/s69mkBg==",
             "dev": true,
             "requires": {
-                "cosmiconfig": "3.1.0",
-                "debug": "3.2.6",
-                "get-stdin": "5.0.1",
-                "globby": "6.1.0",
-                "ignore": "3.3.10",
-                "import-local": "0.1.1",
-                "meow": "3.7.0",
-                "pify": "3.0.0",
-                "prettier": "1.14.3",
-                "resolve-from": "4.0.0",
-                "stylelint": "8.4.0",
-                "temp-write": "3.4.0",
-                "tempy": "0.2.1",
-                "update-notifier": "2.5.0"
+                "cosmiconfig": "^3.0.1",
+                "debug": "^3.0.1",
+                "get-stdin": "^5.0.1",
+                "globby": "^6.1.0",
+                "ignore": "^3.3.5",
+                "import-local": "^0.1.1",
+                "meow": "^3.7.0",
+                "pify": "^3.0.0",
+                "prettier": "^1.7.0",
+                "resolve-from": "^4.0.0",
+                "stylelint": "^8.1.1",
+                "temp-write": "^3.3.0",
+                "tempy": "^0.2.1",
+                "update-notifier": "^2.2.0"
             },
             "dependencies": {
                 "ajv-keywords": {
@@ -10631,7 +10640,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "array-unique": {
@@ -10646,9 +10655,9 @@
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.3"
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
                     }
                 },
                 "camelcase-keys": {
@@ -10657,9 +10666,9 @@
                     "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "4.1.0",
-                        "map-obj": "2.0.0",
-                        "quick-lru": "1.1.0"
+                        "camelcase": "^4.1.0",
+                        "map-obj": "^2.0.0",
+                        "quick-lru": "^1.0.0"
                     }
                 },
                 "cosmiconfig": {
@@ -10668,10 +10677,10 @@
                     "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
                     "dev": true,
                     "requires": {
-                        "is-directory": "0.3.1",
-                        "js-yaml": "3.12.0",
-                        "parse-json": "3.0.0",
-                        "require-from-string": "2.0.2"
+                        "is-directory": "^0.3.1",
+                        "js-yaml": "^3.9.0",
+                        "parse-json": "^3.0.0",
+                        "require-from-string": "^2.0.1"
                     }
                 },
                 "debug": {
@@ -10680,7 +10689,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.1.1"
                     }
                 },
                 "expand-brackets": {
@@ -10689,7 +10698,7 @@
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "dev": true,
                     "requires": {
-                        "is-posix-bracket": "0.1.1"
+                        "is-posix-bracket": "^0.1.0"
                     }
                 },
                 "extglob": {
@@ -10698,7 +10707,7 @@
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "globby": {
@@ -10707,16 +10716,16 @@
                     "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "glob": "7.1.3",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "array-union": "^1.0.1",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     },
                     "dependencies": {
                         "pify": {
                             "version": "2.3.0",
-                            "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                             "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                             "dev": true
                         }
@@ -10740,7 +10749,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "kind-of": {
@@ -10749,7 +10758,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 },
                 "map-obj": {
@@ -10764,19 +10773,19 @@
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 },
                 "minimist": {
@@ -10797,7 +10806,7 @@
                     "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.3.1"
                     }
                 },
                 "prettier": {
@@ -10812,8 +10821,8 @@
                     "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
                     "dev": true,
                     "requires": {
-                        "find-up": "2.1.0",
-                        "read-pkg": "3.0.0"
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^3.0.0"
                     }
                 },
                 "redent": {
@@ -10822,8 +10831,8 @@
                     "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
                     "dev": true,
                     "requires": {
-                        "indent-string": "3.2.0",
-                        "strip-indent": "2.0.0"
+                        "indent-string": "^3.0.0",
+                        "strip-indent": "^2.0.0"
                     }
                 },
                 "resolve-from": {
@@ -10844,45 +10853,45 @@
                     "integrity": "sha512-56hPH5mTFnk8LzlEuTWq0epa34fHuS54UFYQidBOFt563RJBNi1nz1F2HK2MoT1X1waq47milvRsRahFCCJs/Q==",
                     "dev": true,
                     "requires": {
-                        "autoprefixer": "7.2.6",
-                        "balanced-match": "1.0.0",
-                        "chalk": "2.4.1",
-                        "cosmiconfig": "3.1.0",
-                        "debug": "3.2.6",
-                        "execall": "1.0.0",
-                        "file-entry-cache": "2.0.0",
-                        "get-stdin": "5.0.1",
-                        "globby": "7.1.1",
-                        "globjoin": "0.1.4",
-                        "html-tags": "2.0.0",
-                        "ignore": "3.3.10",
-                        "imurmurhash": "0.1.4",
-                        "known-css-properties": "0.5.0",
-                        "lodash": "4.17.11",
-                        "log-symbols": "2.2.0",
-                        "mathml-tag-names": "2.1.0",
-                        "meow": "4.0.1",
-                        "micromatch": "2.3.11",
-                        "normalize-selector": "0.2.0",
-                        "pify": "3.0.0",
-                        "postcss": "6.0.23",
-                        "postcss-html": "0.12.0",
-                        "postcss-less": "1.1.5",
-                        "postcss-media-query-parser": "0.2.3",
-                        "postcss-reporter": "5.0.0",
-                        "postcss-resolve-nested-selector": "0.1.1",
-                        "postcss-safe-parser": "3.0.1",
-                        "postcss-sass": "0.2.0",
-                        "postcss-scss": "1.0.6",
-                        "postcss-selector-parser": "3.1.1",
-                        "postcss-value-parser": "3.3.1",
-                        "resolve-from": "4.0.0",
-                        "specificity": "0.3.2",
-                        "string-width": "2.1.1",
-                        "style-search": "0.1.0",
-                        "sugarss": "1.0.1",
-                        "svg-tags": "1.0.0",
-                        "table": "4.0.3"
+                        "autoprefixer": "^7.1.2",
+                        "balanced-match": "^1.0.0",
+                        "chalk": "^2.0.1",
+                        "cosmiconfig": "^3.1.0",
+                        "debug": "^3.0.0",
+                        "execall": "^1.0.0",
+                        "file-entry-cache": "^2.0.0",
+                        "get-stdin": "^5.0.1",
+                        "globby": "^7.0.0",
+                        "globjoin": "^0.1.4",
+                        "html-tags": "^2.0.0",
+                        "ignore": "^3.3.3",
+                        "imurmurhash": "^0.1.4",
+                        "known-css-properties": "^0.5.0",
+                        "lodash": "^4.17.4",
+                        "log-symbols": "^2.0.0",
+                        "mathml-tag-names": "^2.0.1",
+                        "meow": "^4.0.0",
+                        "micromatch": "^2.3.11",
+                        "normalize-selector": "^0.2.0",
+                        "pify": "^3.0.0",
+                        "postcss": "^6.0.6",
+                        "postcss-html": "^0.12.0",
+                        "postcss-less": "^1.1.0",
+                        "postcss-media-query-parser": "^0.2.3",
+                        "postcss-reporter": "^5.0.0",
+                        "postcss-resolve-nested-selector": "^0.1.1",
+                        "postcss-safe-parser": "^3.0.1",
+                        "postcss-sass": "^0.2.0",
+                        "postcss-scss": "^1.0.2",
+                        "postcss-selector-parser": "^3.1.0",
+                        "postcss-value-parser": "^3.3.0",
+                        "resolve-from": "^4.0.0",
+                        "specificity": "^0.3.1",
+                        "string-width": "^2.1.0",
+                        "style-search": "^0.1.0",
+                        "sugarss": "^1.0.0",
+                        "svg-tags": "^1.0.0",
+                        "table": "^4.0.1"
                     },
                     "dependencies": {
                         "globby": {
@@ -10891,12 +10900,12 @@
                             "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
                             "dev": true,
                             "requires": {
-                                "array-union": "1.0.2",
-                                "dir-glob": "2.0.0",
-                                "glob": "7.1.3",
-                                "ignore": "3.3.10",
-                                "pify": "3.0.0",
-                                "slash": "1.0.0"
+                                "array-union": "^1.0.1",
+                                "dir-glob": "^2.0.0",
+                                "glob": "^7.1.2",
+                                "ignore": "^3.3.5",
+                                "pify": "^3.0.0",
+                                "slash": "^1.0.0"
                             }
                         },
                         "meow": {
@@ -10905,15 +10914,15 @@
                             "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                             "dev": true,
                             "requires": {
-                                "camelcase-keys": "4.2.0",
-                                "decamelize-keys": "1.1.0",
-                                "loud-rejection": "1.6.0",
-                                "minimist": "1.2.0",
-                                "minimist-options": "3.0.2",
-                                "normalize-package-data": "2.4.0",
-                                "read-pkg-up": "3.0.0",
-                                "redent": "2.0.0",
-                                "trim-newlines": "2.0.0"
+                                "camelcase-keys": "^4.0.0",
+                                "decamelize-keys": "^1.0.0",
+                                "loud-rejection": "^1.0.0",
+                                "minimist": "^1.1.3",
+                                "minimist-options": "^3.0.1",
+                                "normalize-package-data": "^2.3.4",
+                                "read-pkg-up": "^3.0.0",
+                                "redent": "^2.0.0",
+                                "trim-newlines": "^2.0.0"
                             }
                         }
                     }
@@ -10924,12 +10933,12 @@
                     "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
                     "dev": true,
                     "requires": {
-                        "ajv": "6.5.4",
-                        "ajv-keywords": "3.2.0",
-                        "chalk": "2.4.1",
-                        "lodash": "4.17.11",
+                        "ajv": "^6.0.1",
+                        "ajv-keywords": "^3.0.0",
+                        "chalk": "^2.1.0",
+                        "lodash": "^4.17.4",
                         "slice-ansi": "1.0.0",
-                        "string-width": "2.1.1"
+                        "string-width": "^2.1.1"
                     },
                     "dependencies": {
                         "ajv": {
@@ -10967,7 +10976,7 @@
         "private": {
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+            "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
             "dev": true
         },
         "process": {
@@ -11099,9 +11108,9 @@
             "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0",
-                "kind-of": "6.0.2",
-                "math-random": "1.0.1"
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -11137,10 +11146,10 @@
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
             "requires": {
-                "deep-extend": "0.6.0",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
             },
             "dependencies": {
                 "minimist": {
@@ -11166,9 +11175,9 @@
             "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
             "dev": true,
             "requires": {
-                "load-json-file": "4.0.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "3.0.0"
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
             }
         },
         "read-pkg-up": {
@@ -11177,8 +11186,8 @@
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             },
             "dependencies": {
                 "find-up": {
@@ -11187,8 +11196,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "load-json-file": {
@@ -11197,11 +11206,11 @@
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                     }
                 },
                 "parse-json": {
@@ -11210,7 +11219,7 @@
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-exists": {
@@ -11219,7 +11228,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-type": {
@@ -11228,9 +11237,9 @@
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -11245,9 +11254,9 @@
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     }
                 },
                 "strip-bom": {
@@ -11256,7 +11265,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 }
             }
@@ -11267,13 +11276,13 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "redent": {
@@ -11282,8 +11291,8 @@
             "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
             "dev": true,
             "requires": {
-                "indent-string": "2.1.0",
-                "strip-indent": "1.0.1"
+                "indent-string": "^2.1.0",
+                "strip-indent": "^1.0.1"
             },
             "dependencies": {
                 "indent-string": {
@@ -11292,7 +11301,7 @@
                     "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
                     "dev": true,
                     "requires": {
-                        "repeating": "2.0.1"
+                        "repeating": "^2.0.0"
                     }
                 }
             }
@@ -11323,10 +11332,10 @@
         "regex-cache": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+            "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -11335,8 +11344,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "regexpp": {
@@ -11362,8 +11371,8 @@
             "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
             "dev": true,
             "requires": {
-                "rc": "1.2.8",
-                "safe-buffer": "5.1.2"
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
             }
         },
         "registry-url": {
@@ -11372,7 +11381,7 @@
             "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
             "dev": true,
             "requires": {
-                "rc": "1.2.8"
+                "rc": "^1.0.1"
             }
         },
         "regjsgen": {
@@ -11396,9 +11405,9 @@
             "integrity": "sha512-K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==",
             "dev": true,
             "requires": {
-                "remark-parse": "4.0.0",
-                "remark-stringify": "4.0.0",
-                "unified": "6.2.0"
+                "remark-parse": "^4.0.0",
+                "remark-stringify": "^4.0.0",
+                "unified": "^6.0.0"
             }
         },
         "remark-parse": {
@@ -11407,21 +11416,21 @@
             "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
             "dev": true,
             "requires": {
-                "collapse-white-space": "1.0.4",
-                "is-alphabetical": "1.0.2",
-                "is-decimal": "1.0.2",
-                "is-whitespace-character": "1.0.2",
-                "is-word-character": "1.0.2",
-                "markdown-escapes": "1.0.2",
-                "parse-entities": "1.2.0",
-                "repeat-string": "1.6.1",
-                "state-toggle": "1.0.1",
+                "collapse-white-space": "^1.0.2",
+                "is-alphabetical": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-whitespace-character": "^1.0.0",
+                "is-word-character": "^1.0.0",
+                "markdown-escapes": "^1.0.0",
+                "parse-entities": "^1.0.2",
+                "repeat-string": "^1.5.4",
+                "state-toggle": "^1.0.0",
                 "trim": "0.0.1",
-                "trim-trailing-lines": "1.1.1",
-                "unherit": "1.1.1",
-                "unist-util-remove-position": "1.1.2",
-                "vfile-location": "2.0.3",
-                "xtend": "4.0.1"
+                "trim-trailing-lines": "^1.0.0",
+                "unherit": "^1.0.4",
+                "unist-util-remove-position": "^1.0.0",
+                "vfile-location": "^2.0.0",
+                "xtend": "^4.0.1"
             }
         },
         "remark-stringify": {
@@ -11430,20 +11439,20 @@
             "integrity": "sha512-xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==",
             "dev": true,
             "requires": {
-                "ccount": "1.0.3",
-                "is-alphanumeric": "1.0.0",
-                "is-decimal": "1.0.2",
-                "is-whitespace-character": "1.0.2",
-                "longest-streak": "2.0.2",
-                "markdown-escapes": "1.0.2",
-                "markdown-table": "1.1.2",
-                "mdast-util-compact": "1.0.2",
-                "parse-entities": "1.2.0",
-                "repeat-string": "1.6.1",
-                "state-toggle": "1.0.1",
-                "stringify-entities": "1.3.2",
-                "unherit": "1.1.1",
-                "xtend": "4.0.1"
+                "ccount": "^1.0.0",
+                "is-alphanumeric": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-whitespace-character": "^1.0.0",
+                "longest-streak": "^2.0.1",
+                "markdown-escapes": "^1.0.0",
+                "markdown-table": "^1.1.0",
+                "mdast-util-compact": "^1.0.0",
+                "parse-entities": "^1.0.2",
+                "repeat-string": "^1.5.4",
+                "state-toggle": "^1.0.0",
+                "stringify-entities": "^1.0.1",
+                "unherit": "^1.0.4",
+                "xtend": "^4.0.1"
             }
         },
         "remove-trailing-separator": {
@@ -11470,7 +11479,7 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "1.0.2"
+                "is-finite": "^1.0.0"
             }
         },
         "replace-ext": {
@@ -11485,26 +11494,26 @@
             "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.8.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.7",
-                "extend": "3.0.2",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.3",
-                "har-validator": "5.1.0",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.21",
-                "oauth-sign": "0.9.0",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "tough-cookie": "2.4.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.3.2"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
             }
         },
         "request-debug": {
@@ -11573,7 +11582,7 @@
             "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.6"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-cwd": {
@@ -11582,7 +11591,7 @@
             "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
             "dev": true,
             "requires": {
-                "resolve-from": "3.0.0"
+                "resolve-from": "^3.0.0"
             },
             "dependencies": {
                 "resolve-from": {
@@ -11620,8 +11629,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "2.0.1",
-                "signal-exit": "3.0.2"
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "ret": {
@@ -11639,10 +11648,10 @@
         "rimraf": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
             "dev": true,
             "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.0.5"
             }
         },
         "ripemd160": {
@@ -11661,7 +11670,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "2.1.0"
+                "is-promise": "^2.1.0"
             }
         },
         "run-queue": {
@@ -11698,11 +11707,11 @@
         },
         "safe-regex": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "safer-buffer": {
@@ -12138,7 +12147,7 @@
             "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
             "dev": true,
             "requires": {
-                "semver": "5.6.0"
+                "semver": "^5.0.3"
             }
         },
         "set-blocking": {
@@ -12148,15 +12157,15 @@
             "dev": true
         },
         "set-value": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-            "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+            "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -12165,7 +12174,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -12196,7 +12205,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -12211,10 +12220,10 @@
             "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
             "dev": true,
             "requires": {
-                "array-filter": "0.0.1",
-                "array-map": "0.0.0",
-                "array-reduce": "0.0.0",
-                "jsonify": "0.0.0"
+                "array-filter": "~0.0.0",
+                "array-map": "~0.0.0",
+                "array-reduce": "~0.0.0",
+                "jsonify": "~0.0.0"
             }
         },
         "signal-exit": {
@@ -12241,7 +12250,7 @@
             "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0"
+                "is-fullwidth-code-point": "^2.0.0"
             }
         },
         "smart-buffer": {
@@ -12256,14 +12265,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.2",
-                "use": "3.1.1"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -12272,7 +12281,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -12281,7 +12290,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -12292,9 +12301,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -12303,7 +12312,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -12312,7 +12321,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -12321,7 +12330,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -12330,9 +12339,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -12343,7 +12352,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -12352,7 +12361,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -12400,11 +12409,11 @@
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "2.1.2",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
@@ -12428,8 +12437,8 @@
             "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.1"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -12444,8 +12453,8 @@
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "2.2.0",
-                "spdx-license-ids": "3.0.1"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -12466,7 +12475,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "sprintf-js": {
@@ -12481,15 +12490,15 @@
             "integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
             "dev": true,
             "requires": {
-                "asn1": "0.2.4",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.2",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.2",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "ssri": {
@@ -12513,8 +12522,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -12523,7 +12532,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -12583,11 +12592,11 @@
         "string-width": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
             }
         },
         "string.prototype.padend": {
@@ -12607,7 +12616,7 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringify-clone": {
@@ -12622,10 +12631,10 @@
             "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
             "dev": true,
             "requires": {
-                "character-entities-html4": "1.1.2",
-                "character-entities-legacy": "1.1.2",
-                "is-alphanumerical": "1.0.2",
-                "is-hexadecimal": "1.0.2"
+                "character-entities-html4": "^1.0.0",
+                "character-entities-legacy": "^1.0.0",
+                "is-alphanumerical": "^1.0.0",
+                "is-hexadecimal": "^1.0.0"
             }
         },
         "strip-ansi": {
@@ -12634,7 +12643,7 @@
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
             }
         },
         "strip-bom": {
@@ -12655,7 +12664,7 @@
             "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
             "dev": true,
             "requires": {
-                "get-stdin": "4.0.1"
+                "get-stdin": "^4.0.1"
             },
             "dependencies": {
                 "get-stdin": {
@@ -13249,7 +13258,7 @@
             "integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
             "dev": true,
             "requires": {
-                "postcss": "6.0.23"
+                "postcss": "^6.0.14"
             }
         },
         "supports-color": {
@@ -13258,7 +13267,7 @@
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "dev": true,
             "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
             }
         },
         "svg-tags": {
@@ -13339,12 +13348,12 @@
             "integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "is-stream": "1.1.0",
-                "make-dir": "1.3.0",
-                "pify": "3.0.0",
-                "temp-dir": "1.0.0",
-                "uuid": "3.3.2"
+                "graceful-fs": "^4.1.2",
+                "is-stream": "^1.1.0",
+                "make-dir": "^1.0.0",
+                "pify": "^3.0.0",
+                "temp-dir": "^1.0.0",
+                "uuid": "^3.0.1"
             }
         },
         "tempy": {
@@ -13353,8 +13362,8 @@
             "integrity": "sha512-LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==",
             "dev": true,
             "requires": {
-                "temp-dir": "1.0.0",
-                "unique-string": "1.0.0"
+                "temp-dir": "^1.0.0",
+                "unique-string": "^1.0.0"
             }
         },
         "term-size": {
@@ -13363,7 +13372,7 @@
             "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
             "dev": true,
             "requires": {
-                "execa": "0.7.0"
+                "execa": "^0.7.0"
             }
         },
         "text-table": {
@@ -13406,10 +13415,10 @@
         "tmp": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.2"
             }
         },
         "to-fast-properties": {
@@ -13424,7 +13433,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -13433,7 +13442,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -13450,10 +13459,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
@@ -13462,8 +13471,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             }
         },
         "tough-cookie": {
@@ -13472,8 +13481,8 @@
             "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
             "dev": true,
             "requires": {
-                "psl": "1.1.29",
-                "punycode": "1.4.1"
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
             },
             "dependencies": {
                 "punycode": {
@@ -13498,7 +13507,7 @@
             "dependencies": {
                 "lodash": {
                     "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
+                    "resolved": "http://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
                     "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A=",
                     "dev": true
                 }
@@ -13543,7 +13552,7 @@
         "tty-browserify": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
-            "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+            "integrity": "sha1-PwUlHuF5BN/QZ3VGZw25ZRaCuBE=",
             "dev": true
         },
         "tunnel-agent": {
@@ -13552,7 +13561,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -13591,7 +13600,7 @@
         "uglify-es": {
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-            "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+            "integrity": "sha1-DBxPBwC+2NvBJM2zBNJZLKID5nc=",
             "dev": true,
             "requires": {
                 "commander": "~2.13.0",
@@ -13607,7 +13616,7 @@
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
                     "dev": true
                 }
             }
@@ -13633,7 +13642,7 @@
         },
         "underscore.string": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+            "resolved": "http://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
             "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
             "dev": true
         },
@@ -13643,8 +13652,8 @@
             "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "xtend": "4.0.1"
+                "inherits": "^2.0.1",
+                "xtend": "^4.0.1"
             }
         },
         "unified": {
@@ -13653,12 +13662,12 @@
             "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
             "dev": true,
             "requires": {
-                "bail": "1.0.3",
-                "extend": "3.0.2",
-                "is-plain-obj": "1.1.0",
-                "trough": "1.0.3",
-                "vfile": "2.3.0",
-                "x-is-string": "0.1.0"
+                "bail": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "trough": "^1.0.0",
+                "vfile": "^2.0.0",
+                "x-is-string": "^0.1.0"
             }
         },
         "union": {
@@ -13667,7 +13676,7 @@
             "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
             "dev": true,
             "requires": {
-                "qs": "2.3.3"
+                "qs": "~2.3.3"
             },
             "dependencies": {
                 "qs": {
@@ -13679,38 +13688,15 @@
             }
         },
         "union-value": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+            "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "0.1.1"
-                    }
-                },
-                "set-value": {
-                    "version": "0.4.3",
-                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
-                    }
-                }
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^2.0.1"
             }
         },
         "uniq": {
@@ -13743,7 +13729,7 @@
             "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
             "dev": true,
             "requires": {
-                "crypto-random-string": "1.0.0"
+                "crypto-random-string": "^1.0.0"
             }
         },
         "unist-util-find-all-after": {
@@ -13752,7 +13738,7 @@
             "integrity": "sha512-nDl79mKpffXojLpCimVXnxhlH/jjaTnDuScznU9J4jjsaUtBdDbxmlc109XtcqxY4SDO0SwzngsxxW8DIISt1w==",
             "dev": true,
             "requires": {
-                "unist-util-is": "2.1.2"
+                "unist-util-is": "^2.0.0"
             }
         },
         "unist-util-is": {
@@ -13767,7 +13753,7 @@
             "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
             "dev": true,
             "requires": {
-                "unist-util-visit": "1.4.0"
+                "unist-util-visit": "^1.1.0"
             }
         },
         "unist-util-stringify-position": {
@@ -13782,7 +13768,7 @@
             "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
             "dev": true,
             "requires": {
-                "unist-util-visit-parents": "2.0.1"
+                "unist-util-visit-parents": "^2.0.0"
             }
         },
         "unist-util-visit-parents": {
@@ -13791,7 +13777,7 @@
             "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
             "dev": true,
             "requires": {
-                "unist-util-is": "2.1.2"
+                "unist-util-is": "^2.1.2"
             }
         },
         "universalify": {
@@ -13806,8 +13792,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -13816,9 +13802,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -13852,16 +13838,16 @@
             "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
             "dev": true,
             "requires": {
-                "boxen": "1.3.0",
-                "chalk": "2.4.1",
-                "configstore": "3.1.2",
-                "import-lazy": "2.1.0",
-                "is-ci": "1.2.1",
-                "is-installed-globally": "0.1.0",
-                "is-npm": "1.0.0",
-                "latest-version": "3.1.0",
-                "semver-diff": "2.1.0",
-                "xdg-basedir": "3.0.0"
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-ci": "^1.0.10",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
             }
         },
         "uri-js": {
@@ -13909,7 +13895,7 @@
             "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
             "dev": true,
             "requires": {
-                "prepend-http": "1.0.4"
+                "prepend-http": "^1.0.1"
             }
         },
         "use": {
@@ -13960,8 +13946,8 @@
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "dev": true,
             "requires": {
-                "spdx-correct": "3.0.2",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "validate-npm-package-name": {
@@ -13985,9 +13971,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "vfile": {
@@ -13996,10 +13982,10 @@
             "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6",
+                "is-buffer": "^1.1.4",
                 "replace-ext": "1.0.0",
-                "unist-util-stringify-position": "1.1.2",
-                "vfile-message": "1.0.1"
+                "unist-util-stringify-position": "^1.0.0",
+                "vfile-message": "^1.0.0"
             }
         },
         "vfile-location": {
@@ -14014,7 +14000,7 @@
             "integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
             "dev": true,
             "requires": {
-                "unist-util-stringify-position": "1.1.2"
+                "unist-util-stringify-position": "^1.1.1"
             }
         },
         "vm-browserify": {
@@ -14045,7 +14031,7 @@
                 },
                 "acorn-jsx": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
                     "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
                     "dev": true,
                     "requires": {
@@ -14054,7 +14040,7 @@
                     "dependencies": {
                         "acorn": {
                             "version": "3.3.0",
-                            "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                            "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
                             "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
                             "dev": true
                         }
@@ -14103,7 +14089,7 @@
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -14127,7 +14113,7 @@
             "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
             "dev": true,
             "requires": {
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             }
         },
         "wordwrap": {
@@ -14187,18 +14173,18 @@
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
             "dev": true,
             "requires": {
-                "mkdirp": "0.5.1"
+                "mkdirp": "^0.5.1"
             }
         },
         "write-file-atomic": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-            "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+            "integrity": "sha1-H/YVdcLipOjlENb6TiQ8zhg5mas=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "signal-exit": "3.0.2"
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
             }
         },
         "x-is-string": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
         "stylelint": "10.1.0"
     },
     "dependencies": {
-        "npm": "^6.6.0"
+        "npm": "^6.11.3"
     }
 }


### PR DESCRIPTION
`npm install` is giving us lots of security warnings. This PR is the result of running `npm audit fix`. There are some warnings still, but I thought we could apply these now and then handle the rest in a separate PR.
