### PR TITLE
Throw in catch statement to show .finally dynamics

### DIFF
--- a/live-examples/js-examples/promise/promise-finally.js
+++ b/live-examples/js-examples/promise/promise-finally.js
@@ -13,7 +13,7 @@ checkMail()
     console.log(mail);
   })
   .catch((err) => {
-    console.error(err);
+    throw new Error('Error from within catch block');
   })
   .finally(() => {
     console.log('Experiment completed');


### PR DESCRIPTION
Simply logging in the catch block doesn't show any difference between .finally  and .then  (both producing the same behaviour regardless what we use in line 18.)