### PR TITLE
Add 'new' for constructor and remove repeated line

### DIFF
--- a/live-examples/js-examples/regexp/regexp-prototype-test.js
+++ b/live-examples/js-examples/regexp/regexp-prototype-test.js
@@ -1,10 +1,7 @@
 const str = 'table football';
 
-const regex = RegExp('foo*');
-const globalRegex = RegExp('foo*', 'g');
-
-console.log(regex.test(str));
-// expected output: true
+const regex = new RegExp('foo*');
+const globalRegex = new RegExp('foo*', 'g');
 
 console.log(regex.test(str));
 // expected output: true


### PR DESCRIPTION
I'm still baffled that it worked with `const regex = Regex(...)` without the `new`.