### PR TITLE
Removed vendor prefix from position: sticky

### DIFF
--- a/live-examples/css-examples/positioned-layout/position.html
+++ b/live-examples/css-examples/positioned-layout/position.html
@@ -23,8 +23,7 @@ top: 40px; left: 40px;</code></pre>
     </div>
 
     <div id="choice-sticky" class="example-choice">
-        <pre><code class="language-css">position: -webkit-sticky;
-position: sticky;
+        <pre><code class="language-css">position: sticky;
 top: 20px;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>


### PR DESCRIPTION
In [position](https://developer.mozilla.org/en-US/docs/Web/CSS/position) property, having -webkit-sticky seems unnecessary. It clutters example, while non-prefixed version seems to be working everywhere anyway.