### PR TITLE
corrects usage of <keyframes-name> in `animation` shorthand

### DIFF
--- a/live-examples/css-examples/animation/animation.html
+++ b/live-examples/css-examples/animation/animation.html
@@ -1,27 +1,27 @@
 <section id="example-choice-list" class="example-choice-list" data-property="animation">
 <div class="example-choice">
-<pre><code class="language-css">animation: slidein 3s ease-in 1s infinite reverse both running;</code></pre>
+<pre><code class="language-css">animation: 3s ease-in 1s infinite reverse both running slidein;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code class="language-css">animation: slidein 3s linear 1s infinite running;</code></pre>
+<pre><code class="language-css">animation: 3s linear 1s infinite running slidein;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code class="language-css">animation: slidein 3s linear 1s infinite alternate;</code></pre>
+<pre><code class="language-css">animation: 3s linear 1s infinite alternate slidein;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code class="language-css">animation: slidein .5s linear 1s infinite alternate;</code></pre>
+<pre><code class="language-css">animation: .5s linear 1s infinite alternate slidein;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>


### PR DESCRIPTION
The animation's \<keyframes-name\> should be the last value provided, not the first[1] (though it looks like it might still work either way in many cases).

The position is only incorrect in this interactive code example; the wiki page itself is correct. 

1. https://www.w3.org/TR/css-animations-1/#animation