### PR TITLE
Add alt attribute on <picture> example

### DIFF
--- a/live-examples/html-examples/embedded-content/picture.html
+++ b/live-examples/html-examples/embedded-content/picture.html
@@ -3,5 +3,5 @@
 <picture>
     <source srcset="/media/examples/surfer-240-200.jpg"
             media="(min-width: 800px)">
-    <img src="/media/examples/painted-hand-298-332.jpg" />
+    <img src="/media/examples/painted-hand-298-332.jpg" alt="" />
 </picture>


### PR DESCRIPTION
The alt attribute is required in HTML and must always be included for accessibility. Since we’re switching between two complete different images here, and it's just a demo, we can keep the alt attribute empty.