### PR TITLE
Add options example to intl-collator

### DIFF
--- a/live-examples/js-examples/intl/intl-collator.js
+++ b/live-examples/js-examples/intl/intl-collator.js
@@ -4,5 +4,5 @@ console.log(['Z', 'a', 'z', 'ä'].sort(new Intl.Collator('de').compare));
 console.log(['Z', 'a', 'z', 'ä'].sort(new Intl.Collator('sv').compare));
 // expected output: ["a", "z", "Z", "ä"]
 
-console.log(['Z', 'a', 'z', 'ä'].sort(new Intl.Collator('de', {caseFirst: 'upper'} ).compare));
+console.log(['Z', 'a', 'z', 'ä'].sort(new Intl.Collator('de', { caseFirst: 'upper' } ).compare));
 // expected output: ["a", "ä", "Z", "z"]

--- a/live-examples/js-examples/intl/intl-collator.js
+++ b/live-examples/js-examples/intl/intl-collator.js
@@ -1,10 +1,8 @@
-function letterSort(lang, letters) {
-  letters.sort(new Intl.Collator(lang).compare);
-  return letters;
-}
+console.log(['Z', 'a', 'z', 'ä'].sort(new Intl.Collator('de').compare));
+// expected output: ["a", "ä", "z", "Z"]
 
-console.log(letterSort('de', ['a', 'z', 'ä']));
-// expected output: Array ["a", "ä", "z"]
+console.log(['Z', 'a', 'z', 'ä'].sort(new Intl.Collator('sv').compare));
+// expected output: ["a", "z", "Z", "ä"]
 
-console.log(letterSort('sv', ['a', 'z', 'ä']));
-// expected output: Array ["a", "z", "ä"]
+console.log(['Z', 'a', 'z', 'ä'].sort(new Intl.Collator('de', {caseFirst: 'upper'} ).compare));
+// expected output: ["a", "ä", "Z", "z"]


### PR DESCRIPTION
This modifies the Intl.Collator() example to show how you can use options, since these can radically affect behaviour.

Note that I could have extended the function to pass through the options as well, but decided not to - IMO better to show the actual call as a user will try it.

Appreciate this is arguable.