### PR TITLE
autocapitalize example

### DIFF
--- a/live-examples/html-examples/global-attributes/attribute-autocapitalize.html
+++ b/live-examples/html-examples/global-attributes/attribute-autocapitalize.html
@@ -1,0 +1,11 @@
+<h3>Sentence Case</h3>
+<div class="fields">
+  <label for="sentence">Write sentences in lowercase.</label>
+  <input type="text" autocapitalize="sentences" id="sentence">
+</div>
+
+<h3>Word Case</h3>
+<div class="fields">
+  <label for="word">Write sentences in lowercase.</label>
+  <input type="text" autocapitalize="words" id="word">
+</div>

--- a/live-examples/html-examples/global-attributes/css/attribute-autocapitalize.css
+++ b/live-examples/html-examples/global-attributes/css/attribute-autocapitalize.css
@@ -1,0 +1,10 @@
+.output {
+    font: 1rem 'Fira Sans', sans-serif;
+    letter-spacing: 1px;
+}
+
+.fields {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    gap: .5em;
+}

--- a/live-examples/html-examples/global-attributes/meta.json
+++ b/live-examples/html-examples/global-attributes/meta.json
@@ -8,6 +8,14 @@
             "type": "tabbed",
             "height": "tabbed-shorter"
         },
+        "autocapitalize": {
+            "exampleCode": "./live-examples/html-examples/global-attributes/attribute-autocapitalize.html",
+            "cssExampleSrc": "./live-examples/html-examples/global-attributes/css/attribute-autocapitalize.css",
+            "fileName": "attribute-autocapitalize.html",
+            "title": "HTML Demo: autocapitalize",
+            "type": "tabbed",
+            "height": "tabbed-shorter"
+        },
         "class": {
             "exampleCode": "./live-examples/html-examples/global-attributes/attribute-class.html",
             "cssExampleSrc": "./live-examples/html-examples/global-attributes/css/attribute-class.css",


### PR DESCRIPTION
Adding an example for the global attribute autocapitalize, working on https://github.com/mdn/sprints/issues/3802

This is shipping in Firefox 83. MDN page: https://wiki.developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize