### PR TITLE
Rewrite void operator example

### DIFF
--- a/live-examples/js-examples/expressions/expressions-voidoperator.js
+++ b/live-examples/js-examples/expressions/expressions-voidoperator.js
@@ -1,4 +1,4 @@
-var output = void 1;
+let output = void 1;
 console.log(output);
 // expected output: undefined
 
@@ -15,8 +15,7 @@ void function test() {
 };
 try {
   test();
-}
-catch(e) {
+} catch(e) {
   console.log('test function is not defined');
   // expected output: "test function is not defined"
 }

--- a/live-examples/js-examples/expressions/expressions-voidoperator.js
+++ b/live-examples/js-examples/expressions/expressions-voidoperator.js
@@ -6,6 +6,6 @@ void function test() {
 try {
   test();
 } catch (e) {
-  console.log(e);
+  console.log(e.toString());
   // expected output: ReferenceError: test is not defined
 }

--- a/live-examples/js-examples/expressions/expressions-voidoperator.js
+++ b/live-examples/js-examples/expressions/expressions-voidoperator.js
@@ -1,4 +1,4 @@
-let output = void 1;
+const output = void 1;
 console.log(output);
 // expected output: undefined
 
@@ -15,7 +15,7 @@ void function test() {
 };
 try {
   test();
-} catch(e) {
+} catch (e) {
   console.log('test function is not defined');
   // expected output: "test function is not defined"
 }

--- a/live-examples/js-examples/expressions/expressions-voidoperator.js
+++ b/live-examples/js-examples/expressions/expressions-voidoperator.js
@@ -1,11 +1,22 @@
-void function test() {
-  console.log('boo!');
-  // expected output: "boo!"
-}();
+var output = void 1;
+console.log(output);
+// expected output: undefined
 
+void console.log('expression evaluated');
+// expected output: "expression evaluated"
+
+void function iife() {
+  console.log('iife is executed');
+}();
+// expected output: iife is executed
+
+void function test() {
+  console.log('test function executed');
+};
 try {
   test();
-} catch (e) {
-  console.log(e.toString());
-  // expected output: ReferenceError: test is not defined
+}
+catch(e) {
+  console.log('test function is not defined');
+  // expected output: "test function is not defined"
 }


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/14361.
As discussed in issue [#14361](https://github.com/mdn/content/issues/14361), exception output currently shows "Object {  }" which causes misunderstandings. Change to "e.toString()" will print "ReferenceError: test is not defined"