### PR TITLE
MacOS fix in font-variant-east-asian

### DIFF
--- a/live-examples/css-examples/fonts/font-variant-east-asian.css
+++ b/live-examples/css-examples/fonts/font-variant-east-asian.css
@@ -1,5 +1,5 @@
 #output section {
-    font-family: 'Yu Gothic', sans-serif;
+    font-family: 'YuGothic Medium', YuGothic, 'Yu Gothic Medium', 'Yu Gothic', sans-serif;
     margin-top: 10px;
     font-size: 1.5em;
 }


### PR DESCRIPTION
This commit was proposed by @mfuji09 in #2129 to fix [font-variant-east-asian](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian) example on MacOS. @wbamberg Could you please check if you see any visual difference between property values now?

On windows it's like that:
![image](https://user-images.githubusercontent.com/100634371/173333130-8116c79b-2a0f-4ca8-ba87-1ba369023ed5.png)

![image](https://user-images.githubusercontent.com/100634371/173333149-39e1660b-8887-4c95-aa24-7ebaf671498b.png)

![image](https://user-images.githubusercontent.com/100634371/173333176-0a73700a-174d-49ee-af08-f923ae386102.png)

![image](https://user-images.githubusercontent.com/100634371/173333191-e53bbace-20d8-40e2-9dd5-91af43c3413e.png)
