### PR TITLE
Add position fixed example

### DIFF
--- a/live-examples/css-examples/positioned-layout/position.html
+++ b/live-examples/css-examples/positioned-layout/position.html
@@ -22,6 +22,15 @@ top: 40px; left: 40px;</code></pre>
         </button>
     </div>
 
+
+    <div class="example-choice">
+        <pre><code class="language-css">position: fixed;
+top: 164px;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
     <div id="choice-sticky" class="example-choice">
         <pre><code class="language-css">position: -webkit-sticky;
 position: sticky;
@@ -43,7 +52,7 @@ top: 20px;</code></pre>
             <p>The element will scroll along with its container, until it is at the top of the container (or reaches the offset specified in <code>top</code>), and will then stop scrolling, so it stays visible.</p>
             <p>The rest of this text is only supplied to make sure the container overflows, so as to enable you to scroll it and see the effect.</p>
             <hr/>
-            <p>Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a small unregarded yellow sun. Orbiting this at a distance of roughly ninety-two million miles is an utterly insignificant little blue green planet whose ape-descended life forms are so amazingly primitive that they still think digital watches are a pretty neat idea.</p> 
+            <p>Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a small unregarded yellow sun. Orbiting this at a distance of roughly ninety-two million miles is an utterly insignificant little blue green planet whose ape-descended life forms are so amazingly primitive that they still think digital watches are a pretty neat idea.</p>
         </div>
     </section>
 </div>


### PR DESCRIPTION
Hello. 
At page https://developer.mozilla.org/en-US/docs/Web/CSS/position at interactive example there was no `position: fixed;`.
Hope it fits well in iframe and page. Because I didn't check locally with full setup by `mdn/yari`.
.env with INTERACTIVE_EXAMPLES_BASE_URL didn't help to point iframe to the localhost.