### PR TITLE
Use a fieldset within the input/radio example

### DIFF
--- a/live-examples/html-examples/input/radio.html
+++ b/live-examples/html-examples/input/radio.html
@@ -1,17 +1,19 @@
-<p>Select a maintenance drone:</p>
+<fieldset>
+    <legend>Select a maintenance drone:</legend>
 
-<div>
-  <input type="radio" id="huey" name="drone" value="huey"
-         checked>
-  <label for="huey">Huey</label>
-</div>
+    <div>
+      <input type="radio" id="huey" name="drone" value="huey"
+             checked>
+      <label for="huey">Huey</label>
+    </div>
 
-<div>
-  <input type="radio" id="dewey" name="drone" value="dewey">
-  <label for="dewey">Dewey</label>
-</div>
+    <div>
+      <input type="radio" id="dewey" name="drone" value="dewey">
+      <label for="dewey">Dewey</label>
+    </div>
 
-<div>
-  <input type="radio" id="louie" name="drone" value="louie">
-  <label for="louie">Louie</label>
-</div>
+    <div>
+      <input type="radio" id="louie" name="drone" value="louie">
+      <label for="louie">Louie</label>
+    </div>
+</fieldset>


### PR DESCRIPTION
The fieldset and legend are required for accessibility. My concern is that some developers will copy the example without the needed fieldset/legend.