### PR TITLE
change examples for Remainder operator to use 13 instead of 12

### DIFF
--- a/live-examples/js-examples/expressions/expressions-remainder.js
+++ b/live-examples/js-examples/expressions/expressions-remainder.js
@@ -1,7 +1,7 @@
-console.log(12 % 5);
+console.log(13 % 5);
 // expected output: 2
 
-console.log(-12 % 5);
+console.log(-13 % 5);
 // expected output: -2
 
 console.log(4 % 2);


### PR DESCRIPTION
Also see https://github.com/mdn/content/pull/10290

using 12%5 to explain how the remainder operator works to some of my coding students was confusing for them since the result of integer division `12 / 5` is *also* 2. I explained that `12 / 5` is 2 with a remainder of 2, so `12 % 2 === 2`. Many of them mistakenly thought that that `%` was just an integer division.

I think using 13 in the example would reduce the confusion since the result of integer division  `13 / 2` (2) is different from the remainder (3).

@wbamberg