### PR TITLE
Add lint-fix command

### DIFF
--- a/JS-Example-Style-Guide.md
+++ b/JS-Example-Style-Guide.md
@@ -149,7 +149,7 @@ npm run lint:js
 We've also provided the following command:
 
 ```sh
-npm run lint-fix:js
+npm run lint:js:fix
 ```
 
 This runs ESLint with the `--fix` option, which tries to fix issues.

--- a/JS-Example-Style-Guide.md
+++ b/JS-Example-Style-Guide.md
@@ -146,6 +146,14 @@ You can validate your example anytime by running the following npm script:
 npm run lint:js
 ```
 
+We've also provided the following command:
+
+```sh
+npm run lint-fix:js
+```
+
+This runs ESLint with the `--fix` option, which tries to fix issues.
+
 In the rest of this section we'll describe additional conventions, not enforced using ESLint but instead using code review.
 
 ### Language choice (ES6)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
         "start-server": "http-server -p 9090 ./docs",
         "start-watch": "chokidar '**/{*.js,*.css,*.html,*.json}' -i 'package.json' -i 'docs/**' -i 'node_modules/**' -i 'js/editor-*.js' -c 'npm run build' --initial --silent",
         "start": "npm-run-all --parallel start-watch start-server",
-        "lint:js": "eslint ./live-examples/js-examples"
+        "lint:js": "eslint ./live-examples/js-examples",
+        "lint-fix:js": "eslint --fix ./live-examples/js-examples"
     },
     "keywords": [
         "javascript",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "start-watch": "chokidar '**/{*.js,*.css,*.html,*.json}' -i 'package.json' -i 'docs/**' -i 'node_modules/**' -i 'js/editor-*.js' -c 'npm run build' --initial --silent",
         "start": "npm-run-all --parallel start-watch start-server",
         "lint:js": "eslint ./live-examples/js-examples",
-        "lint-fix:js": "eslint --fix ./live-examples/js-examples"
+        "lint:js:fix": "eslint --fix ./live-examples/js-examples"
     },
     "keywords": [
         "javascript",


### PR DESCRIPTION
I thought it would be helpful to expose ESLint's `--fix` option, so contributors can easily fix up code with lint errors.