### PR TITLE
Add auto width to .example-container for flex-basis interactive demo

### DIFF
--- a/live-examples/css-examples/flexbox/flex-basis.css
+++ b/live-examples/css-examples/flexbox/flex-basis.css
@@ -1,4 +1,4 @@
-.example-container {
+.default-example {
     background-color: #eee;
     border: .75em solid;
     padding: .75em;
@@ -7,7 +7,7 @@
     display: flex;
 }
 
-.example-container > div {
+.default-example > div {
     background-color: rgba(0, 0, 255, 0.2);
     border: 3px solid blue;
     margin: 10px;

--- a/live-examples/css-examples/flexbox/flex-basis.css
+++ b/live-examples/css-examples/flexbox/flex-basis.css
@@ -2,7 +2,7 @@
     background-color: #eee;
     border: .75em solid;
     padding: .75em;
-    width: 80%;
+    width: auto;
     max-height: 300px;
     display: flex;
 }

--- a/live-examples/css-examples/flexbox/flex-basis.html
+++ b/live-examples/css-examples/flexbox/flex-basis.html
@@ -23,10 +23,8 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
-        <div class="example-container">
-            <div id="example-element" class="transition-all">Item One</div>
-            <div>Item Two</div>
-            <div>Item Three</div>
-        </div>
+        <div id="example-element" class="transition-all">Item One</div>
+        <div>Item Two</div>
+        <div>Item Three</div>
     </section>
 </div>


### PR DESCRIPTION
Fixes #1828 

The "side by side" layout doesn't change, but we could perform the same column layout shift like I proposed in #1825 and that could be one more commit added here before this PR is ready to merge.