### PR TITLE
Significantly improve by adding an ALL CAPS word

### DIFF
--- a/live-examples/css-examples/text/text-transform.html
+++ b/live-examples/css-examples/text/text-transform.html
@@ -47,7 +47,7 @@
 <div id="output" class="output large hidden">
     <section id="default-example">
         <div id="example-element" class="transition-all">
-            <p>London. Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall.</p>
+            <p>LONDON. Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall.</p>
             <p>Σ is a Greek letter and appears in ΟΔΥΣΣΕΥΣ. Θα πάμε στο "Θεϊκό φαΐ" ή στη "Νεράιδα"</p>
             <p>ァィゥェ ォヵㇰヶ</p>
         </div>


### PR DESCRIPTION
This example will benefit significantly by adding a word in ALL CAPS so developers can see how an all caps word is affected.

Fortunately, the first word of the quote from Dickens affords this opportunity perfectly.  According to [GoodReads](https://www.goodreads.com/quotes/195229-london-michaelmas-term-lately-over-and-the-lord-chancellor-sitting), the word "London" should be in all caps, so this improvement is a win-win.