### PR TITLE
“accumulator”→“previousValue” in array-reduce.js live example

### DIFF
--- a/live-examples/js-examples/array/array-reduce.js
+++ b/live-examples/js-examples/array/array-reduce.js
@@ -1,5 +1,5 @@
 const array1 = [1, 2, 3, 4];
-const reducer = (accumulator, currentValue) => accumulator + currentValue;
+const reducer = (previousValue, currentValue) => previousValue + currentValue;
 
 // 1 + 2 + 3 + 4
 console.log(array1.reduce(reducer));


### PR DESCRIPTION
For consistency with https://github.com/mdn/content/commit/260094b changes (https://github.com/mdn/content/pull/7484), this change replaces the variable name `accumulator` with `previousValue` in the `live-examples/js-examples/array/array-reduce.js` live-example source.

Cc @hamishwillee