### PR TITLE
CONTRIBUTING - suggest running yarn test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,11 +83,14 @@ Point your browser to either of those URLs, then click on the `pages` link. In t
 -   JavaScript examples are under `js`
 -   HTML examples are under `tabbed`
 
-Find your example and try it out. Once you're satisfied, the final step is to confirm that your change passes the same automatic tests that will be run by our continuous integration system.
-```
-yarn test
-```
-If the tests pass, [submit your pull request](https://help.github.com/articles/creating-a-pull-request/).
+Find your example and try it out.
+
+> **Note** On Linux, you might also run the automatic tests used by our continuous integration system.
+>  ```
+>  yarn test
+>  ```
+
+Once you're satisfied, the final step is to [submit your pull request](https://help.github.com/articles/creating-a-pull-request/).
 
 ## Publishing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,11 @@ Point your browser to either of those URLs, then click on the `pages` link. In t
 -   JavaScript examples are under `js`
 -   HTML examples are under `tabbed`
 
-Find your example and try it out. Once you're satisfied, [submit your pull request](https://help.github.com/articles/creating-a-pull-request/).
+Find your example and try it out. Once you're satisfied, the final step is to confirm that your change passes the same automatic tests that will be run by our continuous integration system.
+```
+yarn test
+```
+If the tests pass, [submit your pull request](https://help.github.com/articles/creating-a-pull-request/).
 
 ## Publishing
 


### PR DESCRIPTION
Perfectly valid javascript can still fail to merge due to the linter - that will, for example, cause a fail based on snake rather than camel case for property names. This suggests running `yarn test` before submitting to CI. We might perhaps instead/as well point to linter rules, but this is easier. 

Note, this actually doesn't work well on Windows, which gives you lots of spurious line ending related errors. 