### PR TITLE
html/input: Escape dot in regular expression for email

### DIFF
--- a/live-examples/html-examples/input/email.html
+++ b/live-examples/html-examples/input/email.html
@@ -1,4 +1,4 @@
 <label for="email">Enter your globex.com email:</label>
 
 <input type="email" id="email"
-       pattern=".+@globex.com" size="30" required>
+       pattern=".+@globex\.com" size="30" required>


### PR DESCRIPTION
While the example suggests that it checked for `globex.com` email addresses, the
pattern accepted any character instead of the dot before `com`. So it matched
for example `foo@globexZcom`.

While it's harmless in our setting, we want to alert users that they have to
escape dots in regular expressions if they intend to only match dots, we set a
good example and escape the dot before `com`.