### PR TITLE
Remove use of Number.parseFloat in toPrecision example

### DIFF
--- a/live-examples/js-examples/number/number-toprecision.js
+++ b/live-examples/js-examples/number/number-toprecision.js
@@ -1,5 +1,5 @@
 function precise(x) {
-  return Number.parseFloat(x).toPrecision(4);
+  return x.toPrecision(4);
 }
 
 console.log(precise(123.456));
@@ -8,5 +8,5 @@ console.log(precise(123.456));
 console.log(precise(0.004));
 // expected output: "0.004000"
 
-console.log(precise('1.23e+5'));
+console.log(precise(1.23e5));
 // expected output: "1.230e+5"


### PR DESCRIPTION
Number.parseFloat here serves only to distract from the use of toPrecision.