### PR TITLE
add example showcasing basic map functionality

### DIFF
--- a/live-examples/js-examples/map/map.js
+++ b/live-examples/js-examples/map/map.js
@@ -11,3 +11,11 @@ map1.set('a', 97);
 
 console.log(map1.get('a'));
 // expected output: 97
+
+console.log(map1.size);
+// expected output: 3
+
+map1.delete('b');
+
+console.log(map1.size);
+// expected output: 2

--- a/live-examples/js-examples/map/map.js
+++ b/live-examples/js-examples/map/map.js
@@ -1,0 +1,17 @@
+const MAP = new Map();
+
+MAP.set('a', 1);
+MAP.set('b', 2);
+MAP.set('c', 3);
+
+let result = MAP.get('a');
+
+console.log(result);
+// expected output: 1
+
+MAP.set('a', 97);
+
+result = MAP.get('a');
+
+console.log(result);
+// expected output: 97

--- a/live-examples/js-examples/map/map.js
+++ b/live-examples/js-examples/map/map.js
@@ -4,14 +4,10 @@ map1.set('a', 1);
 map1.set('b', 2);
 map1.set('c', 3);
 
-let result = map1.get('a');
-
-console.log(result);
+console.log(map1.get('a'));
 // expected output: 1
 
 map1.set('a', 97);
 
-result = map1.get('a');
-
-console.log(result);
+console.log(map1.get('a'));
 // expected output: 97

--- a/live-examples/js-examples/map/map.js
+++ b/live-examples/js-examples/map/map.js
@@ -1,17 +1,17 @@
-const MAP = new Map();
+const map1 = new Map();
 
-MAP.set('a', 1);
-MAP.set('b', 2);
-MAP.set('c', 3);
+map1.set('a', 1);
+map1.set('b', 2);
+map1.set('c', 3);
 
-let result = MAP.get('a');
+let result = map1.get('a');
 
 console.log(result);
 // expected output: 1
 
-MAP.set('a', 97);
+map1.set('a', 97);
 
-result = MAP.get('a');
+result = map1.get('a');
 
 console.log(result);
 // expected output: 97

--- a/live-examples/js-examples/map/meta.json
+++ b/live-examples/js-examples/map/meta.json
@@ -1,5 +1,11 @@
 {
     "pages": {
+        "map": {
+            "exampleCode":"./live-examples/js-examples/map/map.js",
+            "fileName": "map.html",
+            "title":"JavaScript Demo: Map",
+            "type":"js"
+        },
         "mapPrototype@@Iterator": {
             "exampleCode": "./live-examples/js-examples/map/map-prototype-@@iterator.js",
             "fileName": "map-prototype-@@iterator.html",


### PR DESCRIPTION
I think it would be helpful to have an example showcasing a `Map`'s general functionality, so I created an interactive example doing exactly that.

I think it would be useful if we showed this interactive example at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map, since that page has no interactive examples at the time of this writing.