### PR TITLE
Add enterkeyhint example

### DIFF
--- a/live-examples/html-examples/global-attributes/attribute-enterkeyhint.html
+++ b/live-examples/html-examples/global-attributes/attribute-enterkeyhint.html
@@ -1,0 +1,3 @@
+<input enterkeyhint="go">
+
+<p contenteditable enterkeyhint="go">https://example.org</p>

--- a/live-examples/html-examples/global-attributes/css/attribute-enterkeyhint.css
+++ b/live-examples/html-examples/global-attributes/css/attribute-enterkeyhint.css
@@ -1,0 +1,4 @@
+.output {
+    font: 1rem 'Fira Sans', sans-serif;
+    letter-spacing: 1px;
+}

--- a/live-examples/html-examples/global-attributes/meta.json
+++ b/live-examples/html-examples/global-attributes/meta.json
@@ -40,6 +40,14 @@
             "type": "tabbed",
             "height": "tabbed-standard"
         },
+        "enterkeyhint": {
+            "exampleCode": "./live-examples/html-examples/global-attributes/attribute-enterkeyhint.html",
+            "cssExampleSrc": "./live-examples/html-examples/global-attributes/css/attribute-enterkeyhint.css",
+            "fileName": "attribute-enterkeyhint.html",
+            "title": "HTML Demo: enterkeyhint",
+            "type": "tabbed",
+            "height": "tabbed-shorter"
+        },
         "hidden": {
             "exampleCode": "./live-examples/html-examples/global-attributes/attribute-hidden.html",
             "cssExampleSrc": "./live-examples/html-examples/global-attributes/css/attribute-hidden.css",


### PR DESCRIPTION
Interactive example for https://github.com/mdn/content/pull/1106
It just shows how it works with an input element and contenteditable.

I managed to get it all running locally with Yari, so here's the rendering of that:
Not sure why the CSS file is needed but the other global attributes have that, too.

![Bildschirmfoto 2021-01-11 um 12 50 15](https://user-images.githubusercontent.com/349114/104179116-a97f5580-540b-11eb-8f24-518ccafa6860.png)