### PR TITLE
adding examples for new css text properties - text-decoration-thickne…

### DIFF
--- a/live-examples/css-examples/text-decoration/meta.json
+++ b/live-examples/css-examples/text-decoration/meta.json
@@ -35,6 +35,13 @@
             "title": "CSS Demo: text-decoration-style",
             "type": "css"
         },
+        "textDecorationThickness": {
+            "cssExampleSrc": "./live-examples/css-examples/text-decoration/text-decoration-thickness.css",
+            "exampleCode": "./live-examples/css-examples/text-decoration/text-decoration-thickness.html",
+            "fileName": "text-decoration-thickness.html",
+            "title": "CSS Demo: text-decoration-thickness",
+            "type": "css"
+        },
         "textEmphasis": {
             "cssExampleSrc": "./live-examples/css-examples/text-decoration/text-emphasis.css",
             "exampleCode": "./live-examples/css-examples/text-decoration/text-emphasis.html",
@@ -61,6 +68,13 @@
             "exampleCode": "./live-examples/css-examples/text-decoration/text-shadow.html",
             "fileName": "text-shadow.html",
             "title": "CSS Demo: text-shadow",
+            "type": "css"
+        },
+        "textUnderlineOffset": {
+            "cssExampleSrc": "./live-examples/css-examples/text-decoration/text-underline-offset.css",
+            "exampleCode": "./live-examples/css-examples/text-decoration/text-underline-offset.html",
+            "fileName": "text-underline-offset.html",
+            "title": "CSS Demo: text-underline-offset",
             "type": "css"
         },
         "textUnderlinePosition": {

--- a/live-examples/css-examples/text-decoration/text-decoration-thickness.css
+++ b/live-examples/css-examples/text-decoration/text-decoration-thickness.css
@@ -1,0 +1,5 @@
+p {
+    font: 1.5em sans-serif;
+    color: #352995;
+    text-decoration-color: #ff0000;
+}

--- a/live-examples/css-examples/text-decoration/text-decoration-thickness.html
+++ b/live-examples/css-examples/text-decoration/text-decoration-thickness.html
@@ -1,0 +1,31 @@
+<section id="example-choice-list" class="example-choice-list" data-property="textDecorationThickness">
+<div class="example-choice" initial-choice="true">
+<pre><code class="language-css">text-decoration-line: underline;
+text-decoration-thickness: 3px;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code class="language-css">text-decoration-line: line-through;
+text-decoration-thickness: 0.3rem;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+<div class="example-choice">
+<pre><code class="language-css">text-decoration-line: underline overline;
+text-decoration-thickness: from-font;
+font-size: 2rem;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <p id="example-element">Confusion kissed me on the cheek, and left a taste so bittersweet</p>
+    </section>
+</div>

--- a/live-examples/css-examples/text-decoration/text-decoration-thickness.html
+++ b/live-examples/css-examples/text-decoration/text-decoration-thickness.html
@@ -9,7 +9,7 @@ text-decoration-thickness: 3px;</code></pre>
 
 <div class="example-choice">
 <pre><code class="language-css">text-decoration-line: line-through;
-text-decoration-thickness: 0.3rem;</code></pre>
+text-decoration-thickness: 0.4rem;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>

--- a/live-examples/css-examples/text-decoration/text-underline-offset.css
+++ b/live-examples/css-examples/text-decoration/text-underline-offset.css
@@ -1,5 +1,6 @@
 p {
     font: 1.5em sans-serif;
     color: #352995;
-    text-decoration: #ff0000;
+    text-decoration: underline #ff0000;
+
 }

--- a/live-examples/css-examples/text-decoration/text-underline-offset.css
+++ b/live-examples/css-examples/text-decoration/text-underline-offset.css
@@ -1,0 +1,5 @@
+p {
+    font: 1.5em sans-serif;
+    color: #352995;
+    text-decoration: #ff0000;
+}

--- a/live-examples/css-examples/text-decoration/text-underline-offset.html
+++ b/live-examples/css-examples/text-decoration/text-underline-offset.html
@@ -1,22 +1,19 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textUnderlineOffset">
 <div class="example-choice" initial-choice="true">
-<pre><code class="language-css">text-decoration-line: underline;
-text-underline-offset: 3px;</code></pre>
+<pre><code class="language-css">text-underline-offset: 3px;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code class="language-css">text-decoration-line: underline overline;
-text-underline-offset: 0.25rem;</code></pre>
+<pre><code class="language-css">text-underline-offset: 1rem;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 <div class="example-choice">
-<pre><code class="language-css">text-decoration-line: underline;
-text-underline-offset: from-font;
+<pre><code class="language-css">text-underline-offset: from-font;
 font-size: 2rem;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/text-decoration/text-underline-offset.html
+++ b/live-examples/css-examples/text-decoration/text-underline-offset.html
@@ -1,0 +1,31 @@
+<section id="example-choice-list" class="example-choice-list" data-property="textUnderlineOffset">
+<div class="example-choice" initial-choice="true">
+<pre><code class="language-css">text-decoration-line: underline;
+text-underline-offset: 3px;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+
+<div class="example-choice">
+<pre><code class="language-css">text-decoration-line: underline overline;
+text-underline-offset: 0.25rem;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+<div class="example-choice">
+<pre><code class="language-css">text-decoration-line: underline;
+text-underline-offset: from-font;
+font-size: 2rem;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
+</div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <p id="example-element">And after all we're only ordinary men</p>
+    </section>
+</div>


### PR DESCRIPTION
…ss and text-underline-offset

As per https://bugzilla.mozilla.org/show_bug.cgi?id=1573631.

These will be enabled in release as of Fx 70. Therefore I've:

* Added an example for `text-decoration-thickness`. I'll not add it to the relevant property page as yet, because it will only be supported in Firefox, when v 70 comes out. Maybe wait till it has wider support?
* Added an example for `text-underline-offset`. I'll not add it to the relevant property page as yet, because it will only be supported in Firefox, when v 70 comes out. Maybe wait till it has wider support?
* Started to display the relevant interactive example on https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-skip-ink, is it will be supported across Fx and Chromium as of the Fx 70 release

I was also considering updating the interactive example at https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration to show a version that includes the text-decoration-thickness value as part of the shorthand. But this won't work anywhere except Firefox, and not until 70 is released. Do you think I should leave this for now?