### PR TITLE
Add name attribute to select example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3343,9 +3343,9 @@
             "dev": true
         },
         "eslint": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.5.0.tgz",
-            "integrity": "sha512-IIbSW+vKOqMatPmS9ayyku4tvWxHY2iricSRtOz6+ZA5IPRlgXzEL0u/j6dr4eha0ugmhMwDTqxtmNu3kj9O4w==",
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.5.1.tgz",
+            "integrity": "sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "ajv": "6.10.2",
         "all-contributors-cli": "6.9.1",
         "chokidar-cli": "2.0.0",
-        "eslint": "6.5.0",
+        "eslint": "6.5.1",
         "http-server": "0.11.1",
         "mdn-bob": "1.1.37",
         "npm-run-all": "4.1.5",


### PR DESCRIPTION
The description for the select contains the following text: 

> The above example shows typical usage. It is given an id attribute to enable it to be associated with a for accessibility purposes, as well as a name attribute to represent the name of the associated data point submitted to the server.  

The name attribute mentioned in the text is missing in the example. This adds the name attribute.