### PR TITLE
Improve Array.prototype.reduce intro example

### DIFF
--- a/live-examples/js-examples/array/array-reduce.js
+++ b/live-examples/js-examples/array/array-reduce.js
@@ -1,19 +1,19 @@
 const array1 = [1, 2, 3, 4];
 
 // 1 + 2 + 3 + 4
-const result = array1.reduce(
+const sum = array1.reduce(
   (previousValue, currentValue) => previousValue + currentValue
 );
 
-console.log(result);
+console.log(sum);
 // expected output: 10
 
 // 5 + 1 + 2 + 3 + 4
 const initialValue = 5;
-const resultWithInitial = array1.reduce(
+const sumWithInitial = array1.reduce(
   (previousValue, currentValue) => previousValue + currentValue,
   initialValue
 );
 
-console.log(resultWithInitial);
+console.log(sumWithInitial);
 // expected output: 15

--- a/live-examples/js-examples/array/array-reduce.js
+++ b/live-examples/js-examples/array/array-reduce.js
@@ -1,10 +1,17 @@
-const array1 = [1, 2, 3, 4];
-const reducer = (previousValue, currentValue) => previousValue + currentValue;
+const myArray = [1, 2, 3, 4];
 
 // 1 + 2 + 3 + 4
-console.log(array1.reduce(reducer));
+const result = myArray.reduce(
+  (previousValue, currentValue) => previousValue + currentValue
+);
+console.log(result);
 // expected output: 10
 
 // 5 + 1 + 2 + 3 + 4
-console.log(array1.reduce(reducer, 5));
+const initialValue = 5;
+const resultWithInitial = myArray.reduce(
+  (previousValue, currentValue) => previousValue + currentValue,
+  initialValue
+);
+console.log(resultWithInitial);
 // expected output: 15

--- a/live-examples/js-examples/array/array-reduce.js
+++ b/live-examples/js-examples/array/array-reduce.js
@@ -1,17 +1,19 @@
-const myArray = [1, 2, 3, 4];
+const array1 = [1, 2, 3, 4];
 
 // 1 + 2 + 3 + 4
-const result = myArray.reduce(
+const result = array1.reduce(
   (previousValue, currentValue) => previousValue + currentValue
 );
+
 console.log(result);
 // expected output: 10
 
 // 5 + 1 + 2 + 3 + 4
 const initialValue = 5;
-const resultWithInitial = myArray.reduce(
+const resultWithInitial = array1.reduce(
   (previousValue, currentValue) => previousValue + currentValue,
   initialValue
 );
+
 console.log(resultWithInitial);
 // expected output: 15

--- a/live-examples/js-examples/array/array-reduce.js
+++ b/live-examples/js-examples/array/array-reduce.js
@@ -1,6 +1,6 @@
 const array1 = [1, 2, 3, 4];
 
-// 5 + 1 + 2 + 3 + 4
+// 0 + 1 + 2 + 3 + 4
 const initialValue = 0;
 const sumWithInitial = array1.reduce(
   (previousValue, currentValue) => previousValue + currentValue,

--- a/live-examples/js-examples/array/array-reduce.js
+++ b/live-examples/js-examples/array/array-reduce.js
@@ -1,19 +1,11 @@
 const array1 = [1, 2, 3, 4];
 
-// 1 + 2 + 3 + 4
-const sum = array1.reduce(
-  (previousValue, currentValue) => previousValue + currentValue
-);
-
-console.log(sum);
-// expected output: 10
-
 // 5 + 1 + 2 + 3 + 4
-const initialValue = 5;
+const initialValue = 0;
 const sumWithInitial = array1.reduce(
   (previousValue, currentValue) => previousValue + currentValue,
   initialValue
 );
 
 console.log(sumWithInitial);
-// expected output: 15
+// expected output: 10


### PR DESCRIPTION
Goal: `reduce` is often a confusing method for new learners, and we hope that this more explicit example will help build understanding.

Other array methods (`map`, `sort`, `filter`, `forEach`) all use inline arrow functions for their intro examples, but reduce does not. This PR makes the first example shown for `reduce`  follow that same convention. It also uses variable naming to communicate what has changed between the two examples.

The downside of this change is that the example is longer, but we think it's easier to understand now for beginners.

**Alternatives considered**

Examples would be shorter and more readable if we dropped `Value` from the parameter names (`currentValue` becomes `current`). However, that would not match the rest of the page's prose and examples, so we left the variable names as they were.

There are some other improvements to the page that we are brainstorming, and will open an issue for those.

Co-authored-by: [Kennie Boulin](Kennie-create)