### PR TITLE
Add live example for Array iterator

### DIFF
--- a/live-examples/js-examples/array/array-iterator.js
+++ b/live-examples/js-examples/array/array-iterator.js
@@ -1,0 +1,10 @@
+const array1 = ['a', 'b', 'c'];
+const iterator1 = array1[Symbol.iterator]();
+
+for (const value of iterator1) {
+  console.log(value);
+}
+
+// expected output: "a"
+// expected output: "b"
+// expected output: "c"

--- a/live-examples/js-examples/array/meta.json
+++ b/live-examples/js-examples/array/meta.json
@@ -72,6 +72,12 @@
             "title": "JavaScript Demo: Array.indexOf()",
             "type": "js"
         },
+        "arrayIterator": {
+            "exampleCode": "./live-examples/js-examples/array/array-iterator.js",
+            "fileName": "array-iterator.html",
+            "title": "JavaScript Demo: Array.prototype[@@iterator]()",
+            "type": "js"
+        },
         "arrayJoin": {
             "exampleCode": "./live-examples/js-examples/array/array-join.js",
             "fileName": "array-join.html",


### PR DESCRIPTION
Simple PR for adding a live sample for the `Array[Symbol.iterator]` method, based on the example given on [Array.values](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/values) method.