### PR TITLE
Update hasOwn example for readability

### DIFF
--- a/live-examples/js-examples/object/object-hasown.js
+++ b/live-examples/js-examples/object/object-hasown.js
@@ -1,13 +1,12 @@
-const object1 = {};
-object1.prop = 'exists';
-if (Object.hasOwn(object1, 'prop')) {
-  console.log('\'prop\' is own property'); // expected output: 'prop' is own property
-}
-// Property values can be null or undefined
-object1.nullPropertyValue = null;
-console.log(Object.hasOwn(object1, 'nullPropertyValue'));  // expected output: true
-object1.undefinedPropertyValue = undefined;
-console.log(Object.hasOwn(object1, 'undefinedPropertyValue'));  // expected output: true
-// Inherited and undeclared values return false
-console.log(Object.hasOwn(object1, 'toString'));  // expected output: false (inherited)
-console.log(Object.hasOwn(object1, 'undeclaredPropertyValue'));  // expected output: false (not declared)
+const object1 = {
+  prop: 'exists'
+};
+
+console.log(Object.hasOwn(object1, 'prop'));
+// expected output: true
+
+console.log(Object.hasOwn(object1, 'toString'));
+// expected output: false
+
+console.log(Object.hasOwn(object1, 'undeclaredPropertyValue'));
+// expected output: false


### PR DESCRIPTION
Looking at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn , I thought the example has some consistency and readability issues:

* no whitespace between parts of the example
* extra conditional instead of a more concise `console.log()` statement
* extra comments: it's a general policy for examples to "show, not tell". They appear in a documentation page that explains all about the feature in prose. It's better for the example just to be a usage example
* `expected output` should be on the next line and exactly match the expected output with nothing extra
* edge cases: this is arguable but: it's much better if the examples can fit inside 12 lines, so they get the medium-sized editor. It's only really desirable to have a bigger example if it's just not possible to craft a usable example inside 12 lines. Here, the example exceeds 12 lines because it's covering what I'd suggest are edge cases for the API. We don't need to cover these in the interactive example: it is supposed to cover the main usages as simply as possible, and can defer the details to the rest of the page.

This PR rewrites the example to be easier to read and more consistent.