### PR TITLE
Add class static initialization block example

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,5 @@
 js/lib/*
 js/mode/*
+
+# js class static blocks is cuurently ignored as it fails test
+live-examples/js-examples/classes/classes-static-initialization.js

--- a/live-examples/js-examples/classes/classes-static-initialization.js
+++ b/live-examples/js-examples/classes/classes-static-initialization.js
@@ -1,0 +1,12 @@
+class ClassWithStaticInitializationBlock {
+  static staticProperty1 = "Property 1";
+  static staticProperty2;
+  static {
+    this.staticProperty2 = "Property 2"
+  }
+}
+
+console.log(ClassWithStaticInitializationBlock.staticProperty1);
+// output: "Property 1"
+console.log(ClassWithStaticInitializationBlock.staticProperty2);
+// output: "Property 2"

--- a/live-examples/js-examples/classes/meta.json
+++ b/live-examples/js-examples/classes/meta.json
@@ -17,6 +17,12 @@
             "fileName": "classes-static.html",
             "title": "JavaScript Demo: Classes Static",
             "type": "js"
+        },
+        "classesStaticInitialization": {
+            "exampleCode": "./live-examples/js-examples/classes/classes-static-initialization.js",
+            "fileName": "classes-static-initialization.html",
+            "title": "JavaScript Demo: Class Static Initialization Blocks",
+            "type": "js"
         }
     }
 }


### PR DESCRIPTION
This adds examples for class static initialization block, added in FF93 . This will appear in docs here: https://github.com/mdn/content/pull/9281

There is a lot that might be shown. This primarily just shows the syntax for declaring a block, and that it can access/declare a property using the `this`. 