### PR TITLE
Change uint16→int16array in TypedArray.of example

### DIFF
--- a/live-examples/js-examples/typedarray/typedarray-of.js
+++ b/live-examples/js-examples/typedarray/typedarray-of.js
@@ -1,5 +1,5 @@
-let uint16 = new Int16Array;
-uint16 = Int16Array.of('10', '20', '30', '40', '50');
+let int16array = new Int16Array;
+int16array = Int16Array.of('10', '20', '30', '40', '50');
 
-console.log(uint16);
+console.log(int16array);
 // expected output: Int16Array [10, 20, 30, 40, 50]


### PR DESCRIPTION
`new Int16Array` creates an array of signed integers; so using “uint16” as the name of the variable it get assigned to is confusing — because the “u” part by convention is used for indicating *unsigned*.

Fixes https://github.com/mdn/content/issues/1283