### PR TITLE
Fix: tabSize example support 

### DIFF
--- a/live-examples/css-examples/text/tab-size.html
+++ b/live-examples/css-examples/text/tab-size.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="tabSize">
+<section id="example-choice-list" class="example-choice-list large" data-property="tabSize -moz-tab-size">
 
     <div class="example-choice" initial-choice="true">
         <pre><code class="language-css">tab-size: 10px;


### PR DESCRIPTION
Firefox supports tabSize example
#1645 