### PR TITLE
feat(css): Add example of `:host` and  `:host()`

### DIFF
--- a/live-examples/css-examples/pseudo-class/function-host.html
+++ b/live-examples/css-examples/pseudo-class/function-host.html
@@ -1,0 +1,16 @@
+<template id="shadowStructure">
+  <style>
+    :host(div) {
+      background-color: bisque;
+    }
+
+    :host(p) {
+      text-decoration: underline;
+    }
+  </style>
+  <p>
+    Bisque background was applied to Shadow Host, because its tag name is a div. Underline was not applied, because Shadow Host is not a p.
+  </p>
+</template>
+
+<div id="shadowHost"></div>

--- a/live-examples/css-examples/pseudo-class/function-host.js
+++ b/live-examples/css-examples/pseudo-class/function-host.js
@@ -1,0 +1,5 @@
+const shadowStructure = document.getElementById('shadowStructure');
+const shadowHost = document.getElementById('shadowHost');
+
+shadowHost.attachShadow({ mode: "open" });
+shadowHost.shadowRoot.appendChild(shadowStructure.content);

--- a/live-examples/css-examples/pseudo-class/host.html
+++ b/live-examples/css-examples/pseudo-class/host.html
@@ -1,0 +1,12 @@
+<template id="shadowStructure">
+  <style>
+    :host {
+      background-color: bisque;
+    }
+  </style>
+  <p>
+    Bisque background was applied to Shadow Host.
+  </p>
+</template>
+
+<div id="shadowHost"></div>

--- a/live-examples/css-examples/pseudo-class/host.js
+++ b/live-examples/css-examples/pseudo-class/host.js
@@ -1,0 +1,5 @@
+const shadowStructure = document.getElementById('shadowStructure');
+const shadowHost = document.getElementById('shadowHost');
+
+shadowHost.attachShadow({ mode: "open" });
+shadowHost.shadowRoot.appendChild(shadowStructure.content);

--- a/live-examples/css-examples/pseudo-class/meta.json
+++ b/live-examples/css-examples/pseudo-class/meta.json
@@ -162,6 +162,26 @@
             "defaultTab": "css",
             "height": "tabbed-shorter"
         },
+        "functionHost": {
+            "exampleCode": "./live-examples/css-examples/pseudo-class/function-host.html",
+            "jsExampleSrc": "./live-examples/css-examples/pseudo-class/function-host.js",
+            "fileName": "pseudo-class-function-host.html",
+            "title": "CSS Demo: :host()",
+            "type": "tabbed",
+            "defaultTab": "html",
+            "tabs": "html,js",
+            "height": "tabbed-standard"
+        },
+        "host": {
+            "exampleCode": "./live-examples/css-examples/pseudo-class/host.html",
+            "jsExampleSrc": "./live-examples/css-examples/pseudo-class/host.js",
+            "fileName": "pseudo-class-host.html",
+            "title": "CSS Demo: :host",
+            "type": "tabbed",
+            "defaultTab": "html",
+            "tabs": "html,js",
+            "height": "tabbed-shorter"
+        },
         "lastChild": {
             "cssExampleSrc": "./live-examples/css-examples/pseudo-class/last-child.css",
             "exampleCode": "./live-examples/css-examples/pseudo-class/last-child.html",


### PR DESCRIPTION
Those are interactive examples for [:host](https://developer.mozilla.org/en-US/docs/Web/CSS/:host) and [:host()](https://developer.mozilla.org/en-US/docs/Web/CSS/:host_function).

![image](https://user-images.githubusercontent.com/100634371/173833573-e91d8371-1bc6-407b-afe2-e41e51664806.png)

![image](https://user-images.githubusercontent.com/100634371/173833597-66556119-acf4-44da-a413-a24fc86bb039.png)
