### PR TITLE
Fix nesting depth in Array.prototype.flat example

### DIFF
--- a/live-examples/js-examples/array/array-flat.js
+++ b/live-examples/js-examples/array/array-flat.js
@@ -3,7 +3,12 @@ const arr1 = [0, 1, 2, [3, 4]];
 console.log(arr1.flat());
 // Expected output: Array [0, 1, 2, 3, 4]
 
-const arr2 = [0, 1, 2, [[3, 4]]];
+const arr2 = [0, 1, [2, [3, [4, 5]]]];
 
+// flatten with default depth 1
+console.log(arr2.flat());
+// expected output: Array [0, 1, 2, Array [3, Array [4, 5]]]
+
+// flatten with depth 2 (same as calling .flat() two times)
 console.log(arr2.flat(2));
-// Expected output: Array [0, 1, 2, Array [3, 4]]
+// expected output: Array [0, 1, 2, 3, Array [4, 5]]

--- a/live-examples/js-examples/array/array-flat.js
+++ b/live-examples/js-examples/array/array-flat.js
@@ -1,14 +1,15 @@
 const arr1 = [0, 1, 2, [3, 4]];
 
 console.log(arr1.flat());
-// Expected output: Array [0, 1, 2, 3, 4]
+// expected output: Array [0, 1, 2, 3, 4]
 
 const arr2 = [0, 1, [2, [3, [4, 5]]]];
 
-// flatten with default depth 1
 console.log(arr2.flat());
 // expected output: Array [0, 1, 2, Array [3, Array [4, 5]]]
 
-// flatten with depth 2 (same as calling .flat() two times)
 console.log(arr2.flat(2));
 // expected output: Array [0, 1, 2, 3, Array [4, 5]]
+
+console.log(arr2.flat(Infinity));
+// expected output: Array [0, 1, 2, 3, 4, 5]

--- a/live-examples/js-examples/array/array-flat.js
+++ b/live-examples/js-examples/array/array-flat.js
@@ -3,7 +3,7 @@ const arr1 = [0, 1, 2, [3, 4]];
 console.log(arr1.flat());
 // Expected output: Array [0, 1, 2, 3, 4]
 
-const arr2 = [0, 1, 2, [[[3, 4]]]];
+const arr2 = [0, 1, 2, [[3, 4]]];
 
 console.log(arr2.flat(2));
 // Expected output: Array [0, 1, 2, Array [3, 4]]


### PR DESCRIPTION
Nesting is reduced one level by array.flat. I have removed one level of nesting from the input to fix the semantics and at the same time make it more readable, while still illustrating the point.