### PR TITLE
Update intl-collator-prototype-compare.html

### DIFF
--- a/live-examples/js-examples/intl/intl-collator-prototype-compare.html
+++ b/live-examples/js-examples/intl/intl-collator-prototype-compare.html
@@ -1,15 +1,19 @@
 <pre>
 <code id="static-js">function firstAlphabetical(locale, letter1, letter2) {
-  if (new Intl.Collator(locale).compare(letter1, letter2) > 0) {
+  if (new Intl.Collator(locale).compare(letter1, letter2) < 0) {
     return letter1;
   }
   return letter2;
 }
 
+console.log(firstAlphabetical('en', 'z', 'a'));
+// expected output: 'a'
+
 console.log(firstAlphabetical('de', 'z', 'ä'));
-// expected output: "z"
+// expected output: "ä"
 
 console.log(firstAlphabetical('sv', 'z', 'ä'));
-// expected output: "ä"
+// expected output: "z"
+
 </code>
 </pre>

--- a/live-examples/js-examples/intl/intl-collator-prototype-compare.html
+++ b/live-examples/js-examples/intl/intl-collator-prototype-compare.html
@@ -1,19 +1,15 @@
 <pre>
-<code id="static-js">function firstAlphabetical(locale, letter1, letter2) {
-  if (new Intl.Collator(locale).compare(letter1, letter2) < 0) {
-    return letter1;
-  }
-  return letter2;
-}
+<code id="static-js">const enCollator = new Intl.Collator('en');
+const deCollator = new Intl.Collator('de');
+const svCollator = new Intl.Collator('sv');
 
-console.log(firstAlphabetical('en', 'z', 'a'));
-// expected output: 'a'
+console.log(enCollator.compare('z', 'a') > 0);
+// expected output: true
 
-console.log(firstAlphabetical('de', 'z', 'ä'));
-// expected output: "ä"
+console.log(deCollator.compare('z', 'ä') > 0);
+// expected output: true
 
-console.log(firstAlphabetical('sv', 'z', 'ä'));
-// expected output: "z"
-
+console.log(svCollator.compare('z', 'ä') > 0);
+// expected output: false
 </code>
 </pre>


### PR DESCRIPTION
This example was incorrect. The name of the function is `firstAlphabetical` however, the conditional check and expectations were the inverse.

I added an example in english which shows one many reviewers will recognize as correct ('a' is first, not 'z').  My knowledge of other alphabets and collation rules are less good, but some searching and wikipedia seem to confirm that these are correct (and as I would have expected based on the incorrect comparator, simply reversed from the original examples)