### PR TITLE
Remove aria-label from search input example

### DIFF
--- a/live-examples/html-examples/input/search.html
+++ b/live-examples/html-examples/input/search.html
@@ -1,5 +1,4 @@
 <label for="site-search">Search the site:</label>
-<input type="search" id="site-search" name="q"
-       aria-label="Search through site content">
+<input type="search" id="site-search" name="q">
 
 <button>Search</button>


### PR DESCRIPTION
The `aria-label` overrides the label text as the input's accessible name. It doesn't make sense to use ARIA here (cf. the first rule of ARIA).