### PR TITLE
fix: Clarify string-endswith examples

### DIFF
--- a/live-examples/js-examples/string/string-endswith.js
+++ b/live-examples/js-examples/string/string-endswith.js
@@ -1,9 +1,12 @@
 const str1 = 'Cats are the best!';
 
+console.log(str1.endsWith('best!'));
+// expected output: true
+
 console.log(str1.endsWith('best', 17));
 // expected output: true
 
-const str2 = 'Is this a question';
+const str2 = 'Is this a question?';
 
-console.log(str2.endsWith('?'));
+console.log(str2.endsWith('question'));
 // expected output: false


### PR DESCRIPTION
These examples were quite confusing. As a user I expect the easy,
obvious example first, not an example with a "gotcha". And unfortunately
both of these examples were "gotchas", or best case scenario they
illustrated the more complicated things one can do with
string.endsWith(), but such examples should come _after_ the simple
ones.