### PR TITLE
Make volume range controller accessible with label

### DIFF
--- a/live-examples/html-examples/input/range.html
+++ b/live-examples/html-examples/input/range.html
@@ -1,7 +1,7 @@
 <p>Audio settings:</p>
 
 <div>
-  <input type="range" id="start" name="volume"
+  <input type="range" id="volume" name="volume"
          min="0" max="11">
   <label for="volume">Volume</label>
 </div>


### PR DESCRIPTION
In the first example on https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range the label is not linked to the input, so clicking on it wont transfer the focus to the range slider.