### PR TITLE
Edit for-in statement example

### DIFF
--- a/live-examples/js-examples/statement/statement-forin.html
+++ b/live-examples/js-examples/statement/statement-forin.html
@@ -1,12 +1,14 @@
 <pre>
-<code id="static-js">var string1 = "";
-var object1 = {a: 1, b: 2, c: 3};
+<code id="static-js">
+const object = {a: 1, b: 2, c: 3};
 
-for (var property1 in object1) {
-  string1 += object1[property1];
+for (const property in object) {
+  console.log(`${property}: ${object[property]}`);
 }
 
-console.log(string1);
-// expected output: "123"
+// expected output:
+// "a: 1"
+// "b: 2"
+// "c: 3"
 </code>
 </pre>

--- a/live-examples/js-examples/statement/statement-forin.html
+++ b/live-examples/js-examples/statement/statement-forin.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const object = {a: 1, b: 2, c: 3};
+<code id="static-js">const object = {a: 1, b: 2, c: 3};
 
 for (const property in object) {
   console.log(`${property}: ${object[property]}`);


### PR DESCRIPTION
This PR modifies current example of for..in statement, which I've found to be slightly misleading because of those string concatenation. I would like to propose the following trivial example, which is more transparent and readable at the first glance, same as [for...of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of)'s example.