### PR TITLE
Remove -webkit-text-emphasis as it's now unprefixed

### DIFF
--- a/live-examples/css-examples/text-decoration/text-emphasis-color.css
+++ b/live-examples/css-examples/text-decoration/text-emphasis-color.css
@@ -4,5 +4,4 @@ p {
 
 #example-element {
     text-emphasis: filled;
-    -webkit-text-emphasis: filled;
 }

--- a/live-examples/css-examples/text-decoration/text-emphasis-color.html
+++ b/live-examples/css-examples/text-decoration/text-emphasis-color.html
@@ -1,23 +1,20 @@
-<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis-color -webkit-text-emphasis-color">
+<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis-color">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">text-emphasis-color: currentColor;
--webkit-text-emphasis-color: currentColor;</code></pre>
+        <pre><code class="language-css">text-emphasis-color: currentColor;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">text-emphasis-color: red;
--webkit-text-emphasis-color: red;</code></pre>
+        <pre><code class="language-css">text-emphasis-color: red;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">text-emphasis-color: rgba(90, 200, 160, 0.8);
--webkit-text-emphasis-color: rgba(90, 200, 160, 0.8);</code></pre>
+        <pre><code class="language-css">text-emphasis-color: rgba(90, 200, 160, 0.8);</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/text-decoration/text-emphasis-position.css
+++ b/live-examples/css-examples/text-decoration/text-emphasis-position.css
@@ -4,5 +4,4 @@ p {
 
 #example-element {
     text-emphasis: filled double-circle blue;
-    -webkit-text-emphasis: filled double-circle blue;
 }

--- a/live-examples/css-examples/text-decoration/text-emphasis-position.html
+++ b/live-examples/css-examples/text-decoration/text-emphasis-position.html
@@ -1,15 +1,13 @@
-<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis-position -webkit-text-emphasis-position">
+<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis-position">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">text-emphasis-position: over ;
--webkit-text-emphasis-position: over;</code></pre>
+        <pre><code class="language-css">text-emphasis-position: over;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">text-emphasis-position: under ;
--webkit-text-emphasis-position : under;</code></pre>
+        <pre><code class="language-css">text-emphasis-position: under;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/text-decoration/text-emphasis-style.html
+++ b/live-examples/css-examples/text-decoration/text-emphasis-style.html
@@ -1,31 +1,27 @@
-<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis-style -webkit-text-emphasis-style">
+<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis-style">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">text-emphasis-style: none;
--webkit-text-emphasis-style: none;</code></pre>
+        <pre><code class="language-css">text-emphasis-style: none;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">text-emphasis-style: triangle;
--webkit-text-emphasis-style: triangle;</code></pre>
+        <pre><code class="language-css">text-emphasis-style: triangle;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">text-emphasis-style: 'x';
--webkit-text-emphasis-style: 'x';</code></pre>
+        <pre><code class="language-css">text-emphasis-style: 'x';</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">text-emphasis-style: filled double-circle;
--webkit-text-emphasis-style: filled double-circle;</code></pre>
+        <pre><code class="language-css">text-emphasis-style: filled double-circle;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/text-decoration/text-emphasis.html
+++ b/live-examples/css-examples/text-decoration/text-emphasis.html
@@ -1,31 +1,27 @@
-<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis -webkit-text-emphasis">
+<section id="example-choice-list" class="example-choice-list" data-property="text-emphasis">
     <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">text-emphasis: none;
--webkit-text-emphasis: none;</code></pre>
+        <pre><code class="language-css">text-emphasis: none;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">text-emphasis: filled red;
--webkit-text-emphasis: filled red;</code></pre>
+        <pre><code class="language-css">text-emphasis: filled red;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">text-emphasis: 'x';
--webkit-text-emphasis: 'x';</code></pre>
+        <pre><code class="language-css">text-emphasis: 'x';</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">text-emphasis: filled double-circle blue;
--webkit-text-emphasis: filled double-circle blue;</code></pre>
+        <pre><code class="language-css">text-emphasis: filled double-circle blue;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>


### PR DESCRIPTION
See https://github.com/mdn/content/pull/14542

The example at https://github.com/mdn/interactive-examples/blob/d9e7dcae46e1dbbd0207f89628f8660328402978/CONTRIBUTING-CSS.md#supporting-prefixed-properties might need to be reworded or updated, as `text-emphasis` won't be longer a good example for that case.