### PR TITLE
Update interactive example for "all" to add "revert" and "revert-layer"

### DIFF
--- a/live-examples/css-examples/cascading-and-inheritance/all.html
+++ b/live-examples/css-examples/cascading-and-inheritance/all.html
@@ -7,13 +7,6 @@
     </div>
 
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">all: unset;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
-
-    <div class="example-choice">
         <pre><code class="language-css">all: initial;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
@@ -22,6 +15,27 @@
 
     <div class="example-choice">
         <pre><code class="language-css">all: inherit;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">all: unset;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">all: revert;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">all: revert-layer;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>


### PR DESCRIPTION
A new global keyword was introduced in FF97, the `revert-layer` keyword.

The `all` property can now have another value `revert-layer` in addition to `initial`, `inherit`, `unset`, and `revert`.

This PR updates the interactive example to:
- Add `all: revert` (was missing)
- Add `all: revert-layer` (new)
- Reorder values to match the order `initial`, `inherit`, `unset`, `revert`, `revert-layer` as in "Syntax"
- Switch `initial-choice="true"` to  `initial`


Content issue tracking this work: https://github.com/mdn/content/issues/13373
PR for the new `revert-layer` page: https://github.com/mdn/content/pull/14287
PR for `revert-layer` changes to `all` property page: https://github.com/mdn/content/pull/14414