### PR TITLE
Fix setHours example for JS Date

### DIFF
--- a/live-examples/js-examples/date/date-sethours.js
+++ b/live-examples/js-examples/date/date-sethours.js
@@ -1,11 +1,11 @@
 const event = new Date('August 19, 1975 23:15:30');
 event.setHours(20);
 
-console.log(event);
+console.log(event.toString());
 // expected output: Tue Aug 19 1975 20:15:30 GMT+0200 (CEST)
 // (note: your timezone may vary)
 
 event.setHours(20, 21, 22);
 
-console.log(event);
+console.log(event.toString());
 // expected output: Tue Aug 19 1975 20:21:22 GMT+0200 (CEST)


### PR DESCRIPTION
In this page: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setHours

Current `Try it` example's output doesn't match the expected output.

![Screen Shot 2022-03-29 at 2 48 33 PM](https://user-images.githubusercontent.com/16910748/160550506-485c24e4-04cb-45dc-94bd-893a5b8270d3.png)


After this fix

![Screen Shot 2022-03-29 at 2 48 12 PM](https://user-images.githubusercontent.com/16910748/160550450-81dc3a14-83cb-4c18-a7f7-751cecf6c12f.png)

