### PR TITLE
Remove redundant Math.floor()

### DIFF
--- a/live-examples/js-examples/math/math-random.js
+++ b/live-examples/js-examples/math/math-random.js
@@ -1,5 +1,5 @@
 function getRandomInt(max) {
-  return Math.floor(Math.random() * Math.floor(max));
+  return Math.floor(Math.random() * max);
 }
 
 console.log(getRandomInt(3));


### PR DESCRIPTION
Outer Math.floor() is already enough.
As edge scenario, let's assume Math.random returns 0.9999
and we call this function with 5.9999
=> Math.floor(0.9999 * 5.9999) = 5