### PR TITLE
chore: update publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,6 +10,7 @@ jobs:
         uses: mdn/workflows/.github/workflows/publish-release.yml@main
         with:
             npm-publish: ${{ false }}
+            target-repo: "mdn/interactive-examples"
         secrets:
             GH_TOKEN: ${{ secrets.GH_TOKEN }}
     deploy:


### PR DESCRIPTION
Add required `target-repo` input and rename workflow name.
Update required as a result of mdn/workflows#55