### PR TITLE
Add example for String replaceAll

### DIFF
--- a/live-examples/js-examples/string/meta.json
+++ b/live-examples/js-examples/string/meta.json
@@ -127,6 +127,12 @@
             "title": "JavaScript Demo: String.replace()",
             "type": "js"
         },
+        "stringReplaceAll": {
+            "exampleCode": "./live-examples/js-examples/string/string-replaceall.js",
+            "fileName": "string-replaceall.html",
+            "title": "JavaScript Demo: String.replaceAll()",
+            "type": "js"
+        },
         "stringSearch": {
             "exampleCode": "./live-examples/js-examples/string/string-search.js",
             "fileName": "string-search.html",

--- a/live-examples/js-examples/string/string-replaceall.js
+++ b/live-examples/js-examples/string/string-replaceall.js
@@ -1,0 +1,9 @@
+const p = 'The quick brown fox jumps over the lazy dog. If the dog reacted, was it really lazy?';
+
+const regex = /dog/gi;
+
+console.log(p.replaceAll(regex, 'ferret'));
+// expected output: "The quick brown fox jumps over the lazy ferret. If the ferret reacted, was it really lazy?"
+
+console.log(p.replaceAll('dog', 'monkey'));
+// expected output: "The quick brown fox jumps over the lazy monkey. If the monkey reacted, was it really lazy?"


### PR DESCRIPTION
For https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll

Basically a copy of https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace which is a bit lame, but I guess it makes sense to also show this with string argument and with a regex argument.

Happy to hear better proposals