### PR TITLE
Add example for Intl.toString

### DIFF
--- a/live-examples/js-examples/intl/intl-prototype-@@tostringtag.js
+++ b/live-examples/js-examples/intl/intl-prototype-@@tostringtag.js
@@ -1,0 +1,4 @@
+const intl1 = Object.prototype.toString.call(Intl);
+
+console.log(intl1);
+// expected output: "[object Intl]"

--- a/live-examples/js-examples/intl/meta.json
+++ b/live-examples/js-examples/intl/meta.json
@@ -126,6 +126,12 @@
             "title": "JavaScript Demo: Intl.NumberFormat",
             "type": "js"
         },
+        "intlPrototypeToString": {
+            "exampleCode": "./live-examples/js-examples/intl/intl-prototype-@@tostringtag.js",
+            "fileName": "intl-prototype-tostringtag.html",
+            "title": "JavaScript Demo: Intl.prototype.toString()",
+            "type": "js"
+        },
         "intlRelativeTimeFormat": {
             "exampleCode": "./live-examples/js-examples/intl/intl-relativetimeformat.js",
             "fileName": "intl-relativetimeformat.html",


### PR DESCRIPTION
This adds trivial example for `Intl[Symbol.toStringTag]`  following its addtition in https://bugzilla.mozilla.org/show_bug.cgi?id=1670053
This is to populate https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/@@toStringTag

Tested on a codepen. Seems to work OK. But I am not great a JavaScript, so appreciate your review!