### PR TITLE
text-emphasis examples

### DIFF
--- a/live-examples/css-examples/text-decoration/meta.json
+++ b/live-examples/css-examples/text-decoration/meta.json
@@ -56,6 +56,13 @@
             "title": "CSS Demo: text-emphasis-color",
             "type": "css"
         },
+        "textEmphasisPosition": {
+            "cssExampleSrc": "./live-examples/css-examples/text-decoration/text-emphasis-position.css",
+            "exampleCode": "./live-examples/css-examples/text-decoration/text-emphasis-position.html",
+            "fileName": "text-emphasis-position.html",
+            "title": "CSS Demo: text-emphasis-position",
+            "type": "css"
+        },
         "textEmphasisStyle": {
             "cssExampleSrc": "./live-examples/css-examples/text-decoration/text-emphasis-style.css",
             "exampleCode": "./live-examples/css-examples/text-decoration/text-emphasis-style.html",

--- a/live-examples/css-examples/text-decoration/text-emphasis-color.css
+++ b/live-examples/css-examples/text-decoration/text-emphasis-color.css
@@ -4,4 +4,5 @@ p {
 
 #example-element {
     text-emphasis: filled;
+    -webkit-text-emphasis: filled;
 }

--- a/live-examples/css-examples/text-decoration/text-emphasis-color.html
+++ b/live-examples/css-examples/text-decoration/text-emphasis-color.html
@@ -1,20 +1,23 @@
-<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis-color">
+<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis-color -webkit-text-emphasis-color">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">text-emphasis-color: currentColor;</code></pre>
+        <pre><code class="language-css">text-emphasis-color: currentColor;
+-webkit-text-emphasis-color: currentColor;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">text-emphasis-color: red;</code></pre>
+        <pre><code class="language-css">text-emphasis-color: red;
+-webkit-text-emphasis-color: red;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">text-emphasis-color: rgba(90, 200, 160, 0.8);</code></pre>
+        <pre><code class="language-css">text-emphasis-color: rgba(90, 200, 160, 0.8);
+-webkit-text-emphasis-color: rgba(90, 200, 160, 0.8);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/text-decoration/text-emphasis-position.css
+++ b/live-examples/css-examples/text-decoration/text-emphasis-position.css
@@ -1,0 +1,8 @@
+p {
+    font: 1.5em sans-serif;
+}
+
+#example-element {
+    text-emphasis: filled double-circle blue;
+    -webkit-text-emphasis: filled double-circle blue;
+}

--- a/live-examples/css-examples/text-decoration/text-emphasis-position.html
+++ b/live-examples/css-examples/text-decoration/text-emphasis-position.html
@@ -1,0 +1,23 @@
+<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis-position -webkit-text-emphasis-position">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">text-emphasis-position: over ;
+-webkit-text-emphasis-position: over;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-emphasis-position: under ;
+-webkit-text-emphasis-position : under;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <p>I'd far rather be <span id="example-element" class="transition-all">happy than right</span> any day.</p>
+    </section>
+</div>

--- a/live-examples/css-examples/text-decoration/text-emphasis-style.html
+++ b/live-examples/css-examples/text-decoration/text-emphasis-style.html
@@ -1,27 +1,31 @@
-<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis-style">
+<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis-style -webkit-text-emphasis-style">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">text-emphasis-style: none;</code></pre>
+        <pre><code class="language-css">text-emphasis-style: none;
+-webkit-text-emphasis-style: none;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">text-emphasis-style: triangle;</code></pre>
+        <pre><code class="language-css">text-emphasis-style: triangle;
+-webkit-text-emphasis-style: triangle;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">text-emphasis-style: 'x';</code></pre>
+        <pre><code class="language-css">text-emphasis-style: 'x';
+-webkit-text-emphasis-style: 'x';</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">text-emphasis-style: filled double-circle;</code></pre>
+        <pre><code class="language-css">text-emphasis-style: filled double-circle;
+-webkit-text-emphasis-style: filled double-circle;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>


### PR DESCRIPTION
Fixes #1644 

There were already examples for style and color, but they haven't been added to pages and needed the -webkit prefixed versions. So I have added that and also the text-emphasis-position example.