### PR TITLE
fix: only run deploy action if labeled release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,13 +6,14 @@ on:
             - main
 
 jobs:
-    if: github.event.label.name == 'release'
     build:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v3
+            - name: Checkout
+              uses: actions/checkout@v3
 
+              if: github.event.label.name == 'release'
             - name: Setup Node.js environment
               uses: actions/setup-node@v3
               with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
             - main
 
 jobs:
+    if: github.event.label.name == 'release'
     build:
         runs-on: ubuntu-latest
 


### PR DESCRIPTION
Currently, the deploy workflow will still run on every push to main.
This, hopefully, will change this to only run for pushes to main that is labelled `release`

fix #2138