### PR TITLE
Add smaller font-size for last element in grid-auto-rows demo

### DIFF
--- a/live-examples/css-examples/grid/grid-auto-rows.css
+++ b/live-examples/css-examples/grid/grid-auto-rows.css
@@ -12,8 +12,9 @@
 #example-element > div {
     background-color: rgba(0, 0, 255, 0.2);
     border: 3px solid blue;
+    font-size: 22px;
 }
 
 #example-element div:last-child {
-    font-size: 10px;
+    font-size: 13px;
 }

--- a/live-examples/css-examples/grid/grid-auto-rows.css
+++ b/live-examples/css-examples/grid/grid-auto-rows.css
@@ -13,3 +13,7 @@
     background-color: rgba(0, 0, 255, 0.2);
     border: 3px solid blue;
 }
+
+#example-element div:last-child {
+    font-size: 10px;
+}

--- a/live-examples/css-examples/grid/grid-auto-rows.html
+++ b/live-examples/css-examples/grid/grid-auto-rows.html
@@ -21,7 +21,7 @@
     </div> 
 
     <div class="example-choice">
-        <pre><code class="language-css">grid-auto-rows: minmax(10px, auto);</code></pre>
+        <pre><code class="language-css">grid-auto-rows: minmax(30px, auto);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>


### PR DESCRIPTION
Resolves #1801 @wbamberg 

> Yes the "missing" text was intentional as otherwise you can't see the difference (it's a bit tricky in such a small space). I think the solution of adding a smaller font size would work.

In this [comment](https://github.com/mdn/interactive-examples/pull/1801#issuecomment-830572374), @rachelandrew mentioned that adding a smaller font size for the last element would be a way to resolve this. I'm happy to push another commit and remove the text content if its more preferred without text to really highlight the different heights the last box will occupy.