### PR TITLE
Add live example for `accent-color` css property.

### DIFF
--- a/live-examples/css-examples/basic-user-interface/accent-color.css
+++ b/live-examples/css-examples/basic-user-interface/accent-color.css
@@ -1,4 +1,14 @@
+.container > div {
+    display: flex;
+    align-items: center;
+}
+
 #example-element {
     width: 40px;
     height: 40px;
+}
+
+#example-label {
+    margin-left: 10px;
+    font-size: x-large;
 }

--- a/live-examples/css-examples/basic-user-interface/accent-color.css
+++ b/live-examples/css-examples/basic-user-interface/accent-color.css
@@ -1,0 +1,4 @@
+#example-element {
+    width: 40px;
+    height: 40px;
+}

--- a/live-examples/css-examples/basic-user-interface/accent-color.html
+++ b/live-examples/css-examples/basic-user-interface/accent-color.html
@@ -28,7 +28,8 @@
 <div id="output" class="output hidden large">
   <section id="default-example" class="default-example container">
     <div>
-        <p><input checked type="checkbox" id="example-element"></p>
+        <input checked type="checkbox" id="example-element">
+        <label id="example-label" for="example-element">Example Label</label>
     </div>
   </section>
 </div>

--- a/live-examples/css-examples/basic-user-interface/accent-color.html
+++ b/live-examples/css-examples/basic-user-interface/accent-color.html
@@ -1,0 +1,34 @@
+<section id="example-choice-list" class="example-choice-list" data-property="accent-color">
+  <div class="example-choice">
+    <pre><code class="language-css">accent-color: red;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+  <div class="example-choice">
+    <pre><code class="language-css">accent-color: #74992e;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+  <div class="example-choice">
+    <pre><code class="language-css">accent-color: rgb(255, 255, 128);</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+  <div class="example-choice">
+    <pre><code class="language-css">accent-color: hsl(250, 100%, 34%);</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+</section>
+
+<div id="output" class="output hidden large">
+  <section id="default-example" class="default-example container">
+    <div>
+        <p><input checked type="checkbox" id="example-element"></p>
+    </div>
+  </section>
+</div>

--- a/live-examples/css-examples/basic-user-interface/meta.json
+++ b/live-examples/css-examples/basic-user-interface/meta.json
@@ -1,5 +1,12 @@
 {
     "pages": {
+        "accentColor": {
+            "cssExampleSrc": "./live-examples/css-examples/basic-user-interface/accent-color.css",
+            "exampleCode": "./live-examples/css-examples/basic-user-interface/accent-color.html",
+            "fileName": "accent-color.html",
+            "title": "CSS Demo: accent-color",
+            "type": "css"
+        },
         "appearance": {
             "exampleCode": "./live-examples/css-examples/basic-user-interface/appearance.html",
             "fileName": "appearance.html",


### PR DESCRIPTION
Added a live example of the `accent-color` property from https://drafts.csswg.org/css-ui-4/#widget-accent. To test you need Chrome 91+ with the `experimental-web-platform-features` flag enabled, or Firefox 90+ with the `layout.css.accent-color.enabled` flag enabled.

Shipping on by default in Chrome 93 and Firefox 92.