### PR TITLE
Stringify error (Intl - getCanonicalLocales)

### DIFF
--- a/live-examples/js-examples/intl/intl-getcanonicallocales.js
+++ b/live-examples/js-examples/intl/intl-getcanonicallocales.js
@@ -7,6 +7,6 @@ console.log(Intl.getCanonicalLocales(['EN-US', 'Fr']));
 try {
   Intl.getCanonicalLocales('EN_US');
 } catch (err) {
-  console.log(err);
+  console.log(err.toString());
   // expected output: RangeError: invalid language tag: EN_US
 }


### PR DESCRIPTION
Hello folks, sorry I couldn't find guidelines for creating PRs.

I was looking at the documentation for Intl and found this (notice the error is not displayed):
![image](https://user-images.githubusercontent.com/63238713/157232238-04c11623-977a-41ce-a7eb-bba9d5349b9f.png)

After stringifying the error:
![image](https://user-images.githubusercontent.com/63238713/157232191-b31065c1-9ef5-4faa-ae1c-ca3dcccc971c.png)
