### PR TITLE
Use ES6 variable declaration in globalprops live examples

### DIFF
--- a/live-examples/js-examples/globalprops/globalprops-decodeuri.html
+++ b/live-examples/js-examples/globalprops/globalprops-decodeuri.html
@@ -1,6 +1,6 @@
 <pre>
 <code id="static-js">const uri = 'https://mozilla.org/?x=шеллы';
-let encoded = encodeURI(uri);
+const encoded = encodeURI(uri);
 console.log(encoded);
 // expected output: "https://mozilla.org/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B"
 

--- a/live-examples/js-examples/globalprops/globalprops-decodeuri.html
+++ b/live-examples/js-examples/globalprops/globalprops-decodeuri.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">var uri = 'https://mozilla.org/?x=шеллы';
-var encoded = encodeURI(uri);
+<code id="static-js">const uri = 'https://mozilla.org/?x=шеллы';
+let encoded = encodeURI(uri);
 console.log(encoded);
 // expected output: "https://mozilla.org/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B"
 

--- a/live-examples/js-examples/globalprops/globalprops-encodeuri.html
+++ b/live-examples/js-examples/globalprops/globalprops-encodeuri.html
@@ -1,6 +1,6 @@
 <pre>
 <code id="static-js">const uri = 'https://mozilla.org/?x=шеллы';
-let encoded = encodeURI(uri);
+const encoded = encodeURI(uri);
 console.log(encoded);
 // expected output: "https://mozilla.org/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B"
 

--- a/live-examples/js-examples/globalprops/globalprops-encodeuri.html
+++ b/live-examples/js-examples/globalprops/globalprops-encodeuri.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">var uri = 'https://mozilla.org/?x=шеллы';
-var encoded = encodeURI(uri);
+<code id="static-js">const uri = 'https://mozilla.org/?x=шеллы';
+let encoded = encodeURI(uri);
 console.log(encoded);
 // expected output: "https://mozilla.org/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B"
 

--- a/live-examples/js-examples/globalprops/globalprops-infinity.html
+++ b/live-examples/js-examples/globalprops/globalprops-infinity.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">let maxNumber = Math.pow(10, 1000); // max positive number
+<code id="static-js">const maxNumber = Math.pow(10, 1000); // max positive number
 
 if (maxNumber === Infinity) {
   console.log("Let's call it Infinity!");

--- a/live-examples/js-examples/globalprops/globalprops-infinity.html
+++ b/live-examples/js-examples/globalprops/globalprops-infinity.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var maxNumber = Math.pow(10, 1000); // max positive number
+<code id="static-js">let maxNumber = Math.pow(10, 1000); // max positive number
 
 if (maxNumber === Infinity) {
   console.log("Let's call it Infinity!");

--- a/live-examples/js-examples/globalprops/globalprops-null.html
+++ b/live-examples/js-examples/globalprops/globalprops-null.html
@@ -1,6 +1,6 @@
 <pre>
 <code id="static-js">function getVowels(str) {
-  var m = str.match(/[aeiou]/gi);
+  let m = str.match(/[aeiou]/gi);
   if (m === null) {
     return 0;
   }

--- a/live-examples/js-examples/globalprops/globalprops-null.html
+++ b/live-examples/js-examples/globalprops/globalprops-null.html
@@ -1,6 +1,6 @@
 <pre>
 <code id="static-js">function getVowels(str) {
-  let m = str.match(/[aeiou]/gi);
+  const m = str.match(/[aeiou]/gi);
   if (m === null) {
     return 0;
   }

--- a/live-examples/js-examples/globalprops/globalprops-parseint.html
+++ b/live-examples/js-examples/globalprops/globalprops-parseint.html
@@ -1,6 +1,6 @@
 <pre>
 <code id="static-js">function roughScale(x, base) {
-  var parsed = parseInt(x, base);
+  let parsed = parseInt(x, base);
   if (isNaN(parsed)) { return 0 }
   return parsed * 100;
 }

--- a/live-examples/js-examples/globalprops/globalprops-parseint.html
+++ b/live-examples/js-examples/globalprops/globalprops-parseint.html
@@ -1,6 +1,6 @@
 <pre>
 <code id="static-js">function roughScale(x, base) {
-  let parsed = parseInt(x, base);
+  const parsed = parseInt(x, base);
   if (isNaN(parsed)) { return 0 }
   return parsed * 100;
 }

--- a/live-examples/js-examples/globalprops/globalprops-undefined.html
+++ b/live-examples/js-examples/globalprops/globalprops-undefined.html
@@ -6,7 +6,7 @@
   return t;
 }
 
-var x;
+let x;
 
 console.log(test(x));
 // expected output: "Undefined value!"


### PR DESCRIPTION
This PR aims to replace `var` keyword with `let` and `const` in live examples for the globalprops