### PR TITLE
Property contain

### DIFF
--- a/live-examples/css-examples/basic-box-model/contain.css
+++ b/live-examples/css-examples/basic-box-model/contain.css
@@ -1,0 +1,17 @@
+#example-element {
+    border: 1px solid #c5c5c5;
+    padding: .75em;
+    text-align: left;
+    width: 80%;
+    line-height: normal;
+}
+
+.floating {
+    border: solid 10px #ffc129;
+    background-color: rgba(255, 244, 219, .6);
+    padding: 1em;
+    width: 40%;
+    height: 150px;
+    margin-right: 10px;
+    float: left;
+}

--- a/live-examples/css-examples/basic-box-model/contain.html
+++ b/live-examples/css-examples/basic-box-model/contain.html
@@ -1,0 +1,26 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="contain">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">contain: none;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">contain: content;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <div class="example-container">
+            <div id="example-element" class="transition-all">
+                <div class="floating">Floating Element</div>
+                The Goldfish is a species of domestic fish best known for its bright colors and patterns.
+            </div>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/basic-box-model/meta.json
+++ b/live-examples/css-examples/basic-box-model/meta.json
@@ -7,6 +7,13 @@
             "title": "CSS Demo: clear",
             "type": "css"
         },
+        "contain": {
+            "cssExampleSrc": "./live-examples/css-examples/basic-box-model/contain.css",
+            "exampleCode": "./live-examples/css-examples/basic-box-model/contain.html",
+            "fileName": "contain.html",
+            "title": "CSS Demo: contain",
+            "type": "css"
+        },
         "float": {
             "cssExampleSrc": "./live-examples/css-examples/basic-box-model/float.css",
             "exampleCode": "./live-examples/css-examples/basic-box-model/float.html",


### PR DESCRIPTION
Interactive example for property [contain](https://developer.mozilla.org/en-US/docs/Web/CSS/contain). It is just shown, that new stacking context is established.

![image](https://user-images.githubusercontent.com/100634371/167029452-6f7f527c-4692-4c8d-9cda-ad43409bbb93.png)
![image](https://user-images.githubusercontent.com/100634371/167029479-e922ea72-b247-45b4-a331-5e0b246dfd2f.png)
