### PR TITLE
Interactive examples for RegExp Unicode Property Escapes

### DIFF
--- a/live-examples/js-examples/regexp/meta.json
+++ b/live-examples/js-examples/regexp/meta.json
@@ -107,6 +107,12 @@
             "fileName": "regexp-prototype-unicode.html",
             "title": "JavaScript Demo: RegExp.prototype.unicode",
             "type": "js"
+        },
+        "regexpUnicodePropertyEscapes": {
+            "exampleCode": "./live-examples/js-examples/regexp/regexp-unicode-property-escapes.html",
+            "fileName": "regexp-unicode-property-escapes.html",
+            "title": "JavaScript Demo: RegExp Unicode property escapes",
+            "type": "js"
         }
     }
 }

--- a/live-examples/js-examples/regexp/regexp-unicode-property-escapes.html
+++ b/live-examples/js-examples/regexp/regexp-unicode-property-escapes.html
@@ -1,0 +1,16 @@
+<pre>
+<code id="static-js">const sentence = "A ticket to 大阪 costs ¥2000 👌.";
+
+const regexpEmojiPres = /\p{Emoji_Presentation}/gu;
+console.log(sentence.match(regexpEmojis));
+// expected output: Array ["👌"]
+
+const regexpNonLatin = /\P{Script_Extensions=Latin}+/gu;
+console.log(sentence.match(regexpNonLatin));
+// expected output: Array [" ", " ", " 大阪 ", " ¥2000 👌."]
+
+const regexpCurrencyOrPunctuation = /\p{Sc}|\p{P}/gu;
+console.log(sentence.match(regexpCurrencyOrPunctuation));
+// expected output: Array ["¥", "."]
+</code>
+</pre>

--- a/live-examples/js-examples/regexp/regexp-unicode-property-escapes.html
+++ b/live-examples/js-examples/regexp/regexp-unicode-property-escapes.html
@@ -1,8 +1,8 @@
 <pre>
 <code id="static-js">const sentence = "A ticket to 大阪 costs ¥2000 👌.";
 
-const regexpEmojiPres = /\p{Emoji_Presentation}/gu;
-console.log(sentence.match(regexpEmojis));
+const regexpEmojiPresentation = /\p{Emoji_Presentation}/gu;
+console.log(sentence.match(regexpEmojiPresentation));
 // expected output: Array ["👌"]
 
 const regexpNonLatin = /\P{Script_Extensions=Latin}+/gu;


### PR DESCRIPTION
As part of https://github.com/mdn/sprints/issues/1721 and in order to add interactive examples on https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes, I propose this PR.

As this feature is not supported by Fx and that I don't have a macOS/iOS device, I was only able to test this on Chrome / Chromium.