### PR TITLE
text-combine-upright

### DIFF
--- a/live-examples/css-examples/writing-modes/meta.json
+++ b/live-examples/css-examples/writing-modes/meta.json
@@ -7,13 +7,20 @@
             "title": "CSS Demo: direction",
             "type": "css"
         },
-        "text-orientation": {
+        "textCombineUpright": {
+            "cssExampleSrc": "./live-examples/css-examples/writing-modes/text-combine-upright.css",
+            "exampleCode": "./live-examples/css-examples/writing-modes/text-combine-upright.html",
+            "fileName": "text-combine-upright.html",
+            "title": "CSS Demo: text-combine-upright",
+            "type": "css"
+        },
+        "textOrientation": {
             "exampleCode": "./live-examples/css-examples/writing-modes/text-orientation.html",
             "fileName": "text-orientation.html",
             "title": "CSS Demo: text-orientation",
             "type": "css"
         },
-        "writing-mode": {
+        "writingMode": {
             "cssExampleSrc": "./live-examples/css-examples/writing-modes/writing-mode.css",
             "exampleCode": "./live-examples/css-examples/writing-modes/writing-mode.html",
             "fileName": "writing-mode.html",

--- a/live-examples/css-examples/writing-modes/text-combine-upright.css
+++ b/live-examples/css-examples/writing-modes/text-combine-upright.css
@@ -1,0 +1,3 @@
+p {
+    writing-mode: vertical-rl;
+}

--- a/live-examples/css-examples/writing-modes/text-combine-upright.html
+++ b/live-examples/css-examples/writing-modes/text-combine-upright.html
@@ -1,0 +1,23 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="text-combine-upright">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">text-combine-upright: none;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">text-combine-upright: all;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <div>
+            <p>トで、新章チャプター<span id="example-element" class="transition-all">12</span>を公開</p>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/writing-modes/text-combine-upright.html
+++ b/live-examples/css-examples/writing-modes/text-combine-upright.html
@@ -17,7 +17,7 @@
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
         <div>
-            <p>トで、新章チャプター<span id="example-element" class="transition-all">12</span>を公開</p>
+            <p><span id="example-element" class="transition-all">2022<span>年</span>12<span>月</span>8</span>日から楽しい</p>
         </div>
     </section>
 </div>


### PR DESCRIPTION
Interactive Example for property [text-combine-upright](https://developer.mozilla.org/en-US/docs/Web/CSS/text-combine-upright).
![image](https://user-images.githubusercontent.com/100634371/166329809-cb0f8b2f-ccb8-4c1c-ba5c-b9fd8126d7b6.png)

