### PR TITLE
Improve font-optical-sizing example

### DIFF
--- a/live-examples/css-examples/fonts/font-optical-sizing.css
+++ b/live-examples/css-examples/fonts/font-optical-sizing.css
@@ -1,12 +1,20 @@
 @import 'fonts.css';
 
 @font-face {
-	  src: url('/media/fonts/AmstelvarAlpha-VF.ttf');
-	  font-family:'Amstelvar';
-	  font-style: normal;
+    src: url('/media/fonts/AmstelvarAlpha-VF.ttf');
+    font-family:'Amstelvar';
+    font-style: normal;
 }
 
-#output p {
-    font-size: 36px;
+#example-element {
     font-family: Amstelvar;
+    text-align: left;
+}
+
+#example-element h2 {
+    font-size: 36px;
+}
+
+#example-element p {
+    font-size: 12px;
 }

--- a/live-examples/css-examples/fonts/font-optical-sizing.html
+++ b/live-examples/css-examples/fonts/font-optical-sizing.html
@@ -1,15 +1,13 @@
 <section id="example-choice-list" class="example-choice-list" data-property="font-size">
     <div class="example-choice">
-        <pre><code class="language-css">font-optical-sizing: auto;
-font-size: 36px;</code></pre>
+        <pre><code class="language-css">font-optical-sizing: auto;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">font-optical-sizing: none;
-font-size: 36px;</code></pre>
+        <pre><code class="language-css">font-optical-sizing: none;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
@@ -18,6 +16,15 @@ font-size: 36px;</code></pre>
 
 <div id="output" class="output hidden">
     <section id="default-example">
-        <p id="example-element">Optical sizing example.</p>
+        <div id="example-element" style="font-optical-sizing: auto;">
+            <h2>Chapter 3</h2>
+            <p>
+                On this particular Thursday, something was moving quietly
+                through the ionosphere many miles above the surface of the
+                planet; several somethings in fact, several dozen huge yellow
+                chunky slablike somethings, huge as office blocks, silent as
+                birds.
+            </p>
+        </div>
     </section>
 </div>


### PR DESCRIPTION
I was looking at the example for https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/font-optical-sizing, and thought it would be better to include both larger and smaller font sizes, so we could see the effect on both. Especially I thought it would be good to show improved legibility at smaller sizes.
