### PR TITLE
appearance

### DIFF
--- a/live-examples/css-examples/basic-user-interface/appearance.html
+++ b/live-examples/css-examples/basic-user-interface/appearance.html
@@ -1,8 +1,6 @@
 <section id="example-choice-list" class="example-choice-list">
   <div class="example-choice">
     <pre><code class="language-css">
-    -webkit-appearance: none;
-   -moz-appearance: none;
         appearance: none;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
@@ -11,29 +9,7 @@
 
   <div class="example-choice">
     <pre><code class="language-css">
-    -webkit-appearance: auto;
-   -moz-appearance: auto;
         appearance: auto;</code></pre>
-    <button type="button" class="copy hidden" aria-hidden="true">
-      <span class="visually-hidden">Copy to Clipboard</span>
-    </button>
-  </div>
-
-    <div class="example-choice">
-    <pre><code class="language-css">
-    -webkit-appearance: menulist-button;
-   -moz-appearance: menulist-button;
-        appearance: menulist-button;</code></pre>
-    <button type="button" class="copy hidden" aria-hidden="true">
-      <span class="visually-hidden">Copy to Clipboard</span>
-    </button>
-  </div>
-
-  <div class="example-choice">
-    <pre><code class="language-css">
-    -webkit-appearance: button;
-   -moz-appearance: button;
-        appearance: button;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
@@ -42,6 +18,6 @@
 
 <div id="output" class="output hidden large">
   <section id="default-example">
-    <div id="example-element">element</div>
+    <button id="example-element">button</button>
   </section>
 </div>


### PR DESCRIPTION
As requested in Issue [#11278](https://github.com/mdn/content/issues/11278), appearance examples now have visual effect. Current standard contains only 4 keywords: none, auto, menulist-button & textfield. I have changed example to button, on which none and auto have an effect(border changes). Unfortunately I don't know any element on which menulist-button and textfield have any visual impact, so I have removed them from examples.