### PR TITLE
Fixed text color in dark mode for CSS border

### DIFF
--- a/live-examples/css-examples/backgrounds-and-borders/border-bottom.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-bottom.html
@@ -29,7 +29,7 @@
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">border-bottom: 4mm ridge rgb(170, 50, 220, .6);</code></pre>
+        <pre><code class="language-css">border-bottom: 4mm ridge rgba(211, 220, 50, .6);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-color.css
+++ b/live-examples/css-examples/backgrounds-and-borders/border-color.css
@@ -1,5 +1,6 @@
 #example-element {
     background-color: #eee;
+    color: #000;
     border: .75em solid;
     padding: .75em;
     width: 80%;

--- a/live-examples/css-examples/backgrounds-and-borders/border-image.css
+++ b/live-examples/css-examples/backgrounds-and-borders/border-image.css
@@ -6,6 +6,7 @@
     justify-content: center;
     padding: 50px;
     background: #fff3d4;
+    color: #000;
     border: 30px solid;
     border-image: url('/media/examples/border-diamonds.png') 30 round;
     font-size: 1.2em;

--- a/live-examples/css-examples/backgrounds-and-borders/border-left.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-left.html
@@ -29,7 +29,7 @@
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">border-left: 4mm ridge rgb(170, 50, 220, .6);</code></pre>
+        <pre><code class="language-css">border-left: 4mm ridge rgba(211, 220, 50, .6);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-right.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-right.html
@@ -29,7 +29,7 @@
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">border-right: 4mm ridge rgb(170, 50, 220, .6);</code></pre>
+        <pre><code class="language-css">border-right: 4mm ridge rgba(211, 220, 50, .6);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-style.css
+++ b/live-examples/css-examples/backgrounds-and-borders/border-style.css
@@ -1,5 +1,7 @@
 #example-element {
     background-color: #eee;
+    color: #000;
+    border-color: #a52a2a;
     border: .75em solid;
     padding: .75em;
     width: 80%;

--- a/live-examples/css-examples/backgrounds-and-borders/border-top.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-top.html
@@ -29,7 +29,7 @@
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">border-top: 4mm ridge rgb(170, 50, 220, .6);</code></pre>
+        <pre><code class="language-css">border-top: 4mm ridge rgba(211, 220, 50, .6);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-width.css
+++ b/live-examples/css-examples/backgrounds-and-borders/border-width.css
@@ -1,5 +1,6 @@
 #example-element {
     background-color: palegreen;
+    color: #000;
     border: 0 solid crimson;
     padding: .75em;
     width: 80%;

--- a/live-examples/css-examples/backgrounds-and-borders/border.css
+++ b/live-examples/css-examples/backgrounds-and-borders/border.css
@@ -1,5 +1,6 @@
 #example-element {
     background-color: #eee;
+    color: #8b008b;
     padding: .75em;
     width: 80%;
     height: 100px;

--- a/live-examples/css-examples/backgrounds-and-borders/border.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border.html
@@ -29,7 +29,7 @@
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">border: 4mm ridge rgba(170, 50, 220, .6);</code></pre>
+        <pre><code class="language-css">border: 4mm ridge rgba(211, 220, 50, .6);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/logical-properties/border-color.css
+++ b/live-examples/css-examples/logical-properties/border-color.css
@@ -1,5 +1,6 @@
 #example-element {
     background-color: #eee;
+    color: #000;
     border: .75em solid;
     padding: .75em;
     width: 80%;

--- a/live-examples/css-examples/logical-properties/border-style.css
+++ b/live-examples/css-examples/logical-properties/border-style.css
@@ -1,5 +1,7 @@
 #example-element {
     background-color: #eee;
+    color: #000;
+    border-color: #a52a2a;
     border: .75em solid;
     padding: .75em;
     width: 80%;

--- a/live-examples/css-examples/logical-properties/border-width.css
+++ b/live-examples/css-examples/logical-properties/border-width.css
@@ -1,5 +1,6 @@
 #example-element {
     background-color: palegreen;
+    color: #000;
     border: 0 solid crimson;
     padding: .75em;
     width: 80%;

--- a/live-examples/css-examples/logical-properties/border.css
+++ b/live-examples/css-examples/logical-properties/border.css
@@ -1,5 +1,6 @@
 #example-element {
     background-color: #eee;
+    color: #8b008b;
     padding: .75em;
     width: 80%;
     height: 100px;


### PR DESCRIPTION
I have made changes to most of CSS border properties, to fix their visibility on new Dark Theme.

In border-color, border-image & border-width, text is now black.
In border-style properties, text color is now black and border-color is brown.
In border shorthands, text color and default border color is now darkmagenta, border-color of last example was changed from violet to lemon.