### PR TITLE
Update contribution docs now we supply JS examples in .js files

### DIFF
--- a/CONTRIBUTING-JavaScript.md
+++ b/CONTRIBUTING-JavaScript.md
@@ -2,53 +2,26 @@
 
 ## Writing the example
 
-With a JavaScript example you start by creating a new `.html` file in a subfolder of `live-examples/js-examples`. In this example we are going to contribute an example demonstrating the use of `Array.from` so, we'll create a new file called `array-from.html`. Since it is part of the `Array` object, we're going to put it inside the "array" subfolder.
+With a JavaScript example you start by creating a new `.js` file in a subfolder of `live-examples/js-examples`. In this example we are going to contribute an example demonstrating the use of `Array.from`, so we'll create a new file called `array-from.js`. Since it is part of the `Array` object, we're going to put it inside the "array" subfolder.
 
-Next, you need to paste the following code into this new file (this will be the same for all JavaScript examples you add):
+Inside this file we'll write the example code:
 
-```
-<pre>
-<code id="static-js" class="language-js">
-</code>
-</pre>
-```
+```js
+const result = Array.from('foo');
 
-Inside the `code` block is where our example code will go. Change the code to read as follows:
-
-```
-<pre>
-<code id="static-js">// call from(), passing a string
-let result = Array.from('foo');
-
-// log the result
 console.log(result);
-</code>
-</pre>
+// expected output: Array [ "f", "o", "o" ]
 ```
 
 Please make sure the example conforms to the [JS Example Style Guide](JS-Example-Style-Guide.md).
 
-> NOTE: Should your example [exceed the ideal of 12 lines of code](JS-Example-Style-Guide.md#example-size),
-> you should set the following `data` attribute on the `code` element. This will ensure the editor height
-> is taller, allowing you up to 23 total lines of example code.
-
-```
-<pre>
-<code id="static-js" data-height="taller">// call from(), passing a string
-...
-```
-
 ## Updating the metadata
 
-All that remains is to tell the page generator about our new example. To do this, open up `meta.json` in the current folder (i.e. at "./live-examples/js-examples/array/meta.json").
-
-Under `pages`, copy and paste the example then update it to your new example, noting that pages are sorted alphabetically.
-
-You entry will look something like the following when edited:
+All that remains is to tell the page generator about our new example. To do this, open up `meta.json` in the current folder (i.e. at "./live-examples/js-examples/array/meta.json"). This file contains a single JSON object `pages`, with one property for each example. Add a property for the new example, keeping the properties of `pages` in alphabetical order:
 
 ```
 "arrayFrom": {
-    "exampleCode": "./live-examples/js-examples/array/array-from.html",
+    "exampleCode": "./live-examples/js-examples/array/array-from.js",
     "fileName": "array-from.html",
     "title": "JavaScript Demo: Array.from()",
     "type": "js"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,28 @@ After your pull request is reviewed and merged, you can publish your example on 
 
 where `TYPE` is the kind of example (such as `js`, `css`, or `tabbed`) and `FILENAME` is the name of the file that contains the example (like `margin.html` or `date-constructor.html`).
 
+### Short or tall examples
+
+For HTML and JS examples, there are three different possible heights for the editor: short, standard, and tall. If your example is short or tall you need to pass an extra parameter to `EmbedInteractiveExample`, like this:
+
+```
+{{EmbedInteractiveExample("pages/js/reflect-deleteproperty.html", "taller")}}
+```
+
+or
+
+```
+{{EmbedInteractiveExample("pages/js/string-length.html", "shorter")}}
+```
+
+How do you know if your example is short or tall?
+
+* for HTML examples, this is a thing you set explicitly, by supplying a CSS class in the example source. See [Changing the editor height](CONTRIBUTING-HTML.md#changing-the-editor-height).
+* for JS examples, short or tall editors are selected automatically for you:
+    * Examples less than 7 lines long get the short editor, so you should provide the `"shorter"` argument to `EmbedInteractiveExample`
+    * Examples 7-12 lines inclusive get the standard editor, so you should not provide any extra argument to `EmbedInteractiveExample`
+    * Examples 13 or more lines long get the tall editor, so you should provide the `"taller"` argument to `EmbedInteractiveExample`
+
 ## Thank you!
 
 Thank you for your contribution ~ o/\o


### PR DESCRIPTION
This PR updates our contribution docs now we:

* provide JS examples in .js files, rather than .html files
* calculate the JS editor height automatically

@ikarasz , please let me know if this looks good to you.