### PR TITLE
Fix font-synthesis example

### DIFF
--- a/live-examples/css-examples/fonts/font-synthesis.css
+++ b/live-examples/css-examples/fonts/font-synthesis.css
@@ -1,6 +1,59 @@
-#output section p {
+@font-face {
+    font-family: Oxygen;
+    font-style: normal;
+    font-weight: 400;
+    src: url('https://fonts.gstatic.com/s/oxygen/v14/2sDfZG1Wl4LcnbuKjk0m.woff2') format('woff2');
+}
+
+/* [108] */
+@font-face {
+    font-family: 'Ma Shan Zheng';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url('https://fonts.gstatic.com/s/mashanzheng/v10/NaPecZTRCLxvwo41b4gvzkXaRMGEFoZJFdX0wQ5Xo5Hr21L9zCcRFhbSe5Nk0pIMuUkHEA.108.woff2') format('woff2');
+}
+/* [110] */
+@font-face {
+    font-family: 'Ma Shan Zheng';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url('https://fonts.gstatic.com/s/mashanzheng/v10/NaPecZTRCLxvwo41b4gvzkXaRMGEFoZJFdX0wQ5Xo5Hr21L9zCcRFhbSe5Nk0pIMuUkHEA.110.woff2') format('woff2');
+}
+/* [117] */
+@font-face {
+    font-family: 'Ma Shan Zheng';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url('https://fonts.gstatic.com/s/mashanzheng/v10/NaPecZTRCLxvwo41b4gvzkXaRMGEFoZJFdX0wQ5Xo5Hr21L9zCcRFhbSe5Nk0pIMuUkHEA.117.woff2') format('woff2');
+}
+/* [118] */
+@font-face {
+    font-family: 'Ma Shan Zheng';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url('https://fonts.gstatic.com/s/mashanzheng/v10/NaPecZTRCLxvwo41b4gvzkXaRMGEFoZJFdX0wQ5Xo5Hr21L9zCcRFhbSe5Nk0pIMuUkHEA.118.woff2') format('woff2');
+}
+/* [119] */
+@font-face {
+    font-family: 'Ma Shan Zheng';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url('https://fonts.gstatic.com/s/mashanzheng/v10/NaPecZTRCLxvwo41b4gvzkXaRMGEFoZJFdX0wQ5Xo5Hr21L9zCcRFhbSe5Nk0pIMuUkHEA.119.woff2') format('woff2');
+}
+
+#output .english {
     font-size: 1.2em;
-    font-family: "KaiTi", serif;
+    font-family: Oxygen;
+}
+
+#output .chinese {
+    font-size: 1.2em;
+    font-family: 'Ma Shan Zheng';
 }
 
 .bold {

--- a/live-examples/css-examples/fonts/font-synthesis.html
+++ b/live-examples/css-examples/fonts/font-synthesis.html
@@ -39,8 +39,8 @@
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
       <div id="example-element" class="transition-all">
-        <p>Most Western fonts include <span class="bold">bold</span>, <span class="italic">italic</span>, and <span class="small-caps">italic</span> variants but CJK fonts tend not to.</p>
-        <p>中文排版通常不运用<span class="bold">粗体</span>或<span class="italic">斜体</span>。</p>
+        <p class="english">Most Western fonts include <span class="bold">bold</span>, <span class="italic">italic</span>, and <span class="small-caps">small-caps</span> variants but CJK fonts tend not to.</p>
+        <p class="chinese">中文排版通常不运用<span class="bold">粗体</span>或<span class="italic">斜体</span>。</p>
       </div>
     </section>
 </div>

--- a/live-examples/css-examples/fonts/font-synthesis.html
+++ b/live-examples/css-examples/fonts/font-synthesis.html
@@ -39,7 +39,7 @@
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
       <div id="example-element" class="transition-all">
-        <p class="english">Most Western fonts include <span class="bold">bold</span>, <span class="italic">italic</span>, and <span class="small-caps">small-caps</span> variants but CJK fonts tend not to.</p>
+        <p class="english">This font does not include <span class="bold">bold</span>, <span class="italic">italic</span>, and <span class="small-caps">small-caps</span> variants.</p>
         <p class="chinese">中文排版通常不运用<span class="bold">粗体</span>或<span class="italic">斜体</span>。</p>
       </div>
     </section>


### PR DESCRIPTION
Current version of font-synthesis usually doesn't give any visual effect, because used fonts had bold, italic and small-caps styles. I have attached fonts from fonts.google.com, that don't have those styles, so they will always be shown as intended. Also text "italic" was changed to "small-caps".
![image](https://user-images.githubusercontent.com/100634371/166914263-01bc6859-2420-48fa-8aff-9d7f39fb8bc8.png)
![image](https://user-images.githubusercontent.com/100634371/166914292-42219a89-b2fa-4f12-a162-f29bf4810538.png)

Unfortunately on Chrome, only small-caps value seems to be working, even though all of them are recognized. Example has visual effect, but bold and italic styles are always active:
![image](https://user-images.githubusercontent.com/100634371/166914770-a5650da7-6e99-4e87-b14a-a6352b62ed29.png)
