### PR TITLE
Add comment that results depend on timezone

### DIFF
--- a/live-examples/js-examples/intl/intl-datetimeformat-prototype-formatrangetoparts.js
+++ b/live-examples/js-examples/intl/intl-datetimeformat-prototype-formatrangetoparts.js
@@ -10,7 +10,7 @@ const parts = dateTimeFormat.formatRangeToParts(startDate, endDate);
 for (const part of parts) {
   console.log(part);
 }
-// expected output (in GMT timezone)
+// expected output (in GMT timezone):
 // Object { type: "hour", value: "2", source: "startRange" }
 // Object { type: "literal", value: ":", source: "startRange" }
 // Object { type: "minute", value: "00", source: "startRange" }

--- a/live-examples/js-examples/intl/intl-datetimeformat-prototype-formatrangetoparts.js
+++ b/live-examples/js-examples/intl/intl-datetimeformat-prototype-formatrangetoparts.js
@@ -10,7 +10,7 @@ const parts = dateTimeFormat.formatRangeToParts(startDate, endDate);
 for (const part of parts) {
   console.log(part);
 }
-// expected output:
+// expected output (in GMT timezone)
 // Object { type: "hour", value: "2", source: "startRange" }
 // Object { type: "literal", value: ":", source: "startRange" }
 // Object { type: "minute", value: "00", source: "startRange" }


### PR DESCRIPTION
The expected output of the [Intl.DateTimeFormat.prototype.formatRangeToParts()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatRangeToParts) example depends on the timezone in which you run the example. 

This just adds the clarification to the output: 

> expected output *(in GMT timezone)*:

This is part of https://github.com/mdn/content/issues/6710