### PR TITLE
Explicitly set interactive example output bg to #fff

### DIFF
--- a/live-examples/css-examples/backgrounds-and-borders/border-style.css
+++ b/live-examples/css-examples/backgrounds-and-borders/border-style.css
@@ -7,3 +7,7 @@
     width: 80%;
     height: 100px;
 }
+
+.output {
+    background-color: #fff;
+}


### PR DESCRIPTION
Explicitly set interactive example output bg to `#fff`
fixes mdn/content#14580