### PR TITLE
fix: remove runs-on

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
     publish-release:
-        runs-on: ubuntu-latest
         uses: mdn/workflows/.github/workflows/publish-release.yml@main
         with:
             npm-publish: false


### PR DESCRIPTION
Even though `act` complains about the missing `runs-on` for the reusable action, GitHub does not like it.