### PR TITLE
Fix for box-shadow in Dark Mode

### DIFF
--- a/live-examples/css-examples/backgrounds-and-borders/box-shadow.css
+++ b/live-examples/css-examples/backgrounds-and-borders/box-shadow.css
@@ -1,5 +1,4 @@
 #example-element {
-    color: #333;
     margin: 20px auto;
     padding: 0;
     border: 2px solid #333;


### PR DESCRIPTION
Now text is visible in both dark and light mode.
It was reported in Issue ~~#2031~~ #2032

Fixes #2032.