### PR TITLE
docs: Change prefixed property example in meta-docs

### DIFF
--- a/CONTRIBUTING-CSS.md
+++ b/CONTRIBUTING-CSS.md
@@ -124,10 +124,10 @@ In general, to add an example for a property, it should be supported by most bro
 -   supply all relevant variants in the `data-property` attribute
 -   include all relevant variants in the example choices.
 
-For example, suppose you want to add an example for [`text-emphasis`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis). This is supported unprefixed by Firefox but requires the `-webkit-` prefix in Chrome. To deal with this you would set `data-property` like this:
+For example, suppose you want to add an example for [`box-decoration-break`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-decoration-break). This is supported unprefixed by Firefox but requires the `-webkit-` prefix in Chrome. To deal with this you would set `data-property` like this:
 
 ```
-data-property="text-emphasis -webkit-text-emphasis">
+data-property="box-decoration-break -webkit-box-decoration-break">
 ```
 
 This means the editor will check both variants when it is testing whether the browser can support the example.
@@ -135,12 +135,13 @@ This means the editor will check both variants when it is testing whether the br
 You would then use both variants in the example choices:
 
 ```
-<div class="example-choice" initial-choice="true">
-    <pre><code class="language-css">text-emphasis: none;
--webkit-text-emphasis: none;</code></pre>
-    <button type="button" class="copy hidden" aria-hidden="true">
-        <span class="visually-hidden">Copy to Clipboard</span>
-    </button>
+<div class="example-choice">
+    <pre><code class="language-css">box-decoration-break: clone;
+-webkit-box-decoration-break: clone;
+box-shadow: 8px 8px 10px 0 #ff1492, -5px -5px 5px 0 #00f, 5px 5px 15px 0 #ff0;</code></pre>
+<button type="button" class="copy hidden" aria-hidden="true">
+    <span class="visually-hidden">Copy to Clipboard</span>
+</button>
 </div>
 ```
 


### PR DESCRIPTION
See https://github.com/mdn/interactive-examples/pull/2073 - `text-emphasis` is no longer prefixed, so it's not a good example. This PR switches it for `box-decoration-break`, which is still prefixed.