### PR TITLE
Added example for RegExp.prototype.hasIndices

### DIFF
--- a/live-examples/js-examples/regexp/meta.json
+++ b/live-examples/js-examples/regexp/meta.json
@@ -66,7 +66,7 @@
             "title": "JavaScript Demo: RegExp.prototype[@@split]",
             "type": "js"
         },
-        "regexPrototypeDotAll": {
+        "regexpPrototypeDotAll": {
             "exampleCode": "./live-examples/js-examples/regexp/regexp-prototype-dotall.js",
             "fileName": "regexp-prototype-dotall.html",
             "title": "JavaScript Demo: RegExp.prototype.dotAll",
@@ -90,7 +90,7 @@
             "title": "JavaScript Demo: RegExp.prototype.global",
             "type": "js"
         },
-        "regexPrototypeHasIndices": {
+        "regexpPrototypeHasIndices": {
             "exampleCode": "./live-examples/js-examples/regexp/regexp-prototype-hasindices.js",
             "fileName": "regexp-prototype-hasindices.html",
             "title": "JavaScript Demo: RegExp.prototype.hasIndices",

--- a/live-examples/js-examples/regexp/meta.json
+++ b/live-examples/js-examples/regexp/meta.json
@@ -90,6 +90,12 @@
             "title": "JavaScript Demo: RegExp.prototype.global",
             "type": "js"
         },
+        "regexPrototypeHasIndices": {
+            "exampleCode": "./live-examples/js-examples/regexp/regexp-prototype-hasindices.js",
+            "fileName": "regexp-prototype-hasindices.html",
+            "title": "JavaScript Demo: RegExp.prototype.hasIndices",
+            "type": "js"
+        },
         "regexpPrototypeIgnoreCase": {
             "exampleCode": "./live-examples/js-examples/regexp/regexp-prototype-ignorecase.js",
             "fileName": "regexp-prototype-ignorecase.html",

--- a/live-examples/js-examples/regexp/regexp-prototype-hasindices.js
+++ b/live-examples/js-examples/regexp/regexp-prototype-hasindices.js
@@ -1,0 +1,9 @@
+const regex1 = new RegExp('foo', 'd');
+
+console.log(regex1.hasIndices);
+// expected output: true
+
+const regex2 = new RegExp('bar');
+
+console.log(regex2.hasIndices);
+// expected output: false


### PR DESCRIPTION
This adds an interactive example for the [newly introduced `RegExp.prototype.hasIndices`](https://bugzilla.mozilla.org/show_bug.cgi?id=1519483) property.

This is in preparation of adding the related content.

Sebastian