### PR TITLE
Fix moon landing date

### DIFF
--- a/live-examples/js-examples/date/date-gettime.js
+++ b/live-examples/js-examples/date/date-gettime.js
@@ -1,5 +1,5 @@
-const moonLanding = new Date('July 20, 69 00:20:18 GMT+00:00');
+const moonLanding = new Date('July 20, 69 20:17:40 GMT+00:00');
 
 // milliseconds since Jan 1, 1970, 00:00:00.000 GMT
 console.log(moonLanding.getTime());
-// expected output: -14254782000
+// expected output: -14182940000


### PR DESCRIPTION
Fixes mdn/content#8831

(Note this really is the UTC time and not the GMT one, but it will add confusion to translate it (UTC and GMT are off by a few seconds)