### PR TITLE
Remove deprecated type attribute from style element example

### DIFF
--- a/live-examples/html-examples/document-metadata/style.html
+++ b/live-examples/html-examples/document-metadata/style.html
@@ -1,7 +1,9 @@
-<style type="text/css">
+<style>
 p {
   color: #26b72b;
 }
 </style>
+
 <p>This text will be green. Inline styles take precedence over CSS included externally.</p>
+
 <p style="color: blue">The <code>style</code> attribute can override it, though.</p>


### PR DESCRIPTION
Fixes https://github.com/mdn/interactive-examples/issues/1957.