### PR TITLE
Removed redundant guard clause

### DIFF
--- a/live-examples/js-examples/functions/functions-getter.js
+++ b/live-examples/js-examples/functions/functions-getter.js
@@ -1,9 +1,6 @@
 const obj = {
   log: ['a', 'b', 'c'],
   get latest() {
-    if (this.log.length === 0) {
-      return undefined;
-    }
     return this.log[this.log.length - 1];
   }
 };


### PR DESCRIPTION
It returns `undefined` without crashing either way, so therefore it is redundant.