### PR TITLE
classes-static: Show class static initialization block

### DIFF
--- a/live-examples/js-examples/classes/classes-static.js
+++ b/live-examples/js-examples/classes/classes-static.js
@@ -4,7 +4,9 @@ class ClassWithStaticMethod {
   static staticMethod() {
     return 'static method has been called.';
   }
-
+  static {  
+    console.log("Static initialization block called");
+  }
 }
 
 console.log(ClassWithStaticMethod.staticProperty);


### PR DESCRIPTION
This is the example on the https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static page showing use of class static methods and properties (public only). 

As this page is about the `static` *keyword* IMO it is important to at least mention the other use of the keyword (and show it's use) here - class static initialization block. 

I will probably do a more extensive example separately and link to it.

related to: https://github.com/mdn/content/issues/8606