### PR TITLE
feat(css): Add example of `<part>`, `<slot>`, `::part`, `::slot` and `::slotted`

### DIFF
--- a/live-examples/css-examples/pseudo-element/meta.json
+++ b/live-examples/css-examples/pseudo-element/meta.json
@@ -63,6 +63,17 @@
             "defaultTab": "css",
             "height": "tabbed-shorter"
         },
+        "part": {
+            "exampleCode": "./live-examples/css-examples/pseudo-element/part.html",
+            "cssExampleSrc": "./live-examples/css-examples/pseudo-element/part.css",
+            "jsExampleSrc": "./live-examples/css-examples/pseudo-element/part.js",
+            "fileName": "pseudo-element-part.html",
+            "title": "HTML Demo: ::part",
+            "type": "tabbed",
+            "defaultTab": "css",
+            "tabs": "html,css,js",
+            "height": "tabbed-standard"
+        },
         "placeholder": {
             "exampleCode": "./live-examples/css-examples/pseudo-element/placeholder.html",
             "cssExampleSrc": "./live-examples/css-examples/pseudo-element/placeholder.css",
@@ -80,6 +91,16 @@
             "type": "tabbed",
             "defaultTab": "css",
             "height": "tabbed-shorter"
+        },
+        "slotted": {
+            "exampleCode": "./live-examples/css-examples/pseudo-element/slotted.html",
+            "jsExampleSrc": "./live-examples/css-examples/pseudo-element/slotted.js",
+            "fileName": "pseudo-element-slotted.html",
+            "title": "HTML Demo: ::slotted",
+            "type": "tabbed",
+            "defaultTab": "html",
+            "tabs": "html,js",
+            "height": "tabbed-standard"
         }
     }
 }

--- a/live-examples/css-examples/pseudo-element/part.css
+++ b/live-examples/css-examples/pseudo-element/part.css
@@ -1,0 +1,9 @@
+#shadowHost::part(paragraph) {
+    color: green;
+}
+
+.not-exported-paragraph {
+    /* This value will not be applied, because selector
+       cannot find elements present in Shadow DOM */
+    color: red;
+}

--- a/live-examples/css-examples/pseudo-element/part.html
+++ b/live-examples/css-examples/pseudo-element/part.html
@@ -1,0 +1,13 @@
+<template id="shadowStructure">
+    <p>
+        This content is placed in Shadow DOM. The next paragraph normally couldn't be reached from outside, but global attribute part allows that to happen.
+    </p>
+    <p part="paragraph">
+        This paragraph is exported, so it can be reached by selectors living outside of the Shadow DOM.
+    </p>
+    <p class="not-exported-paragraph">
+        This paragraph is not exported and cannot be styled by any outside rules.
+    </p>
+</template>
+
+<div id="shadowHost"></div>

--- a/live-examples/css-examples/pseudo-element/part.js
+++ b/live-examples/css-examples/pseudo-element/part.js
@@ -1,0 +1,5 @@
+const shadowStructure = document.getElementById('shadowStructure');
+const shadowHost = document.getElementById('shadowHost');
+
+shadowHost.attachShadow({ mode: "open" });
+shadowHost.shadowRoot.appendChild(shadowStructure.content);

--- a/live-examples/css-examples/pseudo-element/slotted.html
+++ b/live-examples/css-examples/pseudo-element/slotted.html
@@ -1,0 +1,16 @@
+<template id="shadowStructure">
+    <style>
+        ::slotted(.unfinished) {
+            color: red;
+        }
+    </style>
+    <ol>
+        <li>Receive Side-Scaling State: <slot name="sideScaling">Unknown</slot></li>
+        <li>Initial RTO: <slot name="rto">Unknown</slot></li>
+    </ol>
+</template>
+<p>TCP Global Parameters:</p>
+<div id="shadowHost">
+    <span slot="sideScaling">Enabled</span>
+    <span slot="rto" class="unfinished">500 <strong>(Increase later)</strong></span>
+</div>

--- a/live-examples/css-examples/pseudo-element/slotted.js
+++ b/live-examples/css-examples/pseudo-element/slotted.js
@@ -1,0 +1,5 @@
+const shadowStructure = document.getElementById('shadowStructure');
+const shadowHost = document.getElementById('shadowHost');
+
+shadowHost.attachShadow({ mode: "open" });
+shadowHost.shadowRoot.appendChild(shadowStructure.content);

--- a/live-examples/html-examples/global-attributes/attribute-part.html
+++ b/live-examples/html-examples/global-attributes/attribute-part.html
@@ -1,0 +1,13 @@
+<template id="shadowStructure">
+    <p>
+        This content is placed in Shadow DOM. The next paragraph normally couldn't be reached from outside, but global attribute part allows that to happen.
+    </p>
+    <p part="paragraph">
+        This paragraph is exported, so it can be reached by selectors living outside of the Shadow DOM.
+    </p>
+    <p class="not-exported-paragraph">
+        This paragraph is not exported and cannot be styled by any outside rules.
+    </p>
+</template>
+
+<div id="shadowHost"></div>

--- a/live-examples/html-examples/global-attributes/attribute-slot.html
+++ b/live-examples/html-examples/global-attributes/attribute-slot.html
@@ -1,0 +1,16 @@
+<template id="shadowStructure">
+    <style>
+        ::slotted(.unfinished) {
+            color: red;
+        }
+    </style>
+    <ol>
+        <li>Receive Side-Scaling State: <slot name="sideScaling">Unknown</slot></li>
+        <li>Initial RTO: <slot name="rto">Unknown</slot></li>
+    </ol>
+</template>
+<p>TCP Global Parameters:</p>
+<div id="shadowHost">
+    <span slot="sideScaling">Enabled</span>
+    <span slot="rto" class="unfinished">500 <strong>(Increase later)</strong></span>
+</div>

--- a/live-examples/html-examples/global-attributes/css/attribute-part.css
+++ b/live-examples/html-examples/global-attributes/css/attribute-part.css
@@ -1,0 +1,9 @@
+#shadowHost::part(paragraph) {
+    color: green;
+}
+
+.not-exported-paragraph {
+    /* This value will not be applied, because selector
+       cannot find elements present in Shadow DOM */
+    color: red;
+}

--- a/live-examples/html-examples/global-attributes/js/attribute-part.js
+++ b/live-examples/html-examples/global-attributes/js/attribute-part.js
@@ -1,0 +1,5 @@
+const shadowStructure = document.getElementById('shadowStructure');
+const shadowHost = document.getElementById('shadowHost');
+
+shadowHost.attachShadow({ mode: "open" });
+shadowHost.shadowRoot.appendChild(shadowStructure.content);

--- a/live-examples/html-examples/global-attributes/js/attribute-slot.js
+++ b/live-examples/html-examples/global-attributes/js/attribute-slot.js
@@ -1,0 +1,5 @@
+const shadowStructure = document.getElementById('shadowStructure');
+const shadowHost = document.getElementById('shadowHost');
+
+shadowHost.attachShadow({ mode: "open" });
+shadowHost.shadowRoot.appendChild(shadowStructure.content);

--- a/live-examples/html-examples/global-attributes/meta.json
+++ b/live-examples/html-examples/global-attributes/meta.json
@@ -83,6 +83,16 @@
             "tabs": "html,css,js",
             "height": "tabbed-standard"
         },
+        "slot": {
+            "exampleCode": "./live-examples/html-examples/global-attributes/attribute-slot.html",
+            "jsExampleSrc": "./live-examples/html-examples/global-attributes/js/attribute-slot.js",
+            "fileName": "attribute-slot.html",
+            "title": "HTML Demo: slot",
+            "type": "tabbed",
+            "defaultTab": "html",
+            "tabs": "html,js",
+            "height": "tabbed-standard"
+        },
         "spellcheck": {
             "exampleCode": "./live-examples/html-examples/global-attributes/attribute-spellcheck.html",
             "cssExampleSrc": "./live-examples/html-examples/global-attributes/css/attribute-spellcheck.css",

--- a/live-examples/html-examples/global-attributes/meta.json
+++ b/live-examples/html-examples/global-attributes/meta.json
@@ -79,7 +79,7 @@
             "fileName": "attribute-part.html",
             "title": "HTML Demo: part",
             "type": "tabbed",
-            "defaultTab": "css",
+            "defaultTab": "html",
             "tabs": "html,css,js",
             "height": "tabbed-standard"
         },

--- a/live-examples/html-examples/global-attributes/meta.json
+++ b/live-examples/html-examples/global-attributes/meta.json
@@ -72,6 +72,17 @@
             "type": "tabbed",
             "height": "tabbed-shorter"
         },
+        "part": {
+            "exampleCode": "./live-examples/html-examples/global-attributes/attribute-part.html",
+            "cssExampleSrc": "./live-examples/html-examples/global-attributes/css/attribute-part.css",
+            "jsExampleSrc": "./live-examples/html-examples/global-attributes/js/attribute-part.js",
+            "fileName": "attribute-part.html",
+            "title": "HTML Demo: part",
+            "type": "tabbed",
+            "defaultTab": "css",
+            "tabs": "html,css,js",
+            "height": "tabbed-standard"
+        },
         "spellcheck": {
             "exampleCode": "./live-examples/html-examples/global-attributes/attribute-spellcheck.html",
             "cssExampleSrc": "./live-examples/html-examples/global-attributes/css/attribute-spellcheck.css",

--- a/live-examples/html-examples/interactive-elements/js/slot.js
+++ b/live-examples/html-examples/interactive-elements/js/slot.js
@@ -1,0 +1,5 @@
+const shadowStructure = document.getElementById('shadowStructure');
+const shadowHost = document.getElementById('shadowHost');
+
+shadowHost.attachShadow({ mode: "open" });
+shadowHost.shadowRoot.appendChild(shadowStructure.content);

--- a/live-examples/html-examples/interactive-elements/meta.json
+++ b/live-examples/html-examples/interactive-elements/meta.json
@@ -16,6 +16,16 @@
             "type": "tabbed",
             "height": "tabbed-shorter"
         },
+        "slot": {
+            "exampleCode": "./live-examples/html-examples/interactive-elements/slot.html",
+            "jsExampleSrc": "./live-examples/html-examples/interactive-elements/js/slot.js",
+            "fileName": "slot.html",
+            "title": "HTML Demo: slot",
+            "type": "tabbed",
+            "defaultTab": "html",
+            "tabs": "html,js",
+            "height": "tabbed-standard"
+        },
         "summary": {
             "exampleCode": "./live-examples/html-examples/interactive-elements/summary.html",
             "cssExampleSrc": "./live-examples/html-examples/interactive-elements/css/summary.css",

--- a/live-examples/html-examples/interactive-elements/slot.html
+++ b/live-examples/html-examples/interactive-elements/slot.html
@@ -1,0 +1,16 @@
+<template id="shadowStructure">
+    <style>
+        ::slotted(.unfinished) {
+            color: red;
+        }
+    </style>
+    <ol>
+        <li>Receive Side-Scaling State: <slot name="sideScaling">Unknown</slot></li>
+        <li>Initial RTO: <slot name="rto">Unknown</slot></li>
+    </ol>
+</template>
+<p>TCP Global Parameters:</p>
+<div id="shadowHost">
+    <span slot="sideScaling">Enabled</span>
+    <span slot="rto" class="unfinished">500 <strong>(Increase later)</strong></span>
+</div>


### PR DESCRIPTION
Those are interactive examples for pseudo-elements [::part](https://developer.mozilla.org/en-US/docs/Web/CSS/::part) & [::sloted](https://developer.mozilla.org/en-US/docs/Web/CSS/::slotted), global attributes slot & part as well as html element slot.

![image](https://user-images.githubusercontent.com/100634371/173201815-1214dd60-2e32-4bcc-a580-700a6e6bc028.png)

![image](https://user-images.githubusercontent.com/100634371/173201824-2ad0a9e8-a25f-4292-ab8f-6c0ba7091f9e.png)

![image](https://user-images.githubusercontent.com/100634371/179417318-c8057735-70c4-463d-9f68-ca7218295985.png)

![image](https://user-images.githubusercontent.com/100634371/179418926-65daef21-81b5-4908-8d08-1b3b64ffa673.png)

