### PR TITLE
Explicitly call out return value in code example

### DIFF
--- a/live-examples/js-examples/array/array-concat.html
+++ b/live-examples/js-examples/array/array-concat.html
@@ -1,8 +1,9 @@
 <pre>
 <code id="static-js">const array1 = ['a', 'b', 'c'];
 const array2 = ['d', 'e', 'f'];
+const array3 = array1.concat(array2);
 
-console.log(array1.concat(array2));
+console.log(array3);
 // expected output: Array ["a", "b", "c", "d", "e", "f"]
 </code>
 </pre>


### PR DESCRIPTION
While it may be apparent in the current example. I feel like making a new variable very explicitly shows that `concat` returns a new array in the code example which is the first place I personally look