### PR TITLE
Fix Dark Mode in grid, flexbox & box-alignment properties

### DIFF
--- a/live-examples/css-examples/box-alignment/align-content.css
+++ b/live-examples/css-examples/box-alignment/align-content.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 60px 60px;
     grid-auto-rows: 40px;

--- a/live-examples/css-examples/box-alignment/align-items.css
+++ b/live-examples/css-examples/box-alignment/align-items.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     width: 200px;
     grid-template-columns: 1fr 1fr;

--- a/live-examples/css-examples/box-alignment/align-self.css
+++ b/live-examples/css-examples/box-alignment/align-self.css
@@ -1,7 +1,5 @@
 .example-container {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     width: 200px;
     grid-template-columns: 1fr 1fr;

--- a/live-examples/css-examples/box-alignment/column-gap.css
+++ b/live-examples/css-examples/box-alignment/column-gap.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1fr;
     width: 200px;

--- a/live-examples/css-examples/box-alignment/gap.css
+++ b/live-examples/css-examples/box-alignment/gap.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1fr;
     width: 200px;

--- a/live-examples/css-examples/box-alignment/justify-content.css
+++ b/live-examples/css-examples/box-alignment/justify-content.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     width: 220px;
     display: grid;
     grid-template-columns: 60px 60px;

--- a/live-examples/css-examples/box-alignment/justify-items.css
+++ b/live-examples/css-examples/box-alignment/justify-items.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-auto-rows: 40px;

--- a/live-examples/css-examples/box-alignment/justify-self.css
+++ b/live-examples/css-examples/box-alignment/justify-self.css
@@ -1,7 +1,5 @@
 .example-container {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     width: 220px;
     grid-template-columns: 1fr 1fr;

--- a/live-examples/css-examples/box-alignment/place-content.css
+++ b/live-examples/css-examples/box-alignment/place-content.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 60px 60px;
     grid-auto-rows: 40px;

--- a/live-examples/css-examples/box-alignment/place-items.css
+++ b/live-examples/css-examples/box-alignment/place-items.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-auto-rows: 80px;

--- a/live-examples/css-examples/box-alignment/place-self.css
+++ b/live-examples/css-examples/box-alignment/place-self.css
@@ -1,7 +1,5 @@
 .example-container {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     width: 220px;
     grid-template-columns: 1fr 1fr;

--- a/live-examples/css-examples/box-alignment/row-gap.css
+++ b/live-examples/css-examples/box-alignment/row-gap.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1fr;
     width: 200px;

--- a/live-examples/css-examples/flexbox/flex-basis.css
+++ b/live-examples/css-examples/flexbox/flex-basis.css
@@ -1,7 +1,5 @@
 .default-example {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     width: auto;
     max-height: 300px;
     display: flex;

--- a/live-examples/css-examples/flexbox/flex-direction.css
+++ b/live-examples/css-examples/flexbox/flex-direction.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     width: 80%;
     display: flex;
 }

--- a/live-examples/css-examples/flexbox/flex-flow.css
+++ b/live-examples/css-examples/flexbox/flex-flow.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     width: 80%;
     max-height: 300px;
     display: flex;

--- a/live-examples/css-examples/flexbox/flex-grow.css
+++ b/live-examples/css-examples/flexbox/flex-grow.css
@@ -1,7 +1,5 @@
 .default-example {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     width: auto;
     max-height: 300px;
     display: flex;

--- a/live-examples/css-examples/flexbox/flex-shrink.css
+++ b/live-examples/css-examples/flexbox/flex-shrink.css
@@ -1,7 +1,5 @@
 .default-example {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     width: auto;
     max-height: 300px;
     display: flex;

--- a/live-examples/css-examples/flexbox/flex-wrap.css
+++ b/live-examples/css-examples/flexbox/flex-wrap.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     width: 80%;
     display: flex;
 }

--- a/live-examples/css-examples/flexbox/flex.css
+++ b/live-examples/css-examples/flexbox/flex.css
@@ -1,7 +1,5 @@
 .default-example {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     width: auto;
     max-height: 300px;
     display: flex;

--- a/live-examples/css-examples/flexbox/order.css
+++ b/live-examples/css-examples/flexbox/order.css
@@ -1,8 +1,4 @@
 .default-example {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
-    width: 80%;
     max-height: 300px;
     display: flex;
 }

--- a/live-examples/css-examples/grid/function-fit-content.css
+++ b/live-examples/css-examples/grid/function-fit-content.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-gap: 10px;
     width: 250px;

--- a/live-examples/css-examples/grid/function-minmax.css
+++ b/live-examples/css-examples/grid/function-minmax.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-gap: 10px;
     width: 250px;

--- a/live-examples/css-examples/grid/function-repeat.css
+++ b/live-examples/css-examples/grid/function-repeat.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-auto-rows: 40px;
     grid-gap: 10px;

--- a/live-examples/css-examples/grid/grid-area.css
+++ b/live-examples/css-examples/grid/grid-area.css
@@ -1,7 +1,5 @@
 .example-container {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
     grid-template-rows: repeat(3, minmax(40px, auto));

--- a/live-examples/css-examples/grid/grid-auto-columns.css
+++ b/live-examples/css-examples/grid/grid-auto-columns.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-auto-rows: 40px;
     grid-gap: 10px;

--- a/live-examples/css-examples/grid/grid-auto-flow.css
+++ b/live-examples/css-examples/grid/grid-auto-flow.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
     grid-template-rows: repeat(3, minmax(40px, auto));

--- a/live-examples/css-examples/grid/grid-auto-rows.css
+++ b/live-examples/css-examples/grid/grid-auto-rows.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-auto-rows: 40px;

--- a/live-examples/css-examples/grid/grid-column-end.css
+++ b/live-examples/css-examples/grid/grid-column-end.css
@@ -1,7 +1,5 @@
 .example-container {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1.5fr 1fr;
     grid-template-rows: repeat(3, minmax(40px, auto));

--- a/live-examples/css-examples/grid/grid-column-start.css
+++ b/live-examples/css-examples/grid/grid-column-start.css
@@ -1,7 +1,5 @@
 .example-container {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1.5fr 1fr;
     grid-template-rows: repeat(3, minmax(40px, auto));

--- a/live-examples/css-examples/grid/grid-column.css
+++ b/live-examples/css-examples/grid/grid-column.css
@@ -1,7 +1,5 @@
 .example-container {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1.5fr 1fr;
     grid-template-rows: repeat(3, minmax(40px, auto));

--- a/live-examples/css-examples/grid/grid-row-end.css
+++ b/live-examples/css-examples/grid/grid-row-end.css
@@ -1,7 +1,5 @@
 .example-container {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1.5fr 1fr;
     grid-template-rows: repeat(3, minmax(40px, auto));

--- a/live-examples/css-examples/grid/grid-row-start.css
+++ b/live-examples/css-examples/grid/grid-row-start.css
@@ -1,7 +1,5 @@
 .example-container {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1.5fr 1fr;
     grid-template-rows: repeat(3, minmax(40px, auto));

--- a/live-examples/css-examples/grid/grid-row.css
+++ b/live-examples/css-examples/grid/grid-row.css
@@ -1,7 +1,5 @@
 .example-container {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1.5fr 1fr;
     grid-template-rows: repeat(3, minmax(40px, auto));

--- a/live-examples/css-examples/grid/grid-template-areas.css
+++ b/live-examples/css-examples/grid/grid-template-areas.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
     grid-template-rows: repeat(3, minmax(40px, auto));

--- a/live-examples/css-examples/grid/grid-template-columns.css
+++ b/live-examples/css-examples/grid/grid-template-columns.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-auto-rows: 40px;
     grid-gap: 10px;

--- a/live-examples/css-examples/grid/grid-template-rows.css
+++ b/live-examples/css-examples/grid/grid-template-rows.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-gap: 10px;

--- a/live-examples/css-examples/grid/grid-template.css
+++ b/live-examples/css-examples/grid/grid-template.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-gap: 10px;
     width: 200px;

--- a/live-examples/css-examples/grid/grid.css
+++ b/live-examples/css-examples/grid/grid.css
@@ -1,7 +1,5 @@
 #example-element {
-    background-color: #eee;
-    border: .75em solid;
-    padding: .75em;
+    border: 1px solid #c5c5c5;
     display: grid;
     grid-gap: 10px;
     width: 200px;


### PR DESCRIPTION
I changed all interactive examples in box-alignment, flexbox & grid directories, so they are visible well on both light and dark mode.
![image](https://user-images.githubusercontent.com/100634371/156895907-210f0941-a73d-4f2b-a36b-693f4a77636d.png)
![image](https://user-images.githubusercontent.com/100634371/156895914-833a7c28-ae1a-4296-b6eb-4ae4ab263856.png)

The only exception is order property, in which I removed 'width: 80%' and border, so all boxes are in interactive-examples container and border is not distracting.
![image](https://user-images.githubusercontent.com/100634371/156895831-979bb14e-746c-456b-a189-8f0aa53d3a63.png)
