### PR TITLE
Remove styling for anchor example

### DIFF
--- a/live-examples/html-examples/inline-text-semantics/css/a.css
+++ b/live-examples/html-examples/inline-text-semantics/css/a.css
@@ -1,15 +1,3 @@
-a[href^="https"]::before {
-  content: "🔗 ";
-}
-
-a[href^="mailto"]::before {
-  content: "📧 ";
-}
-
-a[href^="tel"]::before {
-  content: "📞 ";
-}
-
 li {
   margin-bottom: .5rem;
 }


### PR DESCRIPTION
In https://github.com/mdn/content/issues/10459 someone was confused that after removing all the content from the links the icons still showed up in the example. I agree that this is confusing and suggest we remove the `::before` style so we just show the default behavior.

