### PR TITLE
Update expressions-conditionaloperators.js

### DIFF
--- a/live-examples/js-examples/expressions/expressions-conditionaloperators.js
+++ b/live-examples/js-examples/expressions/expressions-conditionaloperators.js
@@ -10,3 +10,9 @@ console.log(getFee(false));
 
 console.log(getFee(1));
 // expected output: "$2.00"
+
+console.log(getFee(0));
+// expected output: "$10.00"
+
+console.log(getFee(null));
+// expected output: "$10.00"

--- a/live-examples/js-examples/expressions/expressions-conditionaloperators.js
+++ b/live-examples/js-examples/expressions/expressions-conditionaloperators.js
@@ -8,11 +8,5 @@ console.log(getFee(true));
 console.log(getFee(false));
 // expected output: "$10.00"
 
-console.log(getFee(1));
-// expected output: "$2.00"
-
-console.log(getFee(0));
-// expected output: "$10.00"
-
 console.log(getFee(null));
 // expected output: "$10.00"


### PR DESCRIPTION
Add an example for the common case of null and 0 being used as falsy.