### PR TITLE
Few pseudo elements

### DIFF
--- a/live-examples/css-examples/pseudo-element/file-selector-button.css
+++ b/live-examples/css-examples/pseudo-element/file-selector-button.css
@@ -1,0 +1,11 @@
+input {
+    margin-top: 1rem;
+}
+
+input::file-selector-button {
+    font-weight: bold;
+    color: dodgerblue;
+    padding: 0.5em;
+    border: thin solid grey;
+    border-radius: 3px;
+}

--- a/live-examples/css-examples/pseudo-element/file-selector-button.html
+++ b/live-examples/css-examples/pseudo-element/file-selector-button.html
@@ -1,0 +1,5 @@
+<label for="avatar">Choose a profile picture:</label><br>
+
+<input type="file"
+       name="avatar"
+       accept="image/png, image/jpeg">

--- a/live-examples/css-examples/pseudo-element/first-letter.css
+++ b/live-examples/css-examples/pseudo-element/first-letter.css
@@ -1,0 +1,5 @@
+p::first-letter {
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: brown;
+}

--- a/live-examples/css-examples/pseudo-element/first-letter.html
+++ b/live-examples/css-examples/pseudo-element/first-letter.html
@@ -1,0 +1,3 @@
+<p>Scientists exploring the depths of Monterey Bay unexpectedly encountered a rare and unique species of dragonfish. This species is the rarest of its species.</p>
+
+<p>When Robison and a team of researchers discovered this fish, they were aboard a week-long expedition.</p>

--- a/live-examples/css-examples/pseudo-element/first-line.css
+++ b/live-examples/css-examples/pseudo-element/first-line.css
@@ -1,0 +1,5 @@
+p::first-line {
+    font-size: 1.2rem;
+    font-weight: bold;
+    text-decoration: underline;
+}

--- a/live-examples/css-examples/pseudo-element/first-line.html
+++ b/live-examples/css-examples/pseudo-element/first-line.html
@@ -1,0 +1,1 @@
+<p>In warm ocean waters around the world, you may see a strange sight: A fish leaping from the water and soaring dozens of meters before returning to the ocean's depths. Early Mediterranean sailors thought these flying fish returned to the shore at night to sleep, and therefore called this family of marine fish Exocoetidae.</p>

--- a/live-examples/css-examples/pseudo-element/meta.json
+++ b/live-examples/css-examples/pseudo-element/meta.json
@@ -17,6 +17,51 @@
             "type": "tabbed",
             "defaultTab": "css",
             "height": "tabbed-standard"
+        },
+        "fileSelectorButton": {
+            "exampleCode": "./live-examples/css-examples/pseudo-element/file-selector-button.html",
+            "cssExampleSrc": "./live-examples/css-examples/pseudo-element/file-selector-button.css",
+            "fileName": "pseudo-element-file-selector-button.html",
+            "title": "HTML Demo: ::file-selector-button",
+            "type": "tabbed",
+            "defaultTab": "css",
+            "height": "tabbed-shorter"
+        },
+        "firstLetter": {
+            "exampleCode": "./live-examples/css-examples/pseudo-element/first-letter.html",
+            "cssExampleSrc": "./live-examples/css-examples/pseudo-element/first-letter.css",
+            "fileName": "pseudo-element-first-letter.html",
+            "title": "HTML Demo: ::first-letter",
+            "type": "tabbed",
+            "defaultTab": "css",
+            "height": "tabbed-shorter"
+        },
+        "firstLine": {
+            "exampleCode": "./live-examples/css-examples/pseudo-element/first-line.html",
+            "cssExampleSrc": "./live-examples/css-examples/pseudo-element/first-line.css",
+            "fileName": "pseudo-element-first-line.html",
+            "title": "HTML Demo: ::first-line",
+            "type": "tabbed",
+            "defaultTab": "css",
+            "height": "tabbed-shorter"
+        },
+        "placeholder": {
+            "exampleCode": "./live-examples/css-examples/pseudo-element/placeholder.html",
+            "cssExampleSrc": "./live-examples/css-examples/pseudo-element/placeholder.css",
+            "fileName": "pseudo-element-placeholder.html",
+            "title": "HTML Demo: ::placeholder",
+            "type": "tabbed",
+            "defaultTab": "css",
+            "height": "tabbed-shorter"
+        },
+        "selection": {
+            "exampleCode": "./live-examples/css-examples/pseudo-element/selection.html",
+            "cssExampleSrc": "./live-examples/css-examples/pseudo-element/selection.css",
+            "fileName": "pseudo-element-selection.html",
+            "title": "HTML Demo: ::selection",
+            "type": "tabbed",
+            "defaultTab": "css",
+            "height": "tabbed-shorter"
         }
     }
 }

--- a/live-examples/css-examples/pseudo-element/placeholder.css
+++ b/live-examples/css-examples/pseudo-element/placeholder.css
@@ -1,0 +1,9 @@
+input {
+    margin-top: 0.5rem;
+}
+
+input::placeholder {
+    font-weight: bold;
+    opacity: .5;
+    color: red;
+}

--- a/live-examples/css-examples/pseudo-element/placeholder.html
+++ b/live-examples/css-examples/pseudo-element/placeholder.html
@@ -1,0 +1,6 @@
+<label for="first-name">Your phone number:</label><br>
+
+<input type="tel"
+       name="phone"
+       minLength="9" maxLength="9"
+       placeholder="It must be 9 digits">

--- a/live-examples/css-examples/pseudo-element/selection.css
+++ b/live-examples/css-examples/pseudo-element/selection.css
@@ -1,0 +1,4 @@
+p::selection {
+    color: red;
+    background-color: yellow;
+}

--- a/live-examples/css-examples/pseudo-element/selection.html
+++ b/live-examples/css-examples/pseudo-element/selection.html
@@ -1,0 +1,1 @@
+<p>Select a fragment of this paragraph, to see how its appearance is affected.</p>


### PR DESCRIPTION
Added interactive examples to pseudo elements [::file-selector-button](https://developer.mozilla.org/en-US/docs/Web/CSS/::file-selector-button), [::first-letter](https://developer.mozilla.org/en-US/docs/Web/CSS/::first-letter), [::first-line](https://developer.mozilla.org/en-US/docs/Web/CSS/::first-line), [::placeholder](https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder) and [::selection](https://developer.mozilla.org/en-US/docs/Web/CSS/::selection).

![image](https://user-images.githubusercontent.com/100634371/172944888-2b8318b8-6a9e-4dce-8612-114a17e4cee3.png)

![image](https://user-images.githubusercontent.com/100634371/172944907-a5678554-3a51-4224-bb60-e0ae5dd7d237.png)

![image](https://user-images.githubusercontent.com/100634371/172944929-937a38ed-627d-44e7-bb56-f2297dee10bd.png)

![image](https://user-images.githubusercontent.com/100634371/172944955-8cd54ead-c6fd-4978-9629-3cd57c1d2a1c.png)

![image](https://user-images.githubusercontent.com/100634371/172944990-ca96046a-2957-450a-8d3f-1be0bc944038.png)
