### PR TITLE
Better example for proxyHandler.construct

### DIFF
--- a/live-examples/js-examples/proxyhandler/proxyhandler-construct.js
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-construct.js
@@ -4,8 +4,8 @@ function monster1(disposition) {
 
 const handler1 = {
   construct(target, args) {
-    console.log('monster1 constructor called');
-    // expected output: "monster1 constructor called"
+    console.log(`Creating a ${target.name}`);
+    // expected output: "Creating a monster1"
 
     return new target(...args);
   }


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/17426

I only applied the fix to this particular example although other proxyHandler examples are not generic either, because the others already look less contrived.