### PR TITLE
Adds 4 border-radius properties

### DIFF
--- a/live-examples/css-examples/backgrounds-and-borders/border-end-end-radius.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-end-end-radius.html
@@ -9,8 +9,7 @@
 
     <div class="example-choice">
         <pre><code class="language-css">border-end-end-radius: 250px 100px;
-direction: rtl;
-        </code></pre>
+direction: rtl;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-end-end-radius.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-end-end-radius.html
@@ -1,0 +1,43 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="border-end-end-radius">
+
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">border-end-end-radius: 80px 80px;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">border-end-end-radius: 250px 100px;
+direction: rtl;
+        </code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">border-end-end-radius: 50%;
+writing-mode: vertical-lr;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">border-end-end-radius: 50%;
+writing-mode: vertical-rl;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+</section>
+
+<div id="output" class="output large hidden">
+
+    <section id="default-example" class="default-example">
+        <div id="example-element" class="transition-all">This is a box with a bottom right rounded corner.</div>
+    </section>
+
+</div>

--- a/live-examples/css-examples/backgrounds-and-borders/border-end-start-radius.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-end-start-radius.html
@@ -1,0 +1,43 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="border-end-start-radius">
+
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">border-end-start-radius: 80px 80px;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">border-end-start-radius: 250px 100px;
+direction: rtl;
+        </code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">border-end-start-radius: 50%;
+writing-mode: vertical-lr;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">border-end-start-radius: 50%;
+writing-mode: vertical-rl;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+</section>
+
+<div id="output" class="output large hidden">
+
+    <section id="default-example" class="default-example">
+        <div id="example-element" class="transition-all">This is a box with a bottom left rounded corner.</div>
+    </section>
+
+</div>

--- a/live-examples/css-examples/backgrounds-and-borders/border-end-start-radius.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-end-start-radius.html
@@ -9,8 +9,7 @@
 
     <div class="example-choice">
         <pre><code class="language-css">border-end-start-radius: 250px 100px;
-direction: rtl;
-        </code></pre>
+direction: rtl;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-start-end-radius.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-start-end-radius.html
@@ -1,0 +1,43 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="border-start-end-radius">
+
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">border-start-end-radius: 80px 80px;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">border-start-end-radius: 250px 100px;
+direction: rtl;
+        </code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">border-start-end-radius: 50%;
+writing-mode: vertical-lr;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">border-start-end-radius: 50%;
+writing-mode: vertical-rl;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+</section>
+
+<div id="output" class="output large hidden">
+
+    <section id="default-example" class="default-example">
+        <div id="example-element" class="transition-all">This is a box with a top right rounded corner.</div>
+    </section>
+
+</div>

--- a/live-examples/css-examples/backgrounds-and-borders/border-start-end-radius.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-start-end-radius.html
@@ -9,8 +9,7 @@
 
     <div class="example-choice">
         <pre><code class="language-css">border-start-end-radius: 250px 100px;
-direction: rtl;
-        </code></pre>
+direction: rtl;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-start-start-radius.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-start-start-radius.html
@@ -9,8 +9,7 @@
 
     <div class="example-choice">
         <pre><code class="language-css">border-start-start-radius: 250px 100px;
-direction: rtl;
-        </code></pre>
+direction: rtl;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/backgrounds-and-borders/border-start-start-radius.html
+++ b/live-examples/css-examples/backgrounds-and-borders/border-start-start-radius.html
@@ -1,0 +1,43 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="border-start-start-radius">
+
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">border-start-start-radius: 80px 80px;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">border-start-start-radius: 250px 100px;
+direction: rtl;
+        </code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">border-start-start-radius: 50%;
+writing-mode: vertical-lr;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">border-start-start-radius: 50%;
+writing-mode: vertical-rl;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+</section>
+
+<div id="output" class="output large hidden">
+
+    <section id="default-example" class="default-example">
+        <div id="example-element" class="transition-all">This is a box with a top left rounded corner.</div>
+    </section>
+
+</div>

--- a/live-examples/css-examples/backgrounds-and-borders/meta.json
+++ b/live-examples/css-examples/backgrounds-and-borders/meta.json
@@ -217,13 +217,6 @@
             "title": "CSS Demo: border-top-right-radius",
             "type": "css"
         },
-        "borderEndStartRadius": {
-            "cssExampleSrc": "./live-examples/css-examples/backgrounds-and-borders/border-radius.css",
-            "exampleCode": "./live-examples/css-examples/backgrounds-and-borders/border-end-start-radius.html",
-            "fileName": "border-end-start-radius.html",
-            "title": "CSS Demo: border-end-start-radius",
-            "type": "css"
-        },
         "borderEndEndRadius": {
             "cssExampleSrc": "./live-examples/css-examples/backgrounds-and-borders/border-radius.css",
             "exampleCode": "./live-examples/css-examples/backgrounds-and-borders/border-end-end-radius.html",
@@ -231,11 +224,11 @@
             "title": "CSS Demo: border-end-end-radius",
             "type": "css"
         },
-        "borderStartStartRadius": {
+        "borderEndStartRadius": {
             "cssExampleSrc": "./live-examples/css-examples/backgrounds-and-borders/border-radius.css",
-            "exampleCode": "./live-examples/css-examples/backgrounds-and-borders/border-start-start-radius.html",
-            "fileName": "border-start-start-radius.html",
-            "title": "CSS Demo: border-start-start-radius",
+            "exampleCode": "./live-examples/css-examples/backgrounds-and-borders/border-end-start-radius.html",
+            "fileName": "border-end-start-radius.html",
+            "title": "CSS Demo: border-end-start-radius",
             "type": "css"
         },
         "borderStartEndRadius": {
@@ -243,6 +236,13 @@
             "exampleCode": "./live-examples/css-examples/backgrounds-and-borders/border-start-end-radius.html",
             "fileName": "border-start-end-radius.html",
             "title": "CSS Demo: border-start-end-radius",
+            "type": "css"
+        },
+        "borderStartStartRadius": {
+            "cssExampleSrc": "./live-examples/css-examples/backgrounds-and-borders/border-radius.css",
+            "exampleCode": "./live-examples/css-examples/backgrounds-and-borders/border-start-start-radius.html",
+            "fileName": "border-start-start-radius.html",
+            "title": "CSS Demo: border-start-start-radius",
             "type": "css"
         },
         "borderRadius": {

--- a/live-examples/css-examples/backgrounds-and-borders/meta.json
+++ b/live-examples/css-examples/backgrounds-and-borders/meta.json
@@ -217,6 +217,34 @@
             "title": "CSS Demo: border-top-right-radius",
             "type": "css"
         },
+        "borderEndStartRadius": {
+            "cssExampleSrc": "./live-examples/css-examples/backgrounds-and-borders/border-radius.css",
+            "exampleCode": "./live-examples/css-examples/backgrounds-and-borders/border-end-start-radius.html",
+            "fileName": "border-end-start-radius.html",
+            "title": "CSS Demo: border-end-start-radius",
+            "type": "css"
+        },
+        "borderEndEndRadius": {
+            "cssExampleSrc": "./live-examples/css-examples/backgrounds-and-borders/border-radius.css",
+            "exampleCode": "./live-examples/css-examples/backgrounds-and-borders/border-end-end-radius.html",
+            "fileName": "border-end-end-radius.html",
+            "title": "CSS Demo: border-end-end-radius",
+            "type": "css"
+        },
+        "borderStartStartRadius": {
+            "cssExampleSrc": "./live-examples/css-examples/backgrounds-and-borders/border-radius.css",
+            "exampleCode": "./live-examples/css-examples/backgrounds-and-borders/border-start-start-radius.html",
+            "fileName": "border-start-start-radius.html",
+            "title": "CSS Demo: border-start-start-radius",
+            "type": "css"
+        },
+        "borderStartEndRadius": {
+            "cssExampleSrc": "./live-examples/css-examples/backgrounds-and-borders/border-radius.css",
+            "exampleCode": "./live-examples/css-examples/backgrounds-and-borders/border-start-end-radius.html",
+            "fileName": "border-start-end-radius.html",
+            "title": "CSS Demo: border-start-end-radius",
+            "type": "css"
+        },
         "borderRadius": {
             "cssExampleSrc": "./live-examples/css-examples/backgrounds-and-borders/border-radius.css",
             "exampleCode": "./live-examples/css-examples/backgrounds-and-borders/border-radius.html",


### PR DESCRIPTION
Added interactive examples of [border-start-start-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-start-radius), [border-start-end-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-end-radius), [border-end-start-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-start-radius) & [border-end-end-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-end-radius). Visually they are pretty much the same as other border-radius properties, but I added writing-mode & direction too.