### PR TITLE
(fix) media file for track.html missing

### DIFF
--- a/live-examples/html-examples/image-and-multimedia/track.html
+++ b/live-examples/html-examples/image-and-multimedia/track.html
@@ -1,5 +1,5 @@
 <video controls
-       src="/media/examples/friday.mp4">
+       src="/media/cc0-videos/friday.mp4">
     <track default
            kind="captions"
            srclang="en"


### PR DESCRIPTION
The `mp4` for the track.html example is linked incorrectly. Video
files are all located inside the `media/cc0-videos` folder

fix #1683