### PR TITLE
fix: use js file not html for js examples

### DIFF
--- a/live-examples/js-examples/statement/meta.json
+++ b/live-examples/js-examples/statement/meta.json
@@ -73,7 +73,7 @@
             "type": "js"
         },
         "statementForAwaitOf": {
-            "exampleCode": "./live-examples/js-examples/statement/statement-forawaitof.html",
+            "exampleCode": "./live-examples/js-examples/statement/statement-forawaitof.js",
             "fileName": "statement-forawaitof.html",
             "title": "JavaScript Demo: Statement - For Await...Of",
             "type": "js"

--- a/live-examples/js-examples/statement/statement-forawaitof.js
+++ b/live-examples/js-examples/statement/statement-forawaitof.js
@@ -1,10 +1,9 @@
-<pre>
-<code id="static-js">async function* foo(){
+async function* foo() {
   yield 1;
   yield 2;
 }
 
-(async function () {
+(async function() {
   for await (const num of foo()) {
     console.log(num);
     // expected output: 1
@@ -12,5 +11,3 @@
     break; // closes iterator, triggers return
   }
 })();
-</code>
-</pre>


### PR DESCRIPTION
Switched `for await of` example to use a `.js` file and `.html`

fix #2147