### PR TITLE
change no-invalid-regexp to warn for hasindices

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -226,6 +226,13 @@ module.exports = {
             },
         },
         {
+            // Only until the "d" flag is supported by eslint.
+            files: ['**/regexp/regexp-prototype-hasindices.js'],
+            rules: {
+                'no-invalid-regexp': 'warn',
+            },
+        },
+        {
             files: ['**/set/set-prototype-foreach.js'],
             rules: {
                 'no-unused-vars': 'off',

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "ajv": "7.0.3",
         "babel-eslint": "^10.1.0",
         "chokidar-cli": "2.1.0",
-        "eslint": "7.23.0",
+        "eslint": "7.24.0",
         "http-server": "0.12.3",
         "mdn-bob": "2.0.19",
         "npm-run-all": "4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1592,7 +1592,50 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@7.23.0, eslint@^7.9.0:
+eslint@7.24.0:
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.24.0.tgz#2e44fa62d93892bfdb100521f17345ba54b8513a"
+  integrity sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==
+  dependencies:
+    "@babel/code-frame" "7.12.11"
+    "@eslint/eslintrc" "^0.4.0"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    enquirer "^2.3.5"
+    eslint-scope "^5.1.1"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^2.0.0"
+    espree "^7.3.1"
+    esquery "^1.4.0"
+    esutils "^2.0.2"
+    file-entry-cache "^6.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.0.0"
+    globals "^13.6.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash "^4.17.21"
+    minimatch "^3.0.4"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    progress "^2.0.0"
+    regexpp "^3.1.0"
+    semver "^7.2.1"
+    strip-ansi "^6.0.0"
+    strip-json-comments "^3.1.0"
+    table "^6.0.4"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
+eslint@^7.9.0:
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.23.0.tgz#8d029d252f6e8cf45894b4bee08f5493f8e94325"
   integrity sha512-kqvNVbdkjzpFy0XOszNwjkKzZ+6TcwCQ/h+ozlcIWwaimBBuhlQ4nN6kbiM2L+OjDcznkTJxzYfRFH92sx4a0Q==


### PR DESCRIPTION
Changing the `no-invalid-regexp` rule to a warning (rather than a error), but only for `**/regexp/regexp-prototype-hasindices.js`. We can remove this change once `eslint` recognizes the `"d"` flag to the `RegExp` constructor.

This will get the builds passing again after they were broken by #1782.