### PR TITLE
Update globalprops-encodeuricomponent.js

### DIFF
--- a/live-examples/js-examples/globalprops/globalprops-encodeuricomponent.js
+++ b/live-examples/js-examples/globalprops/globalprops-encodeuricomponent.js
@@ -1,6 +1,6 @@
 // encodes characters such as ?,=,/,&,:
-console.log(encodeURIComponent('?x=шеллы'));
-// expected output: "%3Fx%3D%D1%88%D0%B5%D0%BB%D0%BB%D1%8B"
+console.log('?x='+encodeURIComponent('test?'));
+// expected output: "?x=test%3F"
 
-console.log(encodeURIComponent('?x=test'));
-// expected output: "%3Fx%3Dtest"
+console.log('?x='+encodeURIComponent('шеллы'));
+// expected output: "?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B"

--- a/live-examples/js-examples/globalprops/globalprops-encodeuricomponent.js
+++ b/live-examples/js-examples/globalprops/globalprops-encodeuricomponent.js
@@ -1,6 +1,6 @@
 // encodes characters such as ?,=,/,&,:
-console.log('?x='+encodeURIComponent('test?'));
+console.log(`?x=${encodeURIComponent('test?')}`);
 // expected output: "?x=test%3F"
 
-console.log('?x='+encodeURIComponent('шеллы'));
+console.log(`?x=${encodeURIComponent('шеллы')}`);
 // expected output: "?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B"


### PR DESCRIPTION
Do not escape the url parts required for parameters to parse correctly if appended to an url.

This makes the provided example be closer to what users typically would want to do.