### PR TITLE
Change for-of example to something simpler

### DIFF
--- a/live-examples/js-examples/statement/statement-forof.html
+++ b/live-examples/js-examples/statement/statement-forof.html
@@ -1,14 +1,12 @@
 <pre>
-<code id="static-js">function* foo(){
-  yield 1;
-  yield 2;
+<code id="static-js">const array1 = ['a', 'b', 'c'];
+
+for (const element of array1) {
+  console.log(element);
 }
 
-for (let o of foo()) {
-  console.log(o);
-  // expected output: 1
-
-  break; // closes iterator, triggers return
-}
+// expected output: "a"
+// expected output: "b"
+// expected output: "c"
 </code>
 </pre>


### PR DESCRIPTION
I don't think generators should be the intro-example to for-of iterating. This changes it to basically the same as the for-each example.

Very much inspired by @ryanflorence's tweet: https://twitter.com/ryanflorence/status/1178450087531311104?s=20