### PR TITLE
Added Intl.NumberFormat.formatToParts() example

### DIFF
--- a/live-examples/js-examples/intl/intl-numberformat-prototype-formattoparts.js
+++ b/live-examples/js-examples/intl/intl-numberformat-prototype-formattoparts.js
@@ -1,0 +1,23 @@
+const amount = 654321.987;
+const options = { style: 'currency', currency: 'USD' };
+const numberFormat = new Intl.NumberFormat('en-US', options);
+
+const parts = numberFormat.formatToParts(amount);
+
+console.log(parts[0].value);
+// expected output: "$"
+
+console.log(parts[1].value);
+// expected output: "654"
+
+console.log(parts[2].value);
+// expected output: ","
+
+console.log(parts[3].value);
+// expected output: "321"
+
+console.log(parts[4].value);
+// expected output: "."
+
+console.log(parts[5].value);
+// expected output: "99"

--- a/live-examples/js-examples/intl/intl-numberformat-prototype-formattoparts.js
+++ b/live-examples/js-examples/intl/intl-numberformat-prototype-formattoparts.js
@@ -3,21 +3,7 @@ const options = { style: 'currency', currency: 'USD' };
 const numberFormat = new Intl.NumberFormat('en-US', options);
 
 const parts = numberFormat.formatToParts(amount);
+const partValues = parts.map(p => p.value);
 
-console.log(parts[0].value);
-// expected output: "$"
-
-console.log(parts[1].value);
-// expected output: "654"
-
-console.log(parts[2].value);
-// expected output: ","
-
-console.log(parts[3].value);
-// expected output: "321"
-
-console.log(parts[4].value);
-// expected output: "."
-
-console.log(parts[5].value);
-// expected output: "99"
+console.log(partValues);
+// expected output: "["$", "654", ",", "321", ".", "99"]"

--- a/live-examples/js-examples/intl/meta.json
+++ b/live-examples/js-examples/intl/meta.json
@@ -108,6 +108,12 @@
             "title": "JavaScript Demo: Intl.NumberFormat.prototype.format",
             "type": "js"
         },
+        "intlNumberFormatPrototypeFormatToParts": {
+            "exampleCode": "./live-examples/js-examples/intl/intl-numberformat-prototype-formattoparts.js",
+            "fileName": "intl-numberformat-prototype-formattoparts.html",
+            "title": "JavaScript Demo: Intl.NumberFormat.prototype.formatToParts",
+            "type": "js"
+        },
         "intlNumberFormatPrototypeResolvedOptions": {
             "exampleCode": "./live-examples/js-examples/intl/intl-numberformat-prototype-resolvedoptions.js",
             "fileName": "intl-numberformat-prototype-resolvedoptions.html",


### PR DESCRIPTION
#1649 

I took the `Intl.NumberFormat` parts from [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat), and the `formatToParts` parts from [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/formatToParts)