### PR TITLE
Const to var

### DIFF
--- a/live-examples/js-examples/array/array-push.html
+++ b/live-examples/js-examples/array/array-push.html
@@ -1,7 +1,7 @@
 <pre>
-<code id="static-js">const animals = ['pigs', 'goats', 'sheep'];
+<code id="static-js">var animals = ['pigs', 'goats', 'sheep'];
 
-const count = animals.push('cows');
+var count = animals.push('cows');
 console.log(count);
 // expected output: 4
 console.log(animals);


### PR DESCRIPTION
I'm sorry but the Const is totally out of context for an Array. It must be a var.

On Chrome and Firefox I got 4 7 7 instead of what is expected : 4 4 7