### PR TITLE
Update flex-basis.html

### DIFF
--- a/live-examples/css-examples/flexbox/flex-basis.html
+++ b/live-examples/css-examples/flexbox/flex-basis.html
@@ -7,7 +7,7 @@
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">flex-basis: 0;</code></pre>
+        <pre><code class="language-css">flex-basis: 0%;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>


### PR DESCRIPTION
[flex-basis](https://drafts.csswg.org/css-flexbox/#valdef-flex-flex-basis) accepts the same values as the width and height properties, which does not include number zero.