### PR TITLE
Change counter-reset example to use counters() not counter()

### DIFF
--- a/live-examples/css-examples/lists/counter-reset.css
+++ b/live-examples/css-examples/lists/counter-reset.css
@@ -13,5 +13,5 @@ h2 {
 }
 
 h2::before {
-    content: "Chapter " counter(chapter-count) ": ";
+    content: "Chapter " counters(chapter-count, ".") ": ";
 }


### PR DESCRIPTION
https://github.com/mdn/content/issues/6277 (and the linked bugzilla issue) explain why the counter-reset example is confusing. I've updated it as suggested in the bugzilla bug.

Once this is merged and showing up I'll go add an explanation under the example.