### PR TITLE
Remove static white background, fix for dark mode

### DIFF
--- a/live-examples/css-examples/lists/list-style.css
+++ b/live-examples/css-examples/lists/list-style.css
@@ -11,14 +11,6 @@
     flex-direction: column;
 }
 
-.output section li {
-    background: #f1f8ff;
-}
-
-.output section ul.unhighlighted >li {
-    background: white;
-}
-
 .output hr {
     width: 50%;
     color: lightgray;


### PR DESCRIPTION
Removes static white background for lists causing the text not to be visible in dark mode.

Fixes mdn/content#14036