### PR TITLE
Remove reduce function from restparameters example

### DIFF
--- a/live-examples/js-examples/functions/functions-restparameters.js
+++ b/live-examples/js-examples/functions/functions-restparameters.js
@@ -1,6 +1,6 @@
 function sum(...theArgs) {
   let total = 0;
-  for(const arg of theArgs){
+  for (const arg of theArgs) {
     total += arg;
   }
   return total;

--- a/live-examples/js-examples/functions/functions-restparameters.js
+++ b/live-examples/js-examples/functions/functions-restparameters.js
@@ -1,7 +1,9 @@
 function sum(...theArgs) {
-  return theArgs.reduce((previous, current) => {
-    return previous + current;
-  });
+  let total = 0;
+  for(const arg of theArgs){
+    total += arg;
+  }
+  return total;
 }
 
 console.log(sum(1, 2, 3));


### PR DESCRIPTION
reduce() can be confusing for new users, it's better to use a simple for loop here.