### PR TITLE
🔥 Retire firefox vendor prefix from example

### DIFF
--- a/live-examples/css-examples/text/tab-size.html
+++ b/live-examples/css-examples/text/tab-size.html
@@ -1,32 +1,28 @@
-<section id="example-choice-list" class="example-choice-list large" data-property="tabSize -moz-tab-size">
+<section id="example-choice-list" class="example-choice-list large" data-property="tabSize">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">-moz-tab-size: 10px;
-tab-size: 10px;</code></pre>
+        <pre><code class="language-css">tab-size: 10px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">-moz-tab-size: 16px;
-tab-size: 16px;</code></pre>
+        <pre><code class="language-css">tab-size: 16px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">-moz-tab-size: 24px;
-tab-size: 24px;</code></pre>
+        <pre><code class="language-css">tab-size: 24px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">-moz-tab-size: 4;
-tab-size: 4;</code></pre>
+        <pre><code class="language-css">tab-size: 4;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/text/tab-size.html
+++ b/live-examples/css-examples/text/tab-size.html
@@ -1,32 +1,32 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="tabSize -moz-tab-size">
 
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">tab-size: 10px;
--moz-tab-size: 10px;</code></pre>
+        <pre><code class="language-css">-moz-tab-size: 10px;
+tab-size: 10px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">tab-size: 16px;
--moz-tab-size: 16px;</code></pre>
+        <pre><code class="language-css">-moz-tab-size: 16px;
+tab-size: 16px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">tab-size: 24px;
--moz-tab-size: 24px;</code></pre>
+        <pre><code class="language-css">-moz-tab-size: 24px;
+tab-size: 24px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">tab-size: 4;
--moz-tab-size: 4;</code></pre>
+        <pre><code class="language-css">-moz-tab-size: 4;
+tab-size: 4;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>


### PR DESCRIPTION
### Summary

Moves up the vendor prefix `-moz-tab-size` so that the main property gets applied if it is supported by the browser.

