### PR TITLE
Adding interactive examples for nullish coalescing operator

### DIFF
--- a/live-examples/js-examples/expressions/expressions-nullishcoalescingoperator.html
+++ b/live-examples/js-examples/expressions/expressions-nullishcoalescingoperator.html
@@ -1,0 +1,11 @@
+<pre>
+<code id="static-js">
+const foo = null ?? "default string";
+console.log(foo);
+// expected output: "default string"
+
+const bar = "" ?? "default string";
+console.log(bar);
+// expected output: ""
+</code>
+</pre>

--- a/live-examples/js-examples/expressions/expressions-nullishcoalescingoperator.html
+++ b/live-examples/js-examples/expressions/expressions-nullishcoalescingoperator.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">const foo = null ?? "default string";
+<code id="static-js">const foo = null ?? 'default string';
 console.log(foo);
 // expected output: "default string"
 

--- a/live-examples/js-examples/expressions/expressions-nullishcoalescingoperator.html
+++ b/live-examples/js-examples/expressions/expressions-nullishcoalescingoperator.html
@@ -1,11 +1,10 @@
 <pre>
-<code id="static-js">
-const foo = null ?? "default string";
+<code id="static-js">const foo = null ?? "default string";
 console.log(foo);
 // expected output: "default string"
 
-const bar = "" ?? "default string";
-console.log(bar);
-// expected output: ""
+const baz = 0 ?? 42;
+console.log(baz);
+// expected output: 0
 </code>
 </pre>

--- a/live-examples/js-examples/expressions/meta.json
+++ b/live-examples/js-examples/expressions/meta.json
@@ -102,6 +102,12 @@
             "title": "JavaScript Demo: Expressions - new.target",
             "type": "js"
         },
+        "expressionsNullishCoalescingOperator": {
+            "exampleCode": "./live-examples/js-examples/expressions/expressions-nullishcoalescingoperator.html",
+            "fileName": "expressions-nullishcoalescingoperator.html",
+            "title": "JavaScript Demo: Expressions - Nullish coalescing operator",
+            "type": "js"
+        },
         "expressionsObjectInitializer": {
             "exampleCode": "./live-examples/js-examples/expressions/expressions-objectinitializer.html",
             "fileName": "expressions-objectinitializer.html",


### PR DESCRIPTION
As [nullish coalescing operator](https://github.com/tc39/proposal-nullish-coalescing) is now a TC39 proposal of Stage 3 and has been implemented in [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1566141) and in [Safari](https://webkit.org/blog/9497/release-notes-for-safari-technology-preview-89/), I wrote the [corresponding page](https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) and provide the corresponding interactive example.

The example worked as intended on my machine using the last Firefox Nightly.