### PR TITLE
Remove extra "new" instantiation from TypedArray.from() live demo

### DIFF
--- a/live-examples/js-examples/typedarray/typedarray-from.js
+++ b/live-examples/js-examples/typedarray/typedarray-from.js
@@ -1,4 +1,4 @@
-let uint16 = Int16Array.from('12345');
+const uint16 = Int16Array.from('12345');
 
 console.log(uint16);
 // expected output: Int16Array [1, 2, 3, 4, 5]

--- a/live-examples/js-examples/typedarray/typedarray-from.js
+++ b/live-examples/js-examples/typedarray/typedarray-from.js
@@ -1,5 +1,4 @@
-let uint16 = new Int16Array;
-uint16 = Int16Array.from('12345');
+let uint16 = Int16Array.from('12345');
 
 console.log(uint16);
 // expected output: Int16Array [1, 2, 3, 4, 5]


### PR DESCRIPTION
The extra `new` step isn't necessary before using `Int16Array.from`, is it?