### PR TITLE
Fix syntax error (put imports first)

### DIFF
--- a/live-examples/wat-examples/variables/global.wat
+++ b/live-examples/wat-examples/variables/global.wat
@@ -1,11 +1,11 @@
 (module
   (import "console" "log" (func $log (param i32)))
+  
+  ;; import a global variable from js
+  (global $from_js (import "env" "from_js") i32)
 
   ;; create a global variable
   (global $from_wasm i32 (i32.const 10))
-
-  ;; import a global variable from js
-  (global $from_js (import "env" "from_js") i32)
 
   (func $main
     ;; load both global variables onto the stack


### PR DESCRIPTION
Fixes an error when running the live example at https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Variables/Global
```
> Error: parseWat failed:
8:20: error: imports must occur before all non-import definitions
  (global $from_js (import "env" "from_js") i32)
                   ^
```
This moves the imported global to above the created global.