### PR TITLE
Fix contrast in overflow-wrap

### DIFF
--- a/live-examples/css-examples/text/overflow-wrap.css
+++ b/live-examples/css-examples/text/overflow-wrap.css
@@ -1,5 +1,6 @@
 .example-container {
-    background-color: rgba(255, 215, 0, .6);
+    background-color: rgba(255,0,200,.2);
+    border: 3px solid #663399;
     padding: .75em;
     width: min-content;
     max-width: 11em;


### PR DESCRIPTION
It's a fix for #2054 in which contrast was an issue. I have replaced background and border with same values as in [grid-row](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row), which looks quite well.