### PR TITLE
Improve example of property all

### DIFF
--- a/live-examples/css-examples/cascading-and-inheritance/all.css
+++ b/live-examples/css-examples/cascading-and-inheritance/all.css
@@ -1,8 +1,11 @@
 #example-element {
-    border: 2px dashed #999;
     color: red;
     padding: 10px;
     font-size: 1.5rem;
     text-align: left;
     width: 100%;
+}
+
+.example-container {
+    border: 2px dashed #999;
 }

--- a/live-examples/css-examples/cascading-and-inheritance/all.html
+++ b/live-examples/css-examples/cascading-and-inheritance/all.html
@@ -33,13 +33,6 @@
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">all: revert-layer;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
 </section>
 
 <div id="output" class="output hidden">

--- a/live-examples/css-examples/cascading-and-inheritance/all.html
+++ b/live-examples/css-examples/cascading-and-inheritance/all.html
@@ -38,7 +38,7 @@
 <div id="output" class="output hidden">
   <section id="default-example">
       <div class="example-container">
-        <p id="example-element">"As much mud in the streets as if the waters had but newly retired from the face of the earth, and it would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine lizard up Holborn Hill."</p>
+        <p id="example-element">This paragraph has a font size of 1.5rem and a color of red. It also has 1rem of vertical margin set by the user-agent. The parent of the paragraph is a &lt;div&gt; with a dashed gray border.</p>
       </div>
   </section>
 </div>

--- a/live-examples/css-examples/cascading-and-inheritance/all.html
+++ b/live-examples/css-examples/cascading-and-inheritance/all.html
@@ -44,6 +44,8 @@
 
 <div id="output" class="output hidden">
   <section id="default-example">
-      <p id="example-element">"As much mud in the streets as if the waters had but newly retired from the face of the earth, and it would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine lizard up Holborn Hill."</p>
+      <div class="example-container">
+        <p id="example-element">"As much mud in the streets as if the waters had but newly retired from the face of the earth, and it would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine lizard up Holborn Hill."</p>
+      </div>
   </section>
 </div>


### PR DESCRIPTION
Current example for property [all](https://developer.mozilla.org/en-US/docs/Web/CSS/all) doesn't show any difference between values inherit, unset, revert and revert-layer. I have improved example so difference between inherit, unset and revert is visible. Still revert and revert-layer will look the same, because rever-layer requires cascade layers in order to have any impact. Maybe it's better to remove it from this example and make example in layers in [revert-layer](https://developer.mozilla.org/en-US/docs/Web/CSS/revert-layer) page? Scrollbar would be gone too.

![image](https://user-images.githubusercontent.com/100634371/167026162-d25970e6-5a27-4fa0-a008-50dd1b8fa48b.png)
