### PR TITLE
Added code to show how async function returns a promise, which is the…

### DIFF
--- a/live-examples/js-examples/statement/statement-async.html
+++ b/live-examples/js-examples/statement/statement-async.html
@@ -12,8 +12,11 @@ async function asyncCall() {
   var result = await resolveAfter2Seconds();
   console.log(result);
   // expected output: 'resolved'
+  return result;
 }
 
-asyncCall();
+//The async function implicitly returns a promise
+var implicit_promise = asyncCall();
+implicit_promise.then((result)=>console.log("Result of async implicit promise:" + result));
 </code>
 </pre>


### PR DESCRIPTION
… whole point of async.

Previously, a maintainer rejected this request because they wanted to keep the example simple. That is fine, but the example should at least show an example of the functionality being displayed. Currently, the example shows a demo of a manual promise, and that await will wait for that promise. It does not show in any way what async does, other than that the keyword goes before a function declaration. As it is now, this example is not simple, it is confusing. Please take a closer look.