### PR TITLE
move attribution out of <blockquote>

### DIFF
--- a/live-examples/html-examples/text-content/blockquote.html
+++ b/live-examples/html-examples/text-content/blockquote.html
@@ -1,4 +1,6 @@
-<blockquote cite="https://www.huxley.net/bnw/four.html">
-    <p>Words can be like X-rays, if you use them properly—they’ll go through anything. You read and you’re pierced.</p>
-    <footer>—Aldous Huxley, <cite>Brave New World</cite></footer>
-</blockquote>
+<figure>
+    <blockquote cite="https://www.huxley.net/bnw/four.html">
+        <p>Words can be like X-rays, if you use them properly—they’ll go through anything. You read and you’re pierced.</p>
+    </blockquote>
+    <figcaption>—Aldous Huxley, <cite>Brave New World</cite></figcaption>
+</figure>


### PR DESCRIPTION
The [spec](https://html.spec.whatwg.org/multipage/grouping-content.html#the-blockquote-element) for `<blockquote>` states:

> Attribution for the quotation, if any, must be placed outside the blockquote element.

I changed the semantics to one of the examples in the spec.

Fixes mdn/sprints#2705