### PR TITLE
Fix Wasm trunc example

### DIFF
--- a/live-examples/wat-examples/numeric/trunc.wat
+++ b/live-examples/wat-examples/numeric/trunc.wat
@@ -3,7 +3,7 @@
   (func $main
 
     f32.const -2.7 ;; load a number onto the stack
-    f32.ceil ;; discard everything after the decimal point
+    f32.trunc ;; discard everything after the decimal point
     call $log ;; log the result
 
   )


### PR DESCRIPTION
- While browsing the [Truncate docs on MDN](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Numeric/Truncate), I noticed that the example was not calling `f32.trunc`, but rather it was calling `f32.ceil`
- This pull request simply fixes the call