### PR TITLE
use start and end instead of left and right for the text-align property

### DIFF
--- a/live-examples/css-examples/text/text-align.html
+++ b/live-examples/css-examples/text/text-align.html
@@ -1,13 +1,13 @@
 <section id="example-choice-list" class="example-choice-list" data-property="textAlign">
 <div class="example-choice">
-<pre><code class="language-css">text-align: left;</code></pre>
+<pre><code class="language-css">text-align: start;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
 </div>
 
 <div class="example-choice">
-<pre><code class="language-css">text-align: right;</code></pre>
+<pre><code class="language-css">text-align: end;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>


### PR DESCRIPTION
A small fix based on this content issue: https://github.com/mdn/content/issues/7295