### PR TITLE
Fix Grammar Error in a comment

### DIFF
--- a/live-examples/js-examples/math/math-random.js
+++ b/live-examples/js-examples/math/math-random.js
@@ -9,4 +9,4 @@ console.log(getRandomInt(1));
 // expected output: 0
 
 console.log(Math.random());
-// expected output: a number between 0 and 1
+// expected output: a number from 0 to <1


### PR DESCRIPTION
 The correction is regarding the usage of word here.

Since Math.random() always returns a value 0 <= x < 1, using the word 'between' in  "expected output: a number between 0 and 1" falsely indicates that the function Math.random() does not ever return 0.