### PR TITLE
Adding regexp assertions

### DIFF
--- a/live-examples/js-examples/regexp/meta.json
+++ b/live-examples/js-examples/regexp/meta.json
@@ -1,5 +1,11 @@
 {
     "pages": {
+        "regexpAssertions":{
+            "exampleCode": "./live-examples/js-examples/regexp/regexp-assertions.html",
+            "fileName": "regexp-assertions.html",
+            "title": "JavaScript Demo: RegExp Assertions",
+            "type": "js"
+        },
         "regexpConstructor": {
             "exampleCode": "./live-examples/js-examples/regexp/regexp-constructor.html",
             "fileName": "regexp-constructor.html",

--- a/live-examples/js-examples/regexp/regexp-assertions.html
+++ b/live-examples/js-examples/regexp/regexp-assertions.html
@@ -1,15 +1,16 @@
 <pre>
-<code id="static-js">var text = "A quick fox";
-var regexpAhead = /[a-z]+ (?=fox)/;
-console.log(text.match(regexpAhead));
-// expected output [ 'quick ']
+<code id="static-js">const text = "A quick fox";
 
-var regexpNegativeAhead = /[A-Z]+ (?!slow)/
-console.log(text.match(regexpNegativeAhead));
-// expected output [ 'A ']
+const regexpLastWord = /\w+$/;
+console.log(text.match(regexpLastWord));
+// expected output: Array ["fox"]
 
-var regexpBehind = /(?&lt;=quick) \w+/;
-console.log(text.match(regexpBehind));
-// expected output (only in Chrome) for now [ 'fox']
+const regexpWords = /\b\w+\b/g;
+console.log(text.match(regexpWords));
+// expected output: Array ["A", "quick", "fox"]
+
+const regexpFoxQuality = /\w+(?= fox)/;
+console.log(text.match(regexpFoxQuality));
+// expected output: Array ["quick"]
 </code>
 </pre>

--- a/live-examples/js-examples/regexp/regexp-assertions.html
+++ b/live-examples/js-examples/regexp/regexp-assertions.html
@@ -1,0 +1,15 @@
+<pre>
+<code id="static-js">var text = "A quick fox";
+var regexpAhead = /[a-z]+ (?=fox)/;
+console.log(text.match(regexpAhead));
+// expected output [ 'quick ']
+
+var regexpNegativeAhead = /[A-Z]+ (?!slow)/
+console.log(text.match(regexpNegativeAhead));
+// expected output [ 'A ']
+
+var regexpBehind = /(?&lt;=quick) \w+/;
+console.log(text.match(regexpBehind));
+// expected output (only in Chrome) for now [ 'fox']
+</code>
+</pre>


### PR DESCRIPTION
As part of https://github.com/mdn/sprints/issues/1721, I'll be adding both inline / interactive examples.

A few notes about this one:

* Although lookbehind assertions are stage 4, they don't currently work in Fx and make the example slightly longer than 12 lines. I think it is better to include at least one of the "lookbehind" pattern but feel free to voice your objection

* This target a feature of the language but not a property or a method.