### PR TITLE
Update expressions-greater-than.js

### DIFF
--- a/live-examples/js-examples/expressions/expressions-greater-than-or-equal.js
+++ b/live-examples/js-examples/expressions/expressions-greater-than-or-equal.js
@@ -4,6 +4,7 @@ console.log(5 >= 3);
 console.log(3 >= 3);
 // expected output: true
 
+// Compare bigint to int (note: bigint is not supported in all browsers)
 console.log(3n >= 5);
 // expected output: false
 

--- a/live-examples/js-examples/expressions/expressions-greater-than-or-equal.js
+++ b/live-examples/js-examples/expressions/expressions-greater-than-or-equal.js
@@ -4,7 +4,7 @@ console.log(5 >= 3);
 console.log(3 >= 3);
 // expected output: true
 
-// Compare bigint to int (note: bigint is not supported in all browsers)
+// Compare bigint to number (note: bigint is not supported in all browsers)
 console.log(3n >= 5);
 // expected output: false
 

--- a/live-examples/js-examples/expressions/expressions-greater-than.js
+++ b/live-examples/js-examples/expressions/expressions-greater-than.js
@@ -4,7 +4,8 @@ console.log(5 > 3);
 console.log(3 > 3);
 // expected output: false
 
-console.log(3 > 5);
+// Compare bigint to int (note: bigint is not supported in all browsers)
+console.log(3n > 5);
 // expected output: false
 
 console.log('ab' > 'aa');

--- a/live-examples/js-examples/expressions/expressions-greater-than.js
+++ b/live-examples/js-examples/expressions/expressions-greater-than.js
@@ -4,7 +4,7 @@ console.log(5 > 3);
 console.log(3 > 3);
 // expected output: false
 
-console.log(3n > 5);
+console.log(3 > 5);
 // expected output: false
 
 console.log('ab' > 'aa');

--- a/live-examples/js-examples/expressions/expressions-greater-than.js
+++ b/live-examples/js-examples/expressions/expressions-greater-than.js
@@ -4,7 +4,7 @@ console.log(5 > 3);
 console.log(3 > 3);
 // expected output: false
 
-// Compare bigint to int (note: bigint is not supported in all browsers)
+// Compare bigint to number (note: bigint is not supported in all browsers)
 console.log(3n > 5);
 // expected output: false
 

--- a/live-examples/js-examples/expressions/expressions-less-than-or-equal.js
+++ b/live-examples/js-examples/expressions/expressions-less-than-or-equal.js
@@ -4,7 +4,7 @@ console.log(5 <= 3);
 console.log(3 <= 3);
 // expected output: true
 
-// Compare bigint to int (note: bigint is not supported in all browsers)
+// Compare bigint to number (note: bigint is not supported in all browsers)
 console.log(3n <= 5);
 // expected output: true
 

--- a/live-examples/js-examples/expressions/expressions-less-than-or-equal.js
+++ b/live-examples/js-examples/expressions/expressions-less-than-or-equal.js
@@ -4,6 +4,7 @@ console.log(5 <= 3);
 console.log(3 <= 3);
 // expected output: true
 
+// Compare bigint to int (note: bigint is not supported in all browsers)
 console.log(3n <= 5);
 // expected output: true
 

--- a/live-examples/js-examples/expressions/expressions-less-than.js
+++ b/live-examples/js-examples/expressions/expressions-less-than.js
@@ -4,6 +4,7 @@ console.log(5 < 3);
 console.log(3 < 3);
 // expected output: false
 
+// Compare bigint to int (note: bigint is not supported in all browsers)
 console.log(3n < 5);
 // expected output: true
 

--- a/live-examples/js-examples/expressions/expressions-less-than.js
+++ b/live-examples/js-examples/expressions/expressions-less-than.js
@@ -4,7 +4,7 @@ console.log(5 < 3);
 console.log(3 < 3);
 // expected output: false
 
-// Compare bigint to int (note: bigint is not supported in all browsers)
+// Compare bigint to number (note: bigint is not supported in all browsers)
 console.log(3n < 5);
 // expected output: true
 


### PR DESCRIPTION
The previous 3n threw an error in the console on Safari 13 (newest release). Suggest using an example which works in current Safari. Previous example is good on Chrome and Edge browsers.

Error: No identifiers allowed directly after numeric literal