### PR TITLE
Update date string format passed to Date constructor

### DIFF
--- a/live-examples/js-examples/date/date-constructor.html
+++ b/live-examples/js-examples/date/date-constructor.html
@@ -1,9 +1,11 @@
 <pre>
-<code id="static-js">var date1 = new Date('December 17, 1995 03:24:00');
-// Sun Dec 17 1995 03:24:00 GMT...
+<code id="static-js">var date1 = new Date('Sun, 17 Dec 1995 01:24:00 GMT');
+// expected output: Sun Dec 17 1995 03:24:00 GMT+0200 (CEST)
+// note: your timezone may vary
 
-var date2 = new Date('1995-12-17T03:24:00');
-// Sun Dec 17 1995 03:24:00 GMT...
+var date2 = new Date('1995-12-17T01:24:00.000Z');
+// expected output: Sun Dec 17 1995 03:24:00 GMT+0200 (CEST)
+// note: your timezone may vary
 
 console.log(date1 === date2);
 // expected output: false;


### PR DESCRIPTION
This suggestion is to:
* avoid possible confusion of previously used format (1995-12-17T03:24:00) with  ISO8601 format (1995-12-17T03:24:00Z);
* avoid giving example of using  implementation-specific date formats in favour of standardized date interchange formats (UTC string and ISO8601);
* fix confusing console output examples: new Date('December 17, 1995 03:24:00') may give different day and date depending on user timezone;
* emphasize straight away that date string parser used in Date constructor is timezone-aware;