### PR TITLE
Un-`var`-ify (most) JS examples

### DIFF
--- a/live-examples/js-examples/map/map-prototype-entries.html
+++ b/live-examples/js-examples/map/map-prototype-entries.html
@@ -1,10 +1,11 @@
 <pre>
-<code id="static-js">var map1 = new Map();
+<code id="static-js">
+const map1 = new Map();
 
 map1.set('0', 'foo');
 map1.set(1, 'bar');
 
-var iterator1 = map1.entries();
+const iterator1 = map1.entries();
 
 console.log(iterator1.next().value);
 // expected output: ["0", "foo"]

--- a/live-examples/js-examples/map/map-prototype-entries.html
+++ b/live-examples/js-examples/map/map-prototype-entries.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const map1 = new Map();
+<code id="static-js">const map1 = new Map();
 
 map1.set('0', 'foo');
 map1.set(1, 'bar');

--- a/live-examples/js-examples/map/map-prototype-get.html
+++ b/live-examples/js-examples/map/map-prototype-get.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const map1 = new Map();
+<code id="static-js">const map1 = new Map();
 map1.set('bar', 'foo');
 
 console.log(map1.get('bar'));

--- a/live-examples/js-examples/map/map-prototype-get.html
+++ b/live-examples/js-examples/map/map-prototype-get.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var map1 = new Map();
+<code id="static-js">
+const map1 = new Map();
 map1.set('bar', 'foo');
 
 console.log(map1.get('bar'));

--- a/live-examples/js-examples/map/map-prototype-has.html
+++ b/live-examples/js-examples/map/map-prototype-has.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var map1 = new Map();
+<code id="static-js">
+const map1 = new Map();
 map1.set('bar', 'foo');
 
 console.log(map1.has('bar'));

--- a/live-examples/js-examples/map/map-prototype-has.html
+++ b/live-examples/js-examples/map/map-prototype-has.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const map1 = new Map();
+<code id="static-js">const map1 = new Map();
 map1.set('bar', 'foo');
 
 console.log(map1.has('bar'));

--- a/live-examples/js-examples/map/map-prototype-keys.html
+++ b/live-examples/js-examples/map/map-prototype-keys.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const map1 = new Map();
+<code id="static-js">const map1 = new Map();
 
 map1.set('0', 'foo');
 map1.set(1, 'bar');

--- a/live-examples/js-examples/map/map-prototype-keys.html
+++ b/live-examples/js-examples/map/map-prototype-keys.html
@@ -1,10 +1,11 @@
 <pre>
-<code id="static-js">var map1 = new Map();
+<code id="static-js">
+const map1 = new Map();
 
 map1.set('0', 'foo');
 map1.set(1, 'bar');
 
-var iterator1 = map1.keys();
+const iterator1 = map1.keys();
 
 console.log(iterator1.next().value);
 // expected output: "0"

--- a/live-examples/js-examples/map/map-prototype-set.html
+++ b/live-examples/js-examples/map/map-prototype-set.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const map1 = new Map();
+<code id="static-js">const map1 = new Map();
 map1.set('bar', 'foo');
 
 console.log(map1.get('bar'));

--- a/live-examples/js-examples/map/map-prototype-set.html
+++ b/live-examples/js-examples/map/map-prototype-set.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var map1 = new Map();
+<code id="static-js">
+const map1 = new Map();
 map1.set('bar', 'foo');
 
 console.log(map1.get('bar'));

--- a/live-examples/js-examples/map/map-prototype-size.html
+++ b/live-examples/js-examples/map/map-prototype-size.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var map1 = new Map();
+<code id="static-js">
+const map1 = new Map();
 
 map1.set('a', 'alpha');
 map1.set('b', 'beta');

--- a/live-examples/js-examples/map/map-prototype-size.html
+++ b/live-examples/js-examples/map/map-prototype-size.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const map1 = new Map();
+<code id="static-js">const map1 = new Map();
 
 map1.set('a', 'alpha');
 map1.set('b', 'beta');

--- a/live-examples/js-examples/map/map-prototype-values.html
+++ b/live-examples/js-examples/map/map-prototype-values.html
@@ -1,10 +1,11 @@
 <pre>
-<code id="static-js">var map1 = new Map();
+<code id="static-js">
+const map1 = new Map();
 
 map1.set('0', 'foo');
 map1.set(1, 'bar');
 
-var iterator1 = map1.values();
+const iterator1 = map1.values();
 
 console.log(iterator1.next().value);
 // expected output: "foo"

--- a/live-examples/js-examples/map/map-prototype-values.html
+++ b/live-examples/js-examples/map/map-prototype-values.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const map1 = new Map();
+<code id="static-js">const map1 = new Map();
 
 map1.set('0', 'foo');
 map1.set(1, 'bar');

--- a/live-examples/js-examples/math/math-max.html
+++ b/live-examples/js-examples/math/math-max.html
@@ -1,11 +1,12 @@
 <pre>
-<code id="static-js">console.log(Math.max(1, 3, 2));
+<code id="static-js">
+console.log(Math.max(1, 3, 2));
 // expected output: 3
 
 console.log(Math.max(-1, -3, -2));
 // expected output: -1
 
-var array1 = [1, 3, 2];
+const array1 = [1, 3, 2];
 
 console.log(Math.max(...array1));
 // expected output: 3

--- a/live-examples/js-examples/math/math-max.html
+++ b/live-examples/js-examples/math/math-max.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-console.log(Math.max(1, 3, 2));
+<code id="static-js">console.log(Math.max(1, 3, 2));
 // expected output: 3
 
 console.log(Math.max(-1, -3, -2));

--- a/live-examples/js-examples/math/math-min.html
+++ b/live-examples/js-examples/math/math-min.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-console.log(Math.min(2, 3, 1));
+<code id="static-js">console.log(Math.min(2, 3, 1));
 // expected output: 1
 
 console.log(Math.min(-2, -3, -1));

--- a/live-examples/js-examples/math/math-min.html
+++ b/live-examples/js-examples/math/math-min.html
@@ -1,11 +1,12 @@
 <pre>
-<code id="static-js">console.log(Math.min(2, 3, 1));
+<code id="static-js">
+console.log(Math.min(2, 3, 1));
 // expected output: 1
 
 console.log(Math.min(-2, -3, -1));
 // expected output: -3
 
-var array1 = [2, 3, 1];
+const array1 = [2, 3, 1];
 
 console.log(Math.min(...array1));
 // expected output: 1

--- a/live-examples/js-examples/number/number-epsilon.html
+++ b/live-examples/js-examples/number/number-epsilon.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const result = Math.abs(0.2 - 0.3 + 0.1);
+<code id="static-js">const result = Math.abs(0.2 - 0.3 + 0.1);
 
 console.log(result);
 // expected output: 2.7755575615628914e-17

--- a/live-examples/js-examples/number/number-epsilon.html
+++ b/live-examples/js-examples/number/number-epsilon.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var result = Math.abs(0.2 - 0.3 + 0.1);
+<code id="static-js">
+const result = Math.abs(0.2 - 0.3 + 0.1);
 
 console.log(result);
 // expected output: 2.7755575615628914e-17

--- a/live-examples/js-examples/number/number-max-safe-integer.html
+++ b/live-examples/js-examples/number/number-max-safe-integer.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const x = Number.MAX_SAFE_INTEGER + 1;
+<code id="static-js">const x = Number.MAX_SAFE_INTEGER + 1;
 const y = Number.MAX_SAFE_INTEGER + 2;
 
 console.log(Number.MAX_SAFE_INTEGER);

--- a/live-examples/js-examples/number/number-max-safe-integer.html
+++ b/live-examples/js-examples/number/number-max-safe-integer.html
@@ -1,6 +1,7 @@
 <pre>
-<code id="static-js">var x = Number.MAX_SAFE_INTEGER + 1;
-var y = Number.MAX_SAFE_INTEGER + 2;
+<code id="static-js">
+const x = Number.MAX_SAFE_INTEGER + 1;
+const y = Number.MAX_SAFE_INTEGER + 2;
 
 console.log(Number.MAX_SAFE_INTEGER);
 // expected output: 9007199254740991

--- a/live-examples/js-examples/number/number-min-safe-integer.html
+++ b/live-examples/js-examples/number/number-min-safe-integer.html
@@ -1,6 +1,7 @@
 <pre>
-<code id="static-js">var x = Number.MIN_SAFE_INTEGER - 1;
-var y = Number.MIN_SAFE_INTEGER - 2;
+<code id="static-js">
+const x = Number.MIN_SAFE_INTEGER - 1;
+const y = Number.MIN_SAFE_INTEGER - 2;
 
 console.log(Number.MIN_SAFE_INTEGER);
 // expected output: -9007199254740991

--- a/live-examples/js-examples/number/number-min-safe-integer.html
+++ b/live-examples/js-examples/number/number-min-safe-integer.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const x = Number.MIN_SAFE_INTEGER - 1;
+<code id="static-js">const x = Number.MIN_SAFE_INTEGER - 1;
 const y = Number.MIN_SAFE_INTEGER - 2;
 
 console.log(Number.MIN_SAFE_INTEGER);

--- a/live-examples/js-examples/number/number-parseint.html
+++ b/live-examples/js-examples/number/number-parseint.html
@@ -1,6 +1,7 @@
 <pre>
-<code id="static-js">function roughScale(x, base) {
-  var parsed = Number.parseInt(x, base);
+<code id="static-js">
+function roughScale(x, base) {
+  let parsed = Number.parseInt(x, base);
   if (Number.isNaN(parsed)) {
     return 0;
   }

--- a/live-examples/js-examples/number/number-parseint.html
+++ b/live-examples/js-examples/number/number-parseint.html
@@ -1,6 +1,6 @@
 <pre>
 <code id="static-js">function roughScale(x, base) {
-  let parsed = Number.parseInt(x, base);
+  const parsed = Number.parseInt(x, base);
   if (Number.isNaN(parsed)) {
     return 0;
   }

--- a/live-examples/js-examples/number/number-parseint.html
+++ b/live-examples/js-examples/number/number-parseint.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-function roughScale(x, base) {
+<code id="static-js">function roughScale(x, base) {
   let parsed = Number.parseInt(x, base);
   if (Number.isNaN(parsed)) {
     return 0;

--- a/live-examples/js-examples/number/number-valueof.html
+++ b/live-examples/js-examples/number/number-valueof.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const numObj = new Number(42);
+<code id="static-js">const numObj = new Number(42);
 console.log(typeof numObj);
 // expected output: "object"
 

--- a/live-examples/js-examples/number/number-valueof.html
+++ b/live-examples/js-examples/number/number-valueof.html
@@ -1,9 +1,10 @@
 <pre>
-<code id="static-js">var numObj = new Number(42);
+<code id="static-js">
+const numObj = new Number(42);
 console.log(typeof numObj);
 // expected output: "object"
 
-var num = numObj.valueOf();
+const num = numObj.valueOf();
 console.log(num);
 // expected output: 42
 

--- a/live-examples/js-examples/object/object-prototype-tostring.html
+++ b/live-examples/js-examples/object/object-prototype-tostring.html
@@ -1,9 +1,10 @@
 <pre>
-<code id="static-js">function Dog(name) {
+<code id="static-js">
+function Dog(name) {
   this.name = name;
 }
 
-var dog1 = new Dog('Gabby');
+const dog1 = new Dog('Gabby');
 
 Dog.prototype.toString = function dogToString() {
   return '' + this.name;

--- a/live-examples/js-examples/object/object-prototype-tostring.html
+++ b/live-examples/js-examples/object/object-prototype-tostring.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-function Dog(name) {
+<code id="static-js">function Dog(name) {
   this.name = name;
 }
 

--- a/live-examples/js-examples/promise/promise-all.html
+++ b/live-examples/js-examples/promise/promise-all.html
@@ -1,7 +1,8 @@
 <pre>
-<code id="static-js">var promise1 = Promise.resolve(3);
-var promise2 = 42;
-var promise3 = new Promise(function(resolve, reject) {
+<code id="static-js">
+const promise1 = Promise.resolve(3);
+const promise2 = 42;
+const promise3 = new Promise(function(resolve, reject) {
   setTimeout(resolve, 100, 'foo');
 });
 

--- a/live-examples/js-examples/promise/promise-all.html
+++ b/live-examples/js-examples/promise/promise-all.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const promise1 = Promise.resolve(3);
+<code id="static-js">const promise1 = Promise.resolve(3);
 const promise2 = 42;
 const promise3 = new Promise(function(resolve, reject) {
   setTimeout(resolve, 100, 'foo');

--- a/live-examples/js-examples/promise/promise-catch.html
+++ b/live-examples/js-examples/promise/promise-catch.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const promise1 = new Promise(function(resolve, reject) {
+<code id="static-js">const promise1 = new Promise(function(resolve, reject) {
   throw 'Uh-oh!';
 });
 

--- a/live-examples/js-examples/promise/promise-catch.html
+++ b/live-examples/js-examples/promise/promise-catch.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var promise1 = new Promise(function(resolve, reject) {
+<code id="static-js">
+const promise1 = new Promise(function(resolve, reject) {
   throw 'Uh-oh!';
 });
 

--- a/live-examples/js-examples/promise/promise-resolve.html
+++ b/live-examples/js-examples/promise/promise-resolve.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const promise1 = Promise.resolve(123);
+<code id="static-js">const promise1 = Promise.resolve(123);
 
 promise1.then(function(value) {
   console.log(value);

--- a/live-examples/js-examples/promise/promise-resolve.html
+++ b/live-examples/js-examples/promise/promise-resolve.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var promise1 = Promise.resolve(123);
+<code id="static-js">
+const promise1 = Promise.resolve(123);
 
 promise1.then(function(value) {
   console.log(value);

--- a/live-examples/js-examples/promise/promise-then.html
+++ b/live-examples/js-examples/promise/promise-then.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var promise1 = new Promise(function(resolve, reject) {
+<code id="static-js">
+const promise1 = new Promise(function(resolve, reject) {
   resolve('Success!');
 });
 

--- a/live-examples/js-examples/promise/promise-then.html
+++ b/live-examples/js-examples/promise/promise-then.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const promise1 = new Promise(function(resolve, reject) {
+<code id="static-js">const promise1 = new Promise(function(resolve, reject) {
   resolve('Success!');
 });
 

--- a/live-examples/js-examples/proxyhandler/proxyhandler-apply.html
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-apply.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js" data-height="taller">
-function sum(a, b) {
+<code id="static-js" data-height="taller">function sum(a, b) {
   return a + b;
 }
 

--- a/live-examples/js-examples/proxyhandler/proxyhandler-apply.html
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-apply.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js" data-height="taller">function sum(a, b) {
+<code id="static-js" data-height="taller">
+function sum(a, b) {
   return a + b;
 }
 
@@ -12,9 +13,9 @@ const handler = {
   }
 };
 
-var proxy1 = new Proxy(sum, handler);
+const proxy1 = new Proxy(sum, handler);
 
-console.log(sum(1, 2)); 
+console.log(sum(1, 2));
 // expected output: 3
 console.log(proxy1(1, 2));
 // expected output: 30

--- a/live-examples/js-examples/reflect/reflect-deleteproperty.html
+++ b/live-examples/js-examples/reflect/reflect-deleteproperty.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js" data-height="taller">
-const object1 = {
+<code id="static-js" data-height="taller">const object1 = {
   property1: 42
 };
 

--- a/live-examples/js-examples/reflect/reflect-deleteproperty.html
+++ b/live-examples/js-examples/reflect/reflect-deleteproperty.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js" data-height="taller">const object1 = {
+<code id="static-js" data-height="taller">
+const object1 = {
   property1: 42
 };
 
@@ -8,7 +9,7 @@ Reflect.deleteProperty(object1, 'property1');
 console.log(object1.property1);
 // expected output: undefined
 
-var array1 = [1, 2, 3, 4, 5];
+let array1 = [1, 2, 3, 4, 5];
 Reflect.deleteProperty(array1, '3');
 
 console.log(array1);

--- a/live-examples/js-examples/reflect/reflect-deleteproperty.html
+++ b/live-examples/js-examples/reflect/reflect-deleteproperty.html
@@ -8,7 +8,7 @@ Reflect.deleteProperty(object1, 'property1');
 console.log(object1.property1);
 // expected output: undefined
 
-let array1 = [1, 2, 3, 4, 5];
+const array1 = [1, 2, 3, 4, 5];
 Reflect.deleteProperty(array1, '3');
 
 console.log(array1);

--- a/live-examples/js-examples/reflect/reflect-get.html
+++ b/live-examples/js-examples/reflect/reflect-get.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">const object1 = {
+<code id="static-js">
+const object1 = {
   x: 1,
   y: 2
 };
@@ -7,7 +8,7 @@
 console.log(Reflect.get(object1, 'x'));
 // expected output: 1
 
-var array1 = ['zero', 'one'];
+let array1 = ['zero', 'one'];
 
 console.log(Reflect.get(array1, 1));
 // expected output: "one"

--- a/live-examples/js-examples/reflect/reflect-get.html
+++ b/live-examples/js-examples/reflect/reflect-get.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const object1 = {
+<code id="static-js">const object1 = {
   x: 1,
   y: 2
 };

--- a/live-examples/js-examples/reflect/reflect-get.html
+++ b/live-examples/js-examples/reflect/reflect-get.html
@@ -7,7 +7,7 @@
 console.log(Reflect.get(object1, 'x'));
 // expected output: 1
 
-let array1 = ['zero', 'one'];
+const array1 = ['zero', 'one'];
 
 console.log(Reflect.get(array1, 1));
 // expected output: "one"

--- a/live-examples/js-examples/regexp/regexp-constructor.html
+++ b/live-examples/js-examples/regexp/regexp-constructor.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const regex1 = /\w+/;
+<code id="static-js">const regex1 = /\w+/;
 const regex2 = new RegExp('\\w+');
 
 console.log(regex1);

--- a/live-examples/js-examples/regexp/regexp-constructor.html
+++ b/live-examples/js-examples/regexp/regexp-constructor.html
@@ -1,6 +1,7 @@
 <pre>
-<code id="static-js">var regex1 = /\w+/;
-var regex2 = new RegExp('\\w+');
+<code id="static-js">
+const regex1 = /\w+/;
+const regex2 = new RegExp('\\w+');
 
 console.log(regex1);
 // expected output: /\w+/

--- a/live-examples/js-examples/regexp/regexp-lastindex.html
+++ b/live-examples/js-examples/regexp/regexp-lastindex.html
@@ -1,6 +1,7 @@
 <pre>
-<code id="static-js">var regex1 = new RegExp( "foo", "g" );
-var str1 = 'table football, foosball';
+<code id="static-js">
+const regex1 = new RegExp( "foo", "g" );
+const str1 = 'table football, foosball';
 
 regex1.test(str1);
 

--- a/live-examples/js-examples/regexp/regexp-lastindex.html
+++ b/live-examples/js-examples/regexp/regexp-lastindex.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const regex1 = new RegExp( "foo", "g" );
+<code id="static-js">const regex1 = new RegExp( "foo", "g" );
 const str1 = 'table football, foosball';
 
 regex1.test(str1);

--- a/live-examples/js-examples/regexp/regexp-prototype-@@match.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-@@match.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-class RegExp1 extends RegExp {
+<code id="static-js">class RegExp1 extends RegExp {
   [Symbol.match](str) {
     const result = RegExp.prototype[Symbol.match].call(this, str);
     if (result) {

--- a/live-examples/js-examples/regexp/regexp-prototype-@@match.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-@@match.html
@@ -1,7 +1,8 @@
 <pre>
-<code id="static-js">class RegExp1 extends RegExp {
+<code id="static-js">
+class RegExp1 extends RegExp {
   [Symbol.match](str) {
-    var result = RegExp.prototype[Symbol.match].call(this, str);
+    const result = RegExp.prototype[Symbol.match].call(this, str);
     if (result) {
       return 'VALID';
     }

--- a/live-examples/js-examples/regexp/regexp-prototype-@@split.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-@@split.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-class RegExp1 extends RegExp {
+<code id="static-js">class RegExp1 extends RegExp {
   [Symbol.split](str, limit) {
     const result = RegExp.prototype[Symbol.split].call(this, str, limit);
     return result.map(x => "(" + x + ")");

--- a/live-examples/js-examples/regexp/regexp-prototype-@@split.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-@@split.html
@@ -1,7 +1,8 @@
 <pre>
-<code id="static-js">class RegExp1 extends RegExp {
+<code id="static-js">
+class RegExp1 extends RegExp {
   [Symbol.split](str, limit) {
-    var result = RegExp.prototype[Symbol.split].call(this, str, limit);
+    const result = RegExp.prototype[Symbol.split].call(this, str, limit);
     return result.map(x => "(" + x + ")");
   }
 }

--- a/live-examples/js-examples/regexp/regexp-prototype-exec.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-exec.html
@@ -1,7 +1,8 @@
 <pre>
-<code id="static-js">var regex1 = RegExp('foo*','g');
-var str1 = 'table football, foosball';
-var array1;
+<code id="static-js">
+const regex1 = RegExp('foo*','g');
+const str1 = 'table football, foosball';
+let array1;
 
 while ((array1 = regex1.exec(str1)) !== null) {
   console.log(`Found ${array1[0]}. Next starts at ${regex1.lastIndex}.`);

--- a/live-examples/js-examples/regexp/regexp-prototype-exec.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-exec.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const regex1 = RegExp('foo*','g');
+<code id="static-js">const regex1 = RegExp('foo*','g');
 const str1 = 'table football, foosball';
 let array1;
 

--- a/live-examples/js-examples/regexp/regexp-prototype-global.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-global.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const regex1 = new RegExp('foo', 'g');
+<code id="static-js">const regex1 = new RegExp('foo', 'g');
 
 console.log(regex1.global);
 // expected output: true

--- a/live-examples/js-examples/regexp/regexp-prototype-global.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-global.html
@@ -1,10 +1,11 @@
 <pre>
-<code id="static-js">var regex1 = new RegExp('foo', 'g');
+<code id="static-js">
+const regex1 = new RegExp('foo', 'g');
 
 console.log(regex1.global);
 // expected output: true
 
-var regex2 = new RegExp('bar', 'i');
+const regex2 = new RegExp('bar', 'i');
 
 console.log(regex2.global);
 // expected output: false

--- a/live-examples/js-examples/regexp/regexp-prototype-ignorecase.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-ignorecase.html
@@ -1,6 +1,7 @@
 <pre>
-<code id="static-js">var regex1 = new RegExp('foo');
-var regex2 = new RegExp('foo', 'i');
+<code id="static-js">
+const regex1 = new RegExp('foo');
+const regex2 = new RegExp('foo', 'i');
 
 console.log(regex1.test('Football'));
 // expected output: false

--- a/live-examples/js-examples/regexp/regexp-prototype-ignorecase.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-ignorecase.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const regex1 = new RegExp('foo');
+<code id="static-js">const regex1 = new RegExp('foo');
 const regex2 = new RegExp('foo', 'i');
 
 console.log(regex1.test('Football'));

--- a/live-examples/js-examples/regexp/regexp-prototype-multiline.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-multiline.html
@@ -1,6 +1,7 @@
 <pre>
-<code id="static-js" data-height="taller">var regex1 = new RegExp('^football');
-var regex2 = new RegExp('^football', 'm');
+<code id="static-js" data-height="taller">
+const regex1 = new RegExp('^football');
+const regex2 = new RegExp('^football', 'm');
 
 console.log(regex1.multiline);
 // expected output: false

--- a/live-examples/js-examples/regexp/regexp-prototype-multiline.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-multiline.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js" data-height="taller">
-const regex1 = new RegExp('^football');
+<code id="static-js" data-height="taller">const regex1 = new RegExp('^football');
 const regex2 = new RegExp('^football', 'm');
 
 console.log(regex1.multiline);

--- a/live-examples/js-examples/regexp/regexp-prototype-source.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-source.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var regex1 = /fooBar/ig;
+<code id="static-js">
+const regex1 = /fooBar/ig;
 
 console.log(regex1.source);
 // expected output: "fooBar"

--- a/live-examples/js-examples/regexp/regexp-prototype-source.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-source.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const regex1 = /fooBar/ig;
+<code id="static-js">const regex1 = /fooBar/ig;
 
 console.log(regex1.source);
 // expected output: "fooBar"

--- a/live-examples/js-examples/regexp/regexp-prototype-sticky.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-sticky.html
@@ -1,6 +1,7 @@
 <pre>
-<code id="static-js">var str1 = 'table football';
-var regex1 = new RegExp('foo','y');
+<code id="static-js">
+const str1 = 'table football';
+const regex1 = new RegExp('foo','y');
 
 regex1.lastIndex = 6;
 

--- a/live-examples/js-examples/regexp/regexp-prototype-sticky.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-sticky.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const str1 = 'table football';
+<code id="static-js">const str1 = 'table football';
 const regex1 = new RegExp('foo','y');
 
 regex1.lastIndex = 6;

--- a/live-examples/js-examples/regexp/regexp-prototype-test.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-test.html
@@ -1,8 +1,9 @@
 <pre>
-<code id="static-js" data-height="taller">var str = 'table football';
+<code id="static-js" data-height="taller">
+const str = 'table football';
 
-var regex = RegExp('foo*');
-var globalRegex = RegExp('foo*','g');
+const regex = RegExp('foo*');
+const globalRegex = RegExp('foo*','g');
 
 console.log(regex.test(str));
 // expected output: true

--- a/live-examples/js-examples/regexp/regexp-prototype-test.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-test.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js" data-height="taller">
-const str = 'table football';
+<code id="static-js" data-height="taller">const str = 'table football';
 
 const regex = RegExp('foo*');
 const globalRegex = RegExp('foo*','g');

--- a/live-examples/js-examples/regexp/regexp-prototype-unicode.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-unicode.html
@@ -1,6 +1,7 @@
 <pre>
-<code id="static-js" data-height="taller">var regex1 = new RegExp('\u{61}');
-var regex2 = new RegExp('\u{61}', 'u');
+<code id="static-js" data-height="taller">
+const regex1 = new RegExp('\u{61}');
+const regex2 = new RegExp('\u{61}', 'u');
 
 console.log(regex1.unicode);
 // expected output: false

--- a/live-examples/js-examples/regexp/regexp-prototype-unicode.html
+++ b/live-examples/js-examples/regexp/regexp-prototype-unicode.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js" data-height="taller">
-const regex1 = new RegExp('\u{61}');
+<code id="static-js" data-height="taller">const regex1 = new RegExp('\u{61}');
 const regex2 = new RegExp('\u{61}', 'u');
 
 console.log(regex1.unicode);

--- a/live-examples/js-examples/set/set-prototype-size.html
+++ b/live-examples/js-examples/set/set-prototype-size.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const set1 = new Set();
+<code id="static-js">const set1 = new Set();
 const object1 = new Object();
 
 set1.add(42);

--- a/live-examples/js-examples/set/set-prototype-size.html
+++ b/live-examples/js-examples/set/set-prototype-size.html
@@ -1,6 +1,7 @@
 <pre>
-<code id="static-js">const set1 = new Set();
-var object1 = new Object();
+<code id="static-js">
+const set1 = new Set();
+const object1 = new Object();
 
 set1.add(42);
 set1.add('forty two');

--- a/live-examples/js-examples/set/set-prototype-values.html
+++ b/live-examples/js-examples/set/set-prototype-values.html
@@ -1,9 +1,10 @@
 <pre>
-<code id="static-js">const set1 = new Set();
+<code id="static-js">
+const set1 = new Set();
 set1.add(42);
 set1.add('forty two');
 
-var iterator1 = set1.values();
+let iterator1 = set1.values();
 
 console.log(iterator1.next().value);
 // expected output: 42

--- a/live-examples/js-examples/set/set-prototype-values.html
+++ b/live-examples/js-examples/set/set-prototype-values.html
@@ -3,7 +3,7 @@
 set1.add(42);
 set1.add('forty two');
 
-let iterator1 = set1.values();
+const iterator1 = set1.values();
 
 console.log(iterator1.next().value);
 // expected output: 42

--- a/live-examples/js-examples/set/set-prototype-values.html
+++ b/live-examples/js-examples/set/set-prototype-values.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const set1 = new Set();
+<code id="static-js">const set1 = new Set();
 set1.add(42);
 set1.add('forty two');
 

--- a/live-examples/js-examples/statement/statement-async.html
+++ b/live-examples/js-examples/statement/statement-async.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js" data-height="taller">
-function resolveAfter2Seconds() {
+<code id="static-js" data-height="taller">function resolveAfter2Seconds() {
   return new Promise(resolve => {
     setTimeout(() => {
       resolve('resolved');

--- a/live-examples/js-examples/statement/statement-async.html
+++ b/live-examples/js-examples/statement/statement-async.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js" data-height="taller">function resolveAfter2Seconds() {
+<code id="static-js" data-height="taller">
+function resolveAfter2Seconds() {
   return new Promise(resolve => {
     setTimeout(() => {
       resolve('resolved');
@@ -9,7 +10,7 @@
 
 async function asyncCall() {
   console.log('calling');
-  var result = await resolveAfter2Seconds();
+  const result = await resolveAfter2Seconds();
   console.log(result);
   // expected output: 'resolved'
 }

--- a/live-examples/js-examples/statement/statement-block.html
+++ b/live-examples/js-examples/statement/statement-block.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var x = 1;
+<code id="static-js">
+var x = 1;
 let y = 1;
 
 if (true) {

--- a/live-examples/js-examples/statement/statement-block.html
+++ b/live-examples/js-examples/statement/statement-block.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-var x = 1;
+<code id="static-js">var x = 1;
 let y = 1;
 
 if (true) {

--- a/live-examples/js-examples/statement/statement-break.html
+++ b/live-examples/js-examples/statement/statement-break.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var i = 0;
+<code id="static-js">
+let i = 0;
 
 while (i < 6) {
   if (i === 3) {

--- a/live-examples/js-examples/statement/statement-break.html
+++ b/live-examples/js-examples/statement/statement-break.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-let i = 0;
+<code id="static-js">let i = 0;
 
 while (i < 6) {
   if (i === 3) {

--- a/live-examples/js-examples/statement/statement-continue.html
+++ b/live-examples/js-examples/statement/statement-continue.html
@@ -1,7 +1,8 @@
 <pre>
-<code id="static-js">var text = "";
+<code id="static-js">
+let text = "";
 
-for (var i = 0; i < 10; i++) {
+for (let i = 0; i < 10; i++) {
   if (i === 3) {
     continue;
   }

--- a/live-examples/js-examples/statement/statement-continue.html
+++ b/live-examples/js-examples/statement/statement-continue.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-let text = "";
+<code id="static-js">let text = "";
 
 for (let i = 0; i < 10; i++) {
   if (i === 3) {

--- a/live-examples/js-examples/statement/statement-default.html
+++ b/live-examples/js-examples/statement/statement-default.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var expr = 'Pears';
+<code id="static-js">
+const expr = 'Pears';
 switch(expr) {
   case 'Oranges':
     console.log('Oranges are $0.59 a pound.');

--- a/live-examples/js-examples/statement/statement-default.html
+++ b/live-examples/js-examples/statement/statement-default.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const expr = 'Pears';
+<code id="static-js">const expr = 'Pears';
 switch(expr) {
   case 'Oranges':
     console.log('Oranges are $0.59 a pound.');

--- a/live-examples/js-examples/statement/statement-dowhile.html
+++ b/live-examples/js-examples/statement/statement-dowhile.html
@@ -1,6 +1,7 @@
 <pre>
-<code id="static-js">var result = "";
-var i = 0;
+<code id="static-js">
+let result = "";
+let i = 0;
 
 do {
   i = i + 1;

--- a/live-examples/js-examples/statement/statement-dowhile.html
+++ b/live-examples/js-examples/statement/statement-dowhile.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-let result = "";
+<code id="static-js">let result = "";
 let i = 0;
 
 do {

--- a/live-examples/js-examples/statement/statement-empty.html
+++ b/live-examples/js-examples/statement/statement-empty.html
@@ -1,8 +1,9 @@
 <pre>
-<code id="static-js">var array1 = [1, 2, 3];
+<code id="static-js">
+let array1 = [1, 2, 3];
 
 // Assign all array values to 0
-for (i = 0; i < array1.length; array1[i++] = 0) /* empty statement */ ;
+for (let i = 0; i < array1.length; array1[i++] = 0) /* empty statement */ ;
 
 console.log(array1);
 // expected output: Array [0, 0, 0]

--- a/live-examples/js-examples/statement/statement-empty.html
+++ b/live-examples/js-examples/statement/statement-empty.html
@@ -1,5 +1,5 @@
 <pre>
-<code id="static-js">let array1 = [1, 2, 3];
+<code id="static-js">const array1 = [1, 2, 3];
 
 // Assign all array values to 0
 for (let i = 0; i < array1.length; array1[i++] = 0) /* empty statement */ ;

--- a/live-examples/js-examples/statement/statement-empty.html
+++ b/live-examples/js-examples/statement/statement-empty.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-let array1 = [1, 2, 3];
+<code id="static-js">let array1 = [1, 2, 3];
 
 // Assign all array values to 0
 for (let i = 0; i < array1.length; array1[i++] = 0) /* empty statement */ ;

--- a/live-examples/js-examples/statement/statement-for.html
+++ b/live-examples/js-examples/statement/statement-for.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-let str = "";
+<code id="static-js">let str = "";
 
 for (let i = 0; i < 9; i++) {
   str = str + i;

--- a/live-examples/js-examples/statement/statement-for.html
+++ b/live-examples/js-examples/statement/statement-for.html
@@ -1,7 +1,8 @@
 <pre>
-<code id="static-js">var str = "";
+<code id="static-js">
+let str = "";
 
-for (var i = 0; i < 9; i++) {
+for (let i = 0; i < 9; i++) {
   str = str + i;
 }
 

--- a/live-examples/js-examples/statement/statement-functionasterisk.html
+++ b/live-examples/js-examples/statement/statement-functionasterisk.html
@@ -4,7 +4,7 @@
   yield i + 10;
 }
 
-let gen = generator(10);
+const gen = generator(10);
 
 console.log(gen.next().value);
 // expected output: 10

--- a/live-examples/js-examples/statement/statement-functionasterisk.html
+++ b/live-examples/js-examples/statement/statement-functionasterisk.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-function* generator(i) {
+<code id="static-js">function* generator(i) {
   yield i;
   yield i + 10;
 }

--- a/live-examples/js-examples/statement/statement-functionasterisk.html
+++ b/live-examples/js-examples/statement/statement-functionasterisk.html
@@ -1,10 +1,11 @@
 <pre>
-<code id="static-js">function* generator(i) {
+<code id="static-js">
+function* generator(i) {
   yield i;
   yield i + 10;
 }
 
-var gen = generator(10);
+let gen = generator(10);
 
 console.log(gen.next().value);
 // expected output: 10

--- a/live-examples/js-examples/statement/statement-label.html
+++ b/live-examples/js-examples/statement/statement-label.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-let str = "";
+<code id="static-js">let str = "";
 
 loop1:
 for (let i = 0; i < 5; i++) {

--- a/live-examples/js-examples/statement/statement-label.html
+++ b/live-examples/js-examples/statement/statement-label.html
@@ -1,8 +1,9 @@
 <pre>
-<code id="static-js">var str = "";
+<code id="static-js">
+let str = "";
 
 loop1:
-for (var i = 0; i < 5; i++) {
+for (let i = 0; i < 5; i++) {
   if (i === 1) {
     continue loop1;
   }

--- a/live-examples/js-examples/statement/statement-switch.html
+++ b/live-examples/js-examples/statement/statement-switch.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var expr = 'Papayas';
+<code id="static-js">
+const expr = 'Papayas';
 switch (expr) {
   case 'Oranges':
     console.log('Oranges are $0.59 a pound.');

--- a/live-examples/js-examples/statement/statement-switch.html
+++ b/live-examples/js-examples/statement/statement-switch.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const expr = 'Papayas';
+<code id="static-js">const expr = 'Papayas';
 switch (expr) {
   case 'Oranges':
     console.log('Oranges are $0.59 a pound.');

--- a/live-examples/js-examples/statement/statement-var.html
+++ b/live-examples/js-examples/statement/statement-var.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var x = 1;
+<code id="static-js">
+var x = 1;
 
 if (x === 1) {
   var x = 2;

--- a/live-examples/js-examples/statement/statement-var.html
+++ b/live-examples/js-examples/statement/statement-var.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-var x = 1;
+<code id="static-js">var x = 1;
 
 if (x === 1) {
   var x = 2;

--- a/live-examples/js-examples/statement/statement-while.html
+++ b/live-examples/js-examples/statement/statement-while.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-let n = 0;
+<code id="static-js">let n = 0;
 
 while (n < 3) {
   n++;

--- a/live-examples/js-examples/statement/statement-while.html
+++ b/live-examples/js-examples/statement/statement-while.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var n = 0;
+<code id="static-js">
+let n = 0;
 
 while (n < 3) {
   n++;

--- a/live-examples/js-examples/string/string-charat.html
+++ b/live-examples/js-examples/string/string-charat.html
@@ -1,7 +1,8 @@
 <pre>
-<code id="static-js">var sentence = 'The quick brown fox jumps over the lazy dog.';
+<code id="static-js">
+const sentence = 'The quick brown fox jumps over the lazy dog.';
 
-var index = 4;
+const index = 4;
 
 console.log('The character at index ' + index + ' is ' + sentence.charAt(index));
 // expected output: "The character at index 4 is q"

--- a/live-examples/js-examples/string/string-charat.html
+++ b/live-examples/js-examples/string/string-charat.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const sentence = 'The quick brown fox jumps over the lazy dog.';
+<code id="static-js">const sentence = 'The quick brown fox jumps over the lazy dog.';
 
 const index = 4;
 

--- a/live-examples/js-examples/string/string-charcodeat.html
+++ b/live-examples/js-examples/string/string-charcodeat.html
@@ -1,7 +1,8 @@
 <pre>
-<code id="static-js">var sentence = 'The quick brown fox jumps over the lazy dog.';
+<code id="static-js">
+const sentence = 'The quick brown fox jumps over the lazy dog.';
 
-var index = 4;
+const index = 4;
 
 console.log('The character code ' + sentence.charCodeAt(index) + ' is equal to ' + sentence.charAt(index));
 // expected output: "The character code 113 is equal to q"

--- a/live-examples/js-examples/string/string-charcodeat.html
+++ b/live-examples/js-examples/string/string-charcodeat.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const sentence = 'The quick brown fox jumps over the lazy dog.';
+<code id="static-js">const sentence = 'The quick brown fox jumps over the lazy dog.';
 
 const index = 4;
 

--- a/live-examples/js-examples/string/string-codepointat.html
+++ b/live-examples/js-examples/string/string-codepointat.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const icons = '☃★♲';
+<code id="static-js">const icons = '☃★♲';
 
 console.log(icons.codePointAt(1));
 // expected output: "9733"

--- a/live-examples/js-examples/string/string-codepointat.html
+++ b/live-examples/js-examples/string/string-codepointat.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var icons = '☃★♲';
+<code id="static-js">
+const icons = '☃★♲';
 
 console.log(icons.codePointAt(1));
 // expected output: "9733"

--- a/live-examples/js-examples/string/string-concat.html
+++ b/live-examples/js-examples/string/string-concat.html
@@ -1,6 +1,7 @@
 <pre>
-<code id="static-js">var str1 = 'Hello';
-var str2 = 'World';
+<code id="static-js">
+const str1 = 'Hello';
+const str2 = 'World';
 
 console.log(str1.concat(' ', str2));
 // expected output: "Hello World"

--- a/live-examples/js-examples/string/string-concat.html
+++ b/live-examples/js-examples/string/string-concat.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const str1 = 'Hello';
+<code id="static-js">const str1 = 'Hello';
 const str2 = 'World';
 
 console.log(str1.concat(' ', str2));

--- a/live-examples/js-examples/string/string-includes.html
+++ b/live-examples/js-examples/string/string-includes.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const sentence = 'The quick brown fox jumps over the lazy dog.';
+<code id="static-js">const sentence = 'The quick brown fox jumps over the lazy dog.';
 
 const word = 'fox';
 

--- a/live-examples/js-examples/string/string-includes.html
+++ b/live-examples/js-examples/string/string-includes.html
@@ -1,7 +1,8 @@
 <pre>
-<code id="static-js">var sentence = 'The quick brown fox jumps over the lazy dog.';
+<code id="static-js">
+const sentence = 'The quick brown fox jumps over the lazy dog.';
 
-var word = 'fox';
+const word = 'fox';
 
 console.log(`The word "${word}" ${sentence.includes(word)? 'is' : 'is not'} in the sentence`);
 // expected output: "The word "fox" is in the sentence"

--- a/live-examples/js-examples/string/string-indexof.html
+++ b/live-examples/js-examples/string/string-indexof.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
+<code id="static-js">const paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
 
 const searchTerm = 'dog';
 const indexOfFirst = paragraph.indexOf(searchTerm);

--- a/live-examples/js-examples/string/string-indexof.html
+++ b/live-examples/js-examples/string/string-indexof.html
@@ -1,8 +1,9 @@
 <pre>
-<code id="static-js">var paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
+<code id="static-js">
+const paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
 
-var searchTerm = 'dog';
-var indexOfFirst = paragraph.indexOf(searchTerm);
+const searchTerm = 'dog';
+const indexOfFirst = paragraph.indexOf(searchTerm);
 
 console.log('The index of the first "' + searchTerm + '" from the beginning is ' + indexOfFirst);
 // expected output: "The index of the first "dog" from the beginning is 40"

--- a/live-examples/js-examples/string/string-lastindexof.html
+++ b/live-examples/js-examples/string/string-lastindexof.html
@@ -1,7 +1,8 @@
 <pre>
-<code id="static-js">var paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
+<code id="static-js">
+const paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
 
-var searchTerm = 'dog';
+const searchTerm = 'dog';
 
 console.log('The index of the first "' + searchTerm + '" from the end is ' + paragraph.lastIndexOf(searchTerm));
 // expected output: "The index of the first "dog" from the end is 52"

--- a/live-examples/js-examples/string/string-lastindexof.html
+++ b/live-examples/js-examples/string/string-lastindexof.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
+<code id="static-js">const paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
 
 const searchTerm = 'dog';
 

--- a/live-examples/js-examples/string/string-length.html
+++ b/live-examples/js-examples/string/string-length.html
@@ -1,6 +1,7 @@
 <pre>
-<code id="static-js"  data-height="shorter">var str = 'Life, the universe and everything. Answer:';
-  
+<code id="static-js"  data-height="shorter">
+const str = 'Life, the universe and everything. Answer:';
+
 console.log(str + ' ' + str.length);
 // expected output: "Life, the universe and everything. Answer: 42"
 </code>

--- a/live-examples/js-examples/string/string-length.html
+++ b/live-examples/js-examples/string/string-length.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js"  data-height="shorter">
-const str = 'Life, the universe and everything. Answer:';
+<code id="static-js"  data-height="shorter">const str = 'Life, the universe and everything. Answer:';
 
 console.log(str + ' ' + str.length);
 // expected output: "Life, the universe and everything. Answer: 42"

--- a/live-examples/js-examples/string/string-localecompare.html
+++ b/live-examples/js-examples/string/string-localecompare.html
@@ -1,6 +1,7 @@
 <pre>
-<code id="static-js">var a = 'réservé'; // with accents, lowercase
-var b = 'RESERVE'; // no accents, uppercase
+<code id="static-js">
+const a = 'réservé'; // with accents, lowercase
+const b = 'RESERVE'; // no accents, uppercase
 
 console.log(a.localeCompare(b));
 // expected output: 1

--- a/live-examples/js-examples/string/string-localecompare.html
+++ b/live-examples/js-examples/string/string-localecompare.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const a = 'réservé'; // with accents, lowercase
+<code id="static-js">const a = 'réservé'; // with accents, lowercase
 const b = 'RESERVE'; // no accents, uppercase
 
 console.log(a.localeCompare(b));

--- a/live-examples/js-examples/string/string-match.html
+++ b/live-examples/js-examples/string/string-match.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const paragraph = 'The quick brown fox jumps over the lazy dog. It barked.';
+<code id="static-js">const paragraph = 'The quick brown fox jumps over the lazy dog. It barked.';
 const regex = /[A-Z]/g;
 const found = paragraph.match(regex);
 

--- a/live-examples/js-examples/string/string-match.html
+++ b/live-examples/js-examples/string/string-match.html
@@ -1,7 +1,8 @@
 <pre>
-<code id="static-js">var paragraph = 'The quick brown fox jumps over the lazy dog. It barked.';
-var regex = /[A-Z]/g;
-var found = paragraph.match(regex);
+<code id="static-js">
+const paragraph = 'The quick brown fox jumps over the lazy dog. It barked.';
+const regex = /[A-Z]/g;
+const found = paragraph.match(regex);
 
 console.log(found);
 // expected output: Array ["T", "I"]</code>

--- a/live-examples/js-examples/string/string-normalize.html
+++ b/live-examples/js-examples/string/string-normalize.html
@@ -1,6 +1,7 @@
 <pre>
-<code id="static-js">var first = '\u212B';         // "Å"
-var second = '\u0041\u030A';  // "Å"
+<code id="static-js">
+const first = '\u212B';         // "Å"
+const second = '\u0041\u030A';  // "Å"
 
 console.log(first + ' and ' + second + ' are' +
    ((first === second)? '': ' not') + ' the same.');
@@ -10,8 +11,8 @@ console.log(first + ' and ' + second + ' can' +
    ((first.normalize('NFC') === second.normalize('NFC'))? '': ' not') + ' be normalized');
    // expected output: "Å and Å can be normalized"
 
-var oldWord = 'mañana';
-var newWord = oldWord.normalize('NFD');
+const oldWord = 'mañana';
+const newWord = oldWord.normalize('NFD');
 console.log('The word did ' + ((oldWord != newWord)? '' : 'not ') + 'change.');
 // expected output: "The word did change."</code>
 </pre>

--- a/live-examples/js-examples/string/string-normalize.html
+++ b/live-examples/js-examples/string/string-normalize.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const first = '\u212B';         // "Å"
+<code id="static-js">const first = '\u212B';         // "Å"
 const second = '\u0041\u030A';  // "Å"
 
 console.log(first + ' and ' + second + ' are' +

--- a/live-examples/js-examples/string/string-repeat.html
+++ b/live-examples/js-examples/string/string-repeat.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var chorus = 'Because I\'m happy. ';
+<code id="static-js">
+const chorus = 'Because I\'m happy. ';
 
 console.log('Chorus lyrics for "Happy": ' + chorus.repeat(27));
 

--- a/live-examples/js-examples/string/string-repeat.html
+++ b/live-examples/js-examples/string/string-repeat.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const chorus = 'Because I\'m happy. ';
+<code id="static-js">const chorus = 'Because I\'m happy. ';
 
 console.log('Chorus lyrics for "Happy": ' + chorus.repeat(27));
 

--- a/live-examples/js-examples/string/string-replace.html
+++ b/live-examples/js-examples/string/string-replace.html
@@ -1,8 +1,8 @@
 <pre>
 <code id="static-js">
-var p = 'The quick brown fox jumps over the lazy dog. If the dog reacted, was it really lazy?';
+const p = 'The quick brown fox jumps over the lazy dog. If the dog reacted, was it really lazy?';
 
-var regex = /dog/gi;
+const regex = /dog/gi;
 
 console.log(p.replace(regex, 'ferret'));
 // expected output: "The quick brown fox jumps over the lazy ferret. If the ferret reacted, was it really lazy?"

--- a/live-examples/js-examples/string/string-replace.html
+++ b/live-examples/js-examples/string/string-replace.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const p = 'The quick brown fox jumps over the lazy dog. If the dog reacted, was it really lazy?';
+<code id="static-js">const p = 'The quick brown fox jumps over the lazy dog. If the dog reacted, was it really lazy?';
 
 const regex = /dog/gi;
 

--- a/live-examples/js-examples/string/string-search.html
+++ b/live-examples/js-examples/string/string-search.html
@@ -1,8 +1,9 @@
 <pre>
-<code id="static-js">var paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
+<code id="static-js">
+const paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
 
 // any character that is not a word character or whitespace
-var regex = /[^\w\s]/g;
+const regex = /[^\w\s]/g;
 
 console.log(paragraph.search(regex));
 // expected output: 43

--- a/live-examples/js-examples/string/string-search.html
+++ b/live-examples/js-examples/string/string-search.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
+<code id="static-js">const paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
 
 // any character that is not a word character or whitespace
 const regex = /[^\w\s]/g;

--- a/live-examples/js-examples/string/string-slice.html
+++ b/live-examples/js-examples/string/string-slice.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var str = 'The quick brown fox jumps over the lazy dog.';
+<code id="static-js">
+const str = 'The quick brown fox jumps over the lazy dog.';
 
 console.log(str.slice(31));
 // expected output: "the lazy dog."

--- a/live-examples/js-examples/string/string-slice.html
+++ b/live-examples/js-examples/string/string-slice.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const str = 'The quick brown fox jumps over the lazy dog.';
+<code id="static-js">const str = 'The quick brown fox jumps over the lazy dog.';
 
 console.log(str.slice(31));
 // expected output: "the lazy dog."

--- a/live-examples/js-examples/string/string-split.html
+++ b/live-examples/js-examples/string/string-split.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const str = 'The quick brown fox jumps over the lazy dog.';
+<code id="static-js">const str = 'The quick brown fox jumps over the lazy dog.';
 
 const words = str.split(' ');
 console.log(words[3]);

--- a/live-examples/js-examples/string/string-split.html
+++ b/live-examples/js-examples/string/string-split.html
@@ -1,15 +1,16 @@
 <pre>
-<code id="static-js">var str = 'The quick brown fox jumps over the lazy dog.';
+<code id="static-js">
+const str = 'The quick brown fox jumps over the lazy dog.';
 
-var words = str.split(' ');
+const words = str.split(' ');
 console.log(words[3]);
 // expected output: "fox"
 
-var chars = str.split('');
+const chars = str.split('');
 console.log(chars[8]);
 // expected output: "k"
 
-var strCopy = str.split();
+const strCopy = str.split();
 console.log(strCopy);
 // expected output: Array ["The quick brown fox jumps over the lazy dog."]
 </code>

--- a/live-examples/js-examples/string/string-substr.html
+++ b/live-examples/js-examples/string/string-substr.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var str = 'Mozilla';
+<code id="static-js">
+const str = 'Mozilla';
 
 console.log(str.substr(1, 2));
 // expected output: "oz"

--- a/live-examples/js-examples/string/string-substr.html
+++ b/live-examples/js-examples/string/string-substr.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const str = 'Mozilla';
+<code id="static-js">const str = 'Mozilla';
 
 console.log(str.substr(1, 2));
 // expected output: "oz"

--- a/live-examples/js-examples/string/string-substring.html
+++ b/live-examples/js-examples/string/string-substring.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const str = 'Mozilla';
+<code id="static-js">const str = 'Mozilla';
 
 console.log(str.substring(1, 3));
 // expected output: "oz"

--- a/live-examples/js-examples/string/string-substring.html
+++ b/live-examples/js-examples/string/string-substring.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var str = 'Mozilla';
+<code id="static-js">
+const str = 'Mozilla';
 
 console.log(str.substring(1, 3));
 // expected output: "oz"

--- a/live-examples/js-examples/string/string-tolocalelowercase.html
+++ b/live-examples/js-examples/string/string-tolocalelowercase.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var dotted = 'İstanbul';
+<code id="static-js">
+const dotted = 'İstanbul';
 
 console.log('EN-US: ' + dotted.toLocaleLowerCase('en-US'));
 // expected output: "i̇stanbul"

--- a/live-examples/js-examples/string/string-tolocalelowercase.html
+++ b/live-examples/js-examples/string/string-tolocalelowercase.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const dotted = 'İstanbul';
+<code id="static-js">const dotted = 'İstanbul';
 
 console.log('EN-US: ' + dotted.toLocaleLowerCase('en-US'));
 // expected output: "i̇stanbul"

--- a/live-examples/js-examples/string/string-tolocaleuppercase.html
+++ b/live-examples/js-examples/string/string-tolocaleuppercase.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var city = 'istanbul';
+<code id="static-js">
+const city = 'istanbul';
 
 console.log(city.toLocaleUpperCase('en-US'));
 // expected output: "ISTANBUL"

--- a/live-examples/js-examples/string/string-tolocaleuppercase.html
+++ b/live-examples/js-examples/string/string-tolocaleuppercase.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const city = 'istanbul';
+<code id="static-js">const city = 'istanbul';
 
 console.log(city.toLocaleUpperCase('en-US'));
 // expected output: "ISTANBUL"

--- a/live-examples/js-examples/string/string-tolowercase.html
+++ b/live-examples/js-examples/string/string-tolowercase.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const sentence = 'The quick brown fox jumps over the lazy dog.';
+<code id="static-js">const sentence = 'The quick brown fox jumps over the lazy dog.';
 
 console.log(sentence.toLowerCase());
 // expected output: "the quick brown fox jumps over the lazy dog."

--- a/live-examples/js-examples/string/string-tolowercase.html
+++ b/live-examples/js-examples/string/string-tolowercase.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var sentence = 'The quick brown fox jumps over the lazy dog.';
+<code id="static-js">
+const sentence = 'The quick brown fox jumps over the lazy dog.';
 
 console.log(sentence.toLowerCase());
 // expected output: "the quick brown fox jumps over the lazy dog."

--- a/live-examples/js-examples/string/string-tostring.html
+++ b/live-examples/js-examples/string/string-tostring.html
@@ -1,6 +1,7 @@
 
 <pre>
-<code id="static-js">var stringObj = new String("foo");
+<code id="static-js">
+const stringObj = new String("foo");
 
 console.log(stringObj);
 // expected output: String { "foo" }

--- a/live-examples/js-examples/string/string-tostring.html
+++ b/live-examples/js-examples/string/string-tostring.html
@@ -1,7 +1,5 @@
-
 <pre>
-<code id="static-js">
-const stringObj = new String("foo");
+<code id="static-js">const stringObj = new String("foo");
 
 console.log(stringObj);
 // expected output: String { "foo" }

--- a/live-examples/js-examples/string/string-touppercase.html
+++ b/live-examples/js-examples/string/string-touppercase.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var sentence = 'The quick brown fox jumps over the lazy dog.';
+<code id="static-js">
+const sentence = 'The quick brown fox jumps over the lazy dog.';
 
 console.log(sentence.toUpperCase());
 // expected output: "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG."

--- a/live-examples/js-examples/string/string-touppercase.html
+++ b/live-examples/js-examples/string/string-touppercase.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const sentence = 'The quick brown fox jumps over the lazy dog.';
+<code id="static-js">const sentence = 'The quick brown fox jumps over the lazy dog.';
 
 console.log(sentence.toUpperCase());
 // expected output: "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG."

--- a/live-examples/js-examples/string/string-trim.html
+++ b/live-examples/js-examples/string/string-trim.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const greeting = '   Hello world!   ';
+<code id="static-js">const greeting = '   Hello world!   ';
 
 console.log(greeting);
 // expected output: "   Hello world!   ";

--- a/live-examples/js-examples/string/string-trim.html
+++ b/live-examples/js-examples/string/string-trim.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var greeting = '   Hello world!   ';
+<code id="static-js">
+const greeting = '   Hello world!   ';
 
 console.log(greeting);
 // expected output: "   Hello world!   ";

--- a/live-examples/js-examples/string/string-trimend.html
+++ b/live-examples/js-examples/string/string-trimend.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const greeting = '   Hello world!   ';
+<code id="static-js">const greeting = '   Hello world!   ';
 
 console.log(greeting);
 // expected output: "   Hello world!   ";

--- a/live-examples/js-examples/string/string-trimend.html
+++ b/live-examples/js-examples/string/string-trimend.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var greeting = '   Hello world!   ';
+<code id="static-js">
+const greeting = '   Hello world!   ';
 
 console.log(greeting);
 // expected output: "   Hello world!   ";

--- a/live-examples/js-examples/string/string-trimstart.html
+++ b/live-examples/js-examples/string/string-trimstart.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const greeting = '   Hello world!   ';
+<code id="static-js">const greeting = '   Hello world!   ';
 
 console.log(greeting);
 // expected output: "   Hello world!   ";

--- a/live-examples/js-examples/string/string-trimstart.html
+++ b/live-examples/js-examples/string/string-trimstart.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var greeting = '   Hello world!   ';
+<code id="static-js">
+const greeting = '   Hello world!   ';
 
 console.log(greeting);
 // expected output: "   Hello world!   ";

--- a/live-examples/js-examples/string/string-valueof.html
+++ b/live-examples/js-examples/string/string-valueof.html
@@ -1,5 +1,6 @@
 <pre>
-<code id="static-js">var stringObj = new String("foo");
+<code id="static-js">
+const stringObj = new String("foo");
 
 console.log(stringObj);
 // expected output: String { "foo" }

--- a/live-examples/js-examples/string/string-valueof.html
+++ b/live-examples/js-examples/string/string-valueof.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-const stringObj = new String("foo");
+<code id="static-js">const stringObj = new String("foo");
 
 console.log(stringObj);
 // expected output: String { "foo" }

--- a/live-examples/js-examples/symbol/symbol-prototype.html
+++ b/live-examples/js-examples/symbol/symbol-prototype.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-Symbol.prototype.toString = function() {
+<code id="static-js">Symbol.prototype.toString = function() {
   return ('SYMBOL');
 }
 

--- a/live-examples/js-examples/symbol/symbol-prototype.html
+++ b/live-examples/js-examples/symbol/symbol-prototype.html
@@ -1,9 +1,10 @@
 <pre>
-<code id="static-js">Symbol.prototype.toString = function() {
+<code id="static-js">
+Symbol.prototype.toString = function() {
   return ('SYMBOL');
 }
 
-var symbol1 = Symbol('foo');
+const symbol1 = Symbol('foo');
 
 console.log(symbol1.toString());
 // expected output: "SYMBOL"

--- a/live-examples/js-examples/symbol/symbol-split.html
+++ b/live-examples/js-examples/symbol/symbol-split.html
@@ -4,7 +4,7 @@
     this.value = value;
   }
   [Symbol.split](string) {
-    let index = string.indexOf(this.value);
+    const index = string.indexOf(this.value);
     return this.value + string.substr(0, index) + "/"
       + string.substr(index + this.value.length);
   }

--- a/live-examples/js-examples/symbol/symbol-split.html
+++ b/live-examples/js-examples/symbol/symbol-split.html
@@ -1,6 +1,5 @@
 <pre>
-<code id="static-js">
-class Split1 {
+<code id="static-js">class Split1 {
   constructor(value) {
     this.value = value;
   }

--- a/live-examples/js-examples/symbol/symbol-split.html
+++ b/live-examples/js-examples/symbol/symbol-split.html
@@ -1,10 +1,11 @@
 <pre>
-<code id="static-js">class Split1 {
+<code id="static-js">
+class Split1 {
   constructor(value) {
     this.value = value;
   }
   [Symbol.split](string) {
-    var index = string.indexOf(this.value);
+    let index = string.indexOf(this.value);
     return this.value + string.substr(0, index) + "/"
       + string.substr(index + this.value.length);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5291,7 +5291,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "^1.0.0"
+                "builtin-modules": "1.1.1"
             }
         },
         "is-callable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5291,7 +5291,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-callable": {


### PR DESCRIPTION
Didn’t touch examples for the `var` keyword itself, or in examples demonstrating special scope rules.