### PR TITLE
Fixes markup for <cite> example

### DIFF
--- a/live-examples/html-examples/inline-text-semantics/cite.html
+++ b/live-examples/html-examples/inline-text-semantics/cite.html
@@ -1,6 +1,6 @@
-<blockquote>
-    <p>It was a bright cold day in April, and the clocks were striking thirteen.</p>
-    <footer>
-        First sentence in <cite><a href="http://www.george-orwell.org/1984/0.html">Nineteen Eighty-Four</a></cite> by George Orwell (Part 1, Chapter 1).
-    </footer>
-</blockquote>
+<figure>
+    <blockquote>
+        <p>It was a bright cold day in April, and the clocks were striking thirteen.</p>
+    </blockquote>
+    <figcaption>First sentence in <cite><a href="http://www.george-orwell.org/1984/0.html">Nineteen Eighty-Four</a></cite> by George Orwell (Part 1, Chapter 1).</figcaption>
+</figure>


### PR DESCRIPTION
I don't think `<footer>` was meant to be used with non-sectioning content like this. The [page for `blockquote`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote) contains what I believe to be the correct markup,  [corroborated by the HTML living spec](https://html.spec.whatwg.org/multipage/grouping-content.html#the-blockquote-element).

(Update: the `<footer>` usage was previously recommended in the W3C HTML spec)