### PR TITLE
Use ES6 variable declarations in the `Intl` examples

### DIFF
--- a/live-examples/js-examples/expressions/expressions-propertyaccessors.html
+++ b/live-examples/js-examples/expressions/expressions-propertyaccessors.html
@@ -1,6 +1,5 @@
 <pre>
 <code id="static-js">const person1 = {};
-
 person1['firstname'] = 'Mario';
 person1['lastname'] = 'Rossi';
 

--- a/live-examples/js-examples/expressions/expressions-propertyaccessors.html
+++ b/live-examples/js-examples/expressions/expressions-propertyaccessors.html
@@ -1,5 +1,6 @@
 <pre>
 <code id="static-js">const person1 = {};
+
 person1['firstname'] = 'Mario';
 person1['lastname'] = 'Rossi';
 

--- a/live-examples/js-examples/intl/intl-collator-prototype-resolvedoptions.html
+++ b/live-examples/js-examples/intl/intl-collator-prototype-resolvedoptions.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">var numberDe = new Intl.NumberFormat('de-DE');
-var numberAr = new Intl.NumberFormat('ar');
+<code id="static-js">const numberDe = new Intl.NumberFormat('de-DE');
+const numberAr = new Intl.NumberFormat('ar');
 
 console.log(numberDe.resolvedOptions().numberingSystem);
 // expected output: "latn"

--- a/live-examples/js-examples/intl/intl-collator-supportedlocalesof.html
+++ b/live-examples/js-examples/intl/intl-collator-supportedlocalesof.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">var locales1 = ['ban', 'id-u-co-pinyin', 'de-ID'];
-var options1 = { localeMatcher: 'lookup' };
+<code id="static-js">const locales1 = ['ban', 'id-u-co-pinyin', 'de-ID'];
+const options1 = { localeMatcher: 'lookup' };
 
 console.log(Intl.Collator.supportedLocalesOf(locales1, options1));
 // expected output: Array ["id-u-co-pinyin", "de-ID"]

--- a/live-examples/js-examples/intl/intl-datetimeformat-prototype-format.html
+++ b/live-examples/js-examples/intl/intl-datetimeformat-prototype-format.html
@@ -1,15 +1,17 @@
 <pre>
-<code id="static-js">var options1 = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
-var date1 = new Date(2012, 05);
+<code id="static-js">const options1 = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+const date1 = new Date(2012, 05);
 
-var dateTimeFormat1 = new Intl.DateTimeFormat('sr-RS', options1);
+const dateTimeFormat1 = new Intl.DateTimeFormat('sr-RS', options1);
 console.log(dateTimeFormat1.format(date1));
 // expected output: "петак, 1. јун 2012."
 
-var dateTimeFormat2 = new Intl.DateTimeFormat('en-GB', options1);
+const dateTimeFormat2 = new Intl.DateTimeFormat('en-GB', options1);
 console.log(dateTimeFormat2.format(date1));
+// expected output: "Friday, 1 June 2012"
 
-var dateTimeFormat3 = new Intl.DateTimeFormat('en-US', options1);
+const dateTimeFormat3 = new Intl.DateTimeFormat('en-US', options1);
 console.log(dateTimeFormat3.format(date1));
+// expected output: "Friday, June 1, 2012"
 </code>
 </pre>

--- a/live-examples/js-examples/intl/intl-datetimeformat-prototype-formatrange.html
+++ b/live-examples/js-examples/intl/intl-datetimeformat-prototype-formatrange.html
@@ -1,15 +1,15 @@
 <pre>
-<code id="static-js">var options1 = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
-var options2 = { year: '2-digit', month: 'numeric', day: 'numeric' };
+<code id="static-js">const options1 = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+const options2 = { year: '2-digit', month: 'numeric', day: 'numeric' };
 
-var startDate = new Date(Date.UTC(2007, 0, 10, 10, 0, 0));
-var endDate = new Date(Date.UTC(2008, 0, 10, 11, 0, 0));
+const startDate = new Date(Date.UTC(2007, 0, 10, 10, 0, 0));
+const endDate = new Date(Date.UTC(2008, 0, 10, 11, 0, 0));
 
-var dateTimeFormat = new Intl.DateTimeFormat('en', options1);
+const dateTimeFormat = new Intl.DateTimeFormat('en', options1);
 console.log(dateTimeFormat.formatRange(startDate, endDate));
 // expected output: Wednesday, January 10, 2007 – Thursday, January 10, 2008
 
-var dateTimeFormat2 = new Intl.DateTimeFormat("en", options2);
+const dateTimeFormat2 = new Intl.DateTimeFormat('en', options2);
 console.log(dateTimeFormat2.formatRange(startDate, endDate));
 // expected output: 1/10/07 – 1/10/08
 </code>

--- a/live-examples/js-examples/intl/intl-datetimeformat-prototype-resolvedoptions.html
+++ b/live-examples/js-examples/intl/intl-datetimeformat-prototype-resolvedoptions.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">var region1 = new Intl.DateTimeFormat('zh-CN', { timeZone: 'UTC' });
-var options1 = region1.resolvedOptions();
+<code id="static-js">const region1 = new Intl.DateTimeFormat('zh-CN', { timeZone: 'UTC' });
+const options1 = region1.resolvedOptions();
 
 console.log(options1.locale);
 // expected output: "zh-CN"

--- a/live-examples/js-examples/intl/intl-datetimeformat-supportedlocalesof.html
+++ b/live-examples/js-examples/intl/intl-datetimeformat-supportedlocalesof.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">var locales1 = ['ban', 'id-u-co-pinyin', 'de-ID'];
-var options1 = { localeMatcher: 'lookup' };
+<code id="static-js">const locales1 = ['ban', 'id-u-co-pinyin', 'de-ID'];
+const options1 = { localeMatcher: 'lookup' };
 
 console.log(Intl.DateTimeFormat.supportedLocalesOf(locales1, options1));
 // expected output: Array ["id-u-co-pinyin", "de-ID"]

--- a/live-examples/js-examples/intl/intl-datetimeformat.html
+++ b/live-examples/js-examples/intl/intl-datetimeformat.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
+<code id="static-js">const date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
 // Results below assume UTC timezone - your results may vary
 
 console.log(new Intl.DateTimeFormat('en-US').format(date));

--- a/live-examples/js-examples/intl/intl-locale-prototype-maximize.html
+++ b/live-examples/js-examples/intl/intl-locale-prototype-maximize.html
@@ -1,7 +1,7 @@
 <pre>
-<code id="static-js">const english = new Intl.Locale("en");
-const korean = new Intl.Locale("ko");
-const arabic = new Intl.Locale("ar");
+<code id="static-js">const english = new Intl.Locale('en');
+const korean = new Intl.Locale('ko');
+const arabic = new Intl.Locale('ar');
 
 console.log(english.maximize().baseName);
 // expected output: "en-Latn-US"

--- a/live-examples/js-examples/intl/intl-locale-prototype-minimize.html
+++ b/live-examples/js-examples/intl/intl-locale-prototype-minimize.html
@@ -1,7 +1,7 @@
 <pre>
-<code id="static-js">const english = new Intl.Locale("en-Latn-US");
-const korean = new Intl.Locale("ko-Kore-KR");
-const arabic = new Intl.Locale("ar-Arab-EG");
+<code id="static-js">const english = new Intl.Locale('en-Latn-US');
+const korean = new Intl.Locale('ko-Kore-KR');
+const arabic = new Intl.Locale('ar-Arab-EG');
 
 console.log(english.minimize().baseName);
 // expected output: "en"

--- a/live-examples/js-examples/intl/intl-locale-prototype-tostring.html
+++ b/live-examples/js-examples/intl/intl-locale-prototype-tostring.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">const french = new Intl.Locale("fr-Latn-FR", {calendar: "gregory", hourCycle: "h24"});
-const korean = new Intl.Locale("ko-Kore-KR", {numeric: true, caseFirst: "upper"});
+<code id="static-js">const french = new Intl.Locale('fr-Latn-FR', { calendar: 'gregory', hourCycle: 'h24' });
+const korean = new Intl.Locale('ko-Kore-KR', { numeric: true, caseFirst: 'upper' });
 
 console.log(french.toString());
 // expected output: "fr-Latn-FR-u-ca-gregory-hc-h24"

--- a/live-examples/js-examples/intl/intl-numberformat-prototype-format.html
+++ b/live-examples/js-examples/intl/intl-numberformat-prototype-format.html
@@ -1,14 +1,14 @@
 <pre>
-<code id="static-js">var amount = 654321.987;
+<code id="static-js">const amount = 654321.987;
 
-var options1 = { style: 'currency', currency: 'RUB' };
-var numberFormat1 = new Intl.NumberFormat('ru-RU', options1);
+const options1 = { style: 'currency', currency: 'RUB' };
+const numberFormat1 = new Intl.NumberFormat('ru-RU', options1);
 
 console.log(numberFormat1.format(amount));
 // expected output: "654 321,99 ₽"
 
-var options2 = { style: 'currency', currency: 'USD' };
-var numberFormat2 = new Intl.NumberFormat('en-US', options2);
+const options2 = { style: 'currency', currency: 'USD' };
+const numberFormat2 = new Intl.NumberFormat('en-US', options2);
 
 console.log(numberFormat2.format(amount));
 // expected output: "$654,321.99"

--- a/live-examples/js-examples/intl/intl-numberformat-prototype-resolvedoptions.html
+++ b/live-examples/js-examples/intl/intl-numberformat-prototype-resolvedoptions.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">var numberFormat1 = new Intl.NumberFormat('de-DE');
-var options1 = numberFormat1.resolvedOptions();
+<code id="static-js">const numberFormat1 = new Intl.NumberFormat('de-DE');
+const options1 = numberFormat1.resolvedOptions();
 
 console.log(options1.locale);
 // expected output (Firefox / Safari): "de-DE"

--- a/live-examples/js-examples/intl/intl-numberformat-supportedlocalesof.html
+++ b/live-examples/js-examples/intl/intl-numberformat-supportedlocalesof.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">var locales1 = ['ban', 'id-u-co-pinyin', 'de-ID'];
-var options1 = { localeMatcher: 'lookup' };
+<code id="static-js">const locales1 = ['ban', 'id-u-co-pinyin', 'de-ID'];
+const options1 = { localeMatcher: 'lookup' };
 
 console.log(Intl.NumberFormat.supportedLocalesOf(locales1, options1));
 // expected output: Array ["id-u-co-pinyin", "de-ID"]

--- a/live-examples/js-examples/intl/intl-numberformat.html
+++ b/live-examples/js-examples/intl/intl-numberformat.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var number = 123456.789;
+<code id="static-js">const number = 123456.789;
 
 console.log(new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(number));
 // expected output: "123.456,79 €"

--- a/live-examples/js-examples/intl/intl-relativetimeformat-prototype-format.html
+++ b/live-examples/js-examples/intl/intl-relativetimeformat-prototype-format.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var rtf1 = new Intl.RelativeTimeFormat('en', { style: 'narrow' });
+<code id="static-js">const rtf1 = new Intl.RelativeTimeFormat('en', { style: 'narrow' });
 
 console.log(rtf1.format(3, 'quarter'));
 // expected output: "in 3 qtrs."

--- a/live-examples/js-examples/intl/intl-relativetimeformat-prototype-formattoparts.html
+++ b/live-examples/js-examples/intl/intl-relativetimeformat-prototype-formattoparts.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">var rtf1 = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
-var parts = rtf1.formatToParts(10, 'seconds');
+<code id="static-js">const rtf1 = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+const parts = rtf1.formatToParts(10, 'seconds');
 
 console.log(parts[0].value);
 // expected output: "in "

--- a/live-examples/js-examples/intl/intl-relativetimeformat-prototype-resolvedoptions.html
+++ b/live-examples/js-examples/intl/intl-relativetimeformat-prototype-resolvedoptions.html
@@ -1,9 +1,9 @@
 <pre>
-<code id="static-js">var rtf1 = new Intl.RelativeTimeFormat('en', { style: 'narrow' });
-var options1 = rtf1.resolvedOptions();
+<code id="static-js">const rtf1 = new Intl.RelativeTimeFormat('en', { style: 'narrow' });
+const options1 = rtf1.resolvedOptions();
 
-var rtf2 = new Intl.RelativeTimeFormat('es', { numeric: 'auto' });
-var options2 = rtf2.resolvedOptions();
+const rtf2 = new Intl.RelativeTimeFormat('es', { numeric: 'auto' });
+const options2 = rtf2.resolvedOptions();
 
 console.log(`${options1.locale}, ${options1.style}, ${options1.numeric}`);
 // expected output: "en, narrow, always"

--- a/live-examples/js-examples/intl/intl-relativetimeformat-supportedlocalesof.html
+++ b/live-examples/js-examples/intl/intl-relativetimeformat-supportedlocalesof.html
@@ -1,6 +1,6 @@
 <pre>
-<code id="static-js">var locales1 = ['ban', 'id-u-co-pinyin', 'de-ID'];
-var options1 = { localeMatcher: 'lookup' };
+<code id="static-js">const locales1 = ['ban', 'id-u-co-pinyin', 'de-ID'];
+const options1 = { localeMatcher: 'lookup' };
 
 console.log(Intl.RelativeTimeFormat.supportedLocalesOf(locales1, options1));
 // expected output: Array ["id-u-co-pinyin", "de-ID"]

--- a/live-examples/js-examples/intl/intl-relativetimeformat.html
+++ b/live-examples/js-examples/intl/intl-relativetimeformat.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">var rtf1 = new Intl.RelativeTimeFormat('en', { style: 'narrow' });
+<code id="static-js">const rtf1 = new Intl.RelativeTimeFormat('en', { style: 'narrow' });
 
 console.log(rtf1.format(3, 'quarter'));
 //expected output: "in 3 qtrs."
@@ -7,7 +7,7 @@ console.log(rtf1.format(3, 'quarter'));
 console.log(rtf1.format(-1, 'day'));
 //expected output: "1 day ago"
 
-var rtf2 = new Intl.RelativeTimeFormat('es', { numeric: 'auto' });
+const rtf2 = new Intl.RelativeTimeFormat('es', { numeric: 'auto' });
 
 console.log(rtf2.format(2, 'day'));
 //expected output: "pasado mañana"


### PR DESCRIPTION
With this PR I would like to standardize the `Intl` related examples by
 - using consequently es6 variable declarations
 - using consistent styleguide
 - adjusting the expected output