### PR TITLE
change hrefs to '#' in nav example

### DIFF
--- a/live-examples/html-examples/content-sectioning/nav.html
+++ b/live-examples/html-examples/content-sectioning/nav.html
@@ -1,7 +1,7 @@
 <nav class="crumbs">
     <ol>
-        <li class="crumb"><a href="bikes">Bikes</a></li>
-        <li class="crumb"><a href="bikes/bmx">BMX</a></li>
+        <li class="crumb"><a href="#">Bikes</a></li>
+        <li class="crumb"><a href="#">BMX</a></li>
         <li class="crumb">Jump Bike 3000</li>
     </ol>
 </nav>


### PR DESCRIPTION
The href values of the breadcrumbs cause a 404 error in the example when clicked. This PR changes them to "#".

@chrisdavidmills: Fixes mdn/sprints#3454