### PR TITLE
Drop role=main from <main> element

### DIFF
--- a/live-examples/html-examples/text-content/main.html
+++ b/live-examples/html-examples/text-content/main.html
@@ -1,6 +1,6 @@
 <header>Gecko facts</header>
 
-<main role="main">
+<main>
     <p>Geckos are a group of usually small, usually nocturnal lizards. They are found on every continent except Australia.</p>
  
     <p>Many species of gecko have adhesive toe pads which enable them to climb walls and even windows.</p>

--- a/live-examples/webapi-examples/document/queryselector/document-queryselector.html
+++ b/live-examples/webapi-examples/document/queryselector/document-queryselector.html
@@ -1,7 +1,7 @@
 <header>
     <h1>document.querySelector</h1>
 </header>
-<main role="main">
+<main>
     <p>You can use <code>document.querySelector()</code> to select individual elements in the DOM</p>
 </main>
 <footer>


### PR DESCRIPTION
Per the ARIA in HTML spec at https://w3c.github.io/html-aria/#el-main, the `main` element should have no role value; its implicit role is `main`, and at https://w3c.github.io/html-aria/#rules-wd, the spec says:

> It is NOT RECOMMENDED for authors to set the ARIA role and aria-\* attributes to values that match the implicit ARIA semantics defined in the table. Doing so is unnecessary and can potentially lead to unintended consequences.

Fixes https://github.com/mdn/content/issues/5461