### PR TITLE
Update expression yield live example for clarity.

### DIFF
--- a/live-examples/js-examples/expressions/expressions-yield.js
+++ b/live-examples/js-examples/expressions/expressions-yield.js
@@ -1,6 +1,7 @@
 function* foo(index) {
   while (index < 2) {
-    yield index++;
+    yield index;
+    index++;
   }
 }
 


### PR DESCRIPTION
Docs are most effective when few ideas are required to comprehend the definition.

It's easier to understand what a keyword does when it is isolated.  Let's move the "++" to a different expression. It's not fundamental to the definition of yield. 

We want to be clear that we yield the value and then increment. In general, the distinction between ++var and var++ can be difficult for early developers. We should minimize the "confusion surface area" (borrowing a term from security) and just be explicit.  This makes it easier for any reader to understand what yield means.

aka
"Don't use big words in your dictionary definitions"