### PR TITLE
Update boolean constructor example to log expected output

### DIFF
--- a/live-examples/js-examples/boolean/boolean-constructor.js
+++ b/live-examples/js-examples/boolean/boolean-constructor.js
@@ -1,4 +1,4 @@
 const flag = new Boolean();
 
-console.log(flag);
+console.log(flag.valueOf());
 // expected output: false


### PR DESCRIPTION
Currently the [boolean constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/Boolean) example logs `Object {  }` instead of `false`. This does not match the expected output.

Since this code demonstrates the constructor I wondered if it would be better to update the `expected output` comment instead. However, logging `Object {  }` does not feel all that informative either. Please let me know your thoughts.


