### PR TITLE
Fix for text-overflow in Dark Mode

### DIFF
--- a/live-examples/css-examples/basic-user-interface/text-overflow.css
+++ b/live-examples/css-examples/basic-user-interface/text-overflow.css
@@ -5,7 +5,7 @@
 
 #example-element {
     line-height: 50px;
-    background-color: #E5E8FC;
+    border: 1px solid #c5c5c5;
     overflow: hidden;
     white-space: nowrap;
     font-family: sans-serif;


### PR DESCRIPTION
text-overflow should now be visible in both dark and light mode. It was reported in #2031 and #2030