### PR TITLE
Fix for white-space in Dark Mode

### DIFF
--- a/live-examples/css-examples/text/white-space.css
+++ b/live-examples/css-examples/text/white-space.css
@@ -3,7 +3,7 @@
 }
 
 #example-element p {
-  background-color: #eee;
+  border: 1px solid #c5c5c5;
   padding: .75rem;
   text-align: left;
 }


### PR DESCRIPTION
Fixes #2031 by setting border instead of background. All examples are now clearly visible in both light and dark mode.