### PR TITLE
Update ESLint config for version 8

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,2 @@
 js/lib/*
 js/mode/*
-
-# js class static blocks is currently ignored as it fails test
-live-examples/js-examples/classes/classes-static-initialization.js
-live-examples/js-examples/classes/classes-static.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -227,13 +227,6 @@
             }
         },
         {
-            // Only until the "d" flag is supported by eslint.
-            "files": ["**/regexp/regexp-prototype-hasindices.js"],
-            "rules": {
-                "no-invalid-regexp": "warn"
-            }
-        },
-        {
             "files": ["**/set/set-prototype-foreach.js"],
             "rules": {
                 "no-unused-vars": "off"

--- a/live-examples/js-examples/classes/classes-static-initialization.js
+++ b/live-examples/js-examples/classes/classes-static-initialization.js
@@ -1,8 +1,8 @@
 class ClassWithStaticInitializationBlock {
-  static staticProperty1 = "Property 1";
+  static staticProperty1 = 'Property 1';
   static staticProperty2;
   static {
-    this.staticProperty2 = "Property 2"
+    this.staticProperty2 = 'Property 2';
   }
 }
 

--- a/live-examples/js-examples/classes/classes-static.js
+++ b/live-examples/js-examples/classes/classes-static.js
@@ -3,8 +3,8 @@ class ClassWithStaticMethod {
   static staticMethod() {
     return 'static method has been called.';
   }
-  static {  
-    console.log("Class static initialization block called");
+  static {
+    console.log('Class static initialization block called');
   }
 }
 


### PR DESCRIPTION
Now we have ESLint 8 (thanks @schalkneethling ) we should be able to unpick some of the tweaks we had to make:

* undo changes to stop ESLint complaining about static classes, now it supports them (fixes https://github.com/mdn/interactive-examples/issues/1922)
* fix actual lint errors in those examples
* undo https://github.com/mdn/interactive-examples/pull/1798 now ESLint supports `hasIndices`