### PR TITLE
Add interactive example for Intl.PluralRules.supportedLocalesOf

### DIFF
--- a/live-examples/js-examples/intl/intl-pluralrules-supportedlocalesof.js
+++ b/live-examples/js-examples/intl/intl-pluralrules-supportedlocalesof.js
@@ -1,0 +1,5 @@
+const locales = ['en-US', 'ban', 'ar-OM', 'de-DE'];
+const options = { localeMatcher: 'lookup' };
+
+console.log(Intl.PluralRules.supportedLocalesOf(locales, options));
+// expected output: Array ["en-US", "ar-OM", "de-DE"]

--- a/live-examples/js-examples/intl/meta.json
+++ b/live-examples/js-examples/intl/meta.json
@@ -138,6 +138,12 @@
             "title": "JavaScript Demo: Intl.prototype.toString()",
             "type": "js"
         },
+        "intlPluralRulesSupportedLocalesOf": {
+            "exampleCode": "./live-examples/js-examples/intl/intl-pluralrules-supportedlocalesof.js",
+            "fileName": "intl-pluralrules-prototype-supportedlocalesof.html",
+            "title": "JavaScript Demo: Intl.PluralRules.prototype.supportedLocalesOf",
+            "type": "js"
+        },
         "intlRelativeTimeFormat": {
             "exampleCode": "./live-examples/js-examples/intl/intl-relativetimeformat.js",
             "fileName": "intl-relativetimeformat.html",


### PR DESCRIPTION
Fixes #1652 

Assuming a runtime that supports English, Arabic (Oman), and German (Germany) but not Balinese in PluralRules.