### PR TITLE
Remove hgroup descendant selector from CSS

### DIFF
--- a/live-examples/html-examples/content-sectioning/css/section.css
+++ b/live-examples/html-examples/content-sectioning/css/section.css
@@ -1,3 +1,3 @@
-hgroup > h1, h2 {
+h1, h2 {
     margin: 0;
 }


### PR DESCRIPTION
The descendant selector `hgroup > h1` does not exist in the example HTML so styling is not applied to the h1 element. To apply the margin to the h1 we need only select it. Also, hgroup should not be used because no assistive technology supports it.