### PR TITLE
Add an example of slice without arguments

### DIFF
--- a/live-examples/js-examples/array/array-slice.js
+++ b/live-examples/js-examples/array/array-slice.js
@@ -14,3 +14,6 @@ console.log(animals.slice(-2));
 
 console.log(animals.slice(2, -1));
 // expected output: Array ["camel", "duck"]
+
+console.log(animals.slice());
+// expected output: Array ["ant", "bison", "camel", "duck", "elephant"]


### PR DESCRIPTION
Adding a `slice()` example to demonstrate a full shallow copy of the array.