### PR TITLE
Add prefer-const to ESLint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
         'object-curly-spacing': ['error', 'always'],
         'one-var-declaration-per-line': ['error', 'always'],
         'prefer-arrow-callback': 'error',
+        'prefer-const': 'error',
         'prefer-template': 'error',
         'quotes': ['error', 'single'],
         'semi': ['error', 'always'],
@@ -83,6 +84,7 @@ module.exports = {
             files: ['**/expressions/expressions-destructuringassignment.js'],
             rules: {
                 'one-var-declaration-per-line': 'off',
+                'prefer-const': 'off',
             },
         },
         {
@@ -236,6 +238,7 @@ module.exports = {
                 'no-redeclare': 'off',
                 'no-unused-vars': 'off',
                 'no-var': 'off',
+                'prefer-const': 'off',
             },
         },
         {
@@ -248,6 +251,12 @@ module.exports = {
             files: ['**/statement/statement-empty.js'],
             rules: {
                 'curly': 'off',
+            },
+        },
+        {
+            files: ['**/statement/statement-let.js'],
+            rules: {
+                'prefer-const': 'off',
             },
         },
         {

--- a/live-examples/js-examples/map/map-prototype-@@iterator.js
+++ b/live-examples/js-examples/map/map-prototype-@@iterator.js
@@ -5,7 +5,7 @@ map1.set(1, 'bar');
 
 const iterator1 = map1[Symbol.iterator]();
 
-for (let item of iterator1) {
+for (const item of iterator1) {
   console.log(item);
 }
 // expected output: Array ["0", "foo"]

--- a/live-examples/js-examples/proxyhandler/proxyhandler-ownkeys.js
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-ownkeys.js
@@ -12,7 +12,7 @@ const handler1 = {
 
 const proxy1 = new Proxy(monster1, handler1);
 
-for (let key of Object.keys(proxy1)) {
+for (const key of Object.keys(proxy1)) {
   console.log(key);
   // expected output: "_age"
   // expected output: "eyeCount"

--- a/live-examples/js-examples/regexp/regexp-prototype-@@matchall.js
+++ b/live-examples/js-examples/regexp/regexp-prototype-@@matchall.js
@@ -1,6 +1,6 @@
 class MyRegExp extends RegExp {
   [Symbol.matchAll](str) {
-    let result = RegExp.prototype[Symbol.matchAll].call(this, str);
+    const result = RegExp.prototype[Symbol.matchAll].call(this, str);
     if (!result) {
       return null;
     }
@@ -8,6 +8,6 @@ class MyRegExp extends RegExp {
   }
 }
 
-let re = new MyRegExp('-[0-9]+', 'g');
+const re = new MyRegExp('-[0-9]+', 'g');
 console.log('2016-01-02|2019-03-07'.matchAll(re));
 // expected output: Array [Array ["-01"], Array ["-02"], Array ["-03"], Array ["-07"]]

--- a/live-examples/js-examples/set/set-prototype-add.js
+++ b/live-examples/js-examples/set/set-prototype-add.js
@@ -4,7 +4,7 @@ set1.add(42);
 set1.add(42);
 set1.add(13);
 
-for (let item of set1) {
+for (const item of set1) {
   console.log(item);
   // expected output: 42
   // expected output: 13

--- a/live-examples/js-examples/set/set-prototype-entries.js
+++ b/live-examples/js-examples/set/set-prototype-entries.js
@@ -4,7 +4,7 @@ set1.add('forty two');
 
 const iterator1 = set1.entries();
 
-for (let entry of iterator1) {
+for (const entry of iterator1) {
   console.log(entry);
   // expected output: [42, 42]
   // expected output: ["forty two", "forty two"]

--- a/live-examples/js-examples/string/string-iterator.js
+++ b/live-examples/js-examples/string/string-iterator.js
@@ -1,6 +1,6 @@
 const str = 'The quick red fox jumped over the lazy dog\'s back.';
 
-let iterator = str[Symbol.iterator]();
+const iterator = str[Symbol.iterator]();
 let theChar = iterator.next();
 
 while (!theChar.done && theChar.value !== ' ') {

--- a/live-examples/js-examples/string/string-matchall.js
+++ b/live-examples/js-examples/string/string-matchall.js
@@ -1,7 +1,7 @@
-let regexp = /t(e)(st(\d?))/g;
-let str = 'test1test2';
+const regexp = /t(e)(st(\d?))/g;
+const str = 'test1test2';
 
-let array = [...str.matchAll(regexp)];
+const array = [...str.matchAll(regexp)];
 
 console.log(array[0]);
 // expected output: Array ["test1", "e", "st1", "1"]

--- a/live-examples/js-examples/symbol/symbol-matchall.js
+++ b/live-examples/js-examples/symbol/symbol-matchall.js
@@ -1,6 +1,6 @@
-let re = /[0-9]+/g;
-let str = '2016-01-02|2019-03-07';
-let result = re[Symbol.matchAll](str);
+const re = /[0-9]+/g;
+const str = '2016-01-02|2019-03-07';
+const result = re[Symbol.matchAll](str);
 
 console.log(Array.from(result, x => x[0]));
 // expected output: Array ["2016", "01", "02", "2019", "03", "07"]


### PR DESCRIPTION
In reviewing https://github.com/mdn/interactive-examples/pull/1621 I complained about some `let` declarations that could (and therefore should) be `const`: since ESLint can enforce this for us I thought it would be worth doing.

This PR adds [`prefer-const`](https://eslint.org/docs/rules/prefer-const) to our default config, and various automatic fixes that look reasonable.

I've also relaxed `prefer-const` for three examples:
* https://github.com/mdn/interactive-examples/blob/master/live-examples/js-examples/statement/statement-block.js, where using `let` seems more plausible
* https://github.com/mdn/interactive-examples/blob/master/live-examples/js-examples/statement/statement-let.js, where using `let` is obviously needed
* https://github.com/mdn/interactive-examples/blob/master/live-examples/js-examples/expressions/expressions-destructuringassignment.js, which is just weird: if I don't relax `prefer-const` then it complains that `rest` could be `const`, but if I make that change then I get "Error: invalid assignment to const 'rest'". I'd be happy if someone had a better solution here :(.

@ikarasz , I'd be happy to get your feedback in addition to Florian's review :).