### PR TITLE
not, is, where

### DIFF
--- a/live-examples/css-examples/pseudo-class/is.css
+++ b/live-examples/css-examples/pseudo-class/is.css
@@ -3,11 +3,11 @@ ol {
     color: darkblue;
 }
 
+:is(ol, ul, menu:unsupported) :is(ol, ul) {
+    color: green;
+}
+
 :is(ol, ul) :is(ol, ul) ol {
     list-style-type: lower-greek;
     color: chocolate;
-}
-
-:is(ol, ul, menu:unsupported) :is(ol, ul) {
-    color: green;
 }

--- a/live-examples/css-examples/pseudo-class/is.css
+++ b/live-examples/css-examples/pseudo-class/is.css
@@ -1,0 +1,13 @@
+ol {
+    list-style-type: upper-alpha;
+    color: darkblue;
+}
+
+:is(ol, ul) :is(ol, ul) ol {
+    list-style-type: lower-greek;
+    color: chocolate;
+}
+
+:is(ol, ul, menu:unsupported) :is(ol, ul) {
+    color: green;
+}

--- a/live-examples/css-examples/pseudo-class/is.html
+++ b/live-examples/css-examples/pseudo-class/is.html
@@ -1,0 +1,23 @@
+<ol>
+    <li>Saturn</li>
+    <li>
+        <ul>
+            <li>Mimas</li>
+            <li>Enceladus</li>
+            <li>
+                <ol>
+                    <li>Voyager</li>
+                    <li>Cassini</li>
+                </ol>
+            </li>
+            <li>Tethys</li>
+        </ul>
+    </li>
+    <li>Uranus</li>
+    <li>
+        <ol>
+            <li>Titania</li>
+            <li>Oberon</li>
+        </ol>
+    </li>
+</ol>

--- a/live-examples/css-examples/pseudo-class/meta.json
+++ b/live-examples/css-examples/pseudo-class/meta.json
@@ -72,6 +72,15 @@
             "defaultTab": "css",
             "height": "tabbed-shorter"
         },
+        "is": {
+            "cssExampleSrc": "./live-examples/css-examples/pseudo-class/is.css",
+            "exampleCode": "./live-examples/css-examples/pseudo-class/is.html",
+            "fileName": "pseudo-class-is.html",
+            "title": "CSS Demo: :is",
+            "type": "tabbed",
+            "defaultTab": "css",
+            "height": "tabbed-shorter"
+        },
         "lastChild": {
             "cssExampleSrc": "./live-examples/css-examples/pseudo-class/last-child.css",
             "exampleCode": "./live-examples/css-examples/pseudo-class/last-child.html",
@@ -95,6 +104,15 @@
             "exampleCode": "./live-examples/css-examples/pseudo-class/link.html",
             "fileName": "pseudo-class-link.html",
             "title": "CSS Demo: :link",
+            "type": "tabbed",
+            "defaultTab": "css",
+            "height": "tabbed-shorter"
+        },
+        "not": {
+            "cssExampleSrc": "./live-examples/css-examples/pseudo-class/not.css",
+            "exampleCode": "./live-examples/css-examples/pseudo-class/not.html",
+            "fileName": "pseudo-class-not.html",
+            "title": "CSS Demo: :not",
             "type": "tabbed",
             "defaultTab": "css",
             "height": "tabbed-shorter"
@@ -158,6 +176,15 @@
             "exampleCode": "./live-examples/css-examples/pseudo-class/visited.html",
             "fileName": "pseudo-class-visited.html",
             "title": "CSS Demo: :visited",
+            "type": "tabbed",
+            "defaultTab": "css",
+            "height": "tabbed-shorter"
+        },
+        "where": {
+            "cssExampleSrc": "./live-examples/css-examples/pseudo-class/where.css",
+            "exampleCode": "./live-examples/css-examples/pseudo-class/where.html",
+            "fileName": "pseudo-class-where.html",
+            "title": "CSS Demo: :where",
             "type": "tabbed",
             "defaultTab": "css",
             "height": "tabbed-shorter"

--- a/live-examples/css-examples/pseudo-class/not.css
+++ b/live-examples/css-examples/pseudo-class/not.css
@@ -1,0 +1,12 @@
+p:not(.irrelevant) {
+    font-weight: bold;
+}
+
+p > strong,
+p > b.important {
+    color: crimson;
+}
+
+p > :not(strong, b.important) {
+    color: darkmagenta;
+}

--- a/live-examples/css-examples/pseudo-class/not.html
+++ b/live-examples/css-examples/pseudo-class/not.html
@@ -1,0 +1,3 @@
+<p><b>Mars</b> is one of the most Earth-like planets. <b>Mars</b> day is almost the same as an Earth day, only <strong>37 minutes</strong> longer.</p>
+
+<p class="irrelevant"><b class="important">NASA</b>'s Jet <del>Momentum</del> Propulsion Laboratory is designing mission concepts to survive the <b>Venus</b> extreme temperatures and atmospheric pressure.</p>

--- a/live-examples/css-examples/pseudo-class/where.css
+++ b/live-examples/css-examples/pseudo-class/where.css
@@ -1,0 +1,14 @@
+ol {
+    list-style-type: upper-alpha;
+    color: darkblue;
+}
+
+:where(ol, ul) :where(ol, ul) ol {
+    list-style-type: lower-greek;
+    color: chocolate;
+}
+
+/* Not applied to ol, because of lower specificity */
+:where(ol, ul, menu:unsupported) :where(ol, ul) {
+    color: green;
+}

--- a/live-examples/css-examples/pseudo-class/where.css
+++ b/live-examples/css-examples/pseudo-class/where.css
@@ -3,12 +3,12 @@ ol {
     color: darkblue;
 }
 
-:where(ol, ul) :where(ol, ul) ol {
-    list-style-type: lower-greek;
-    color: chocolate;
-}
-
 /* Not applied to ol, because of lower specificity */
 :where(ol, ul, menu:unsupported) :where(ol, ul) {
     color: green;
+}
+
+:where(ol, ul) :where(ol, ul) ol {
+    list-style-type: lower-greek;
+    color: chocolate;
 }

--- a/live-examples/css-examples/pseudo-class/where.html
+++ b/live-examples/css-examples/pseudo-class/where.html
@@ -1,0 +1,23 @@
+<ol>
+    <li>Saturn</li>
+    <li>
+        <ul>
+            <li>Mimas</li>
+            <li>Enceladus</li>
+            <li>
+                <ol>
+                    <li>Voyager</li>
+                    <li>Cassini</li>
+                </ol>
+            </li>
+            <li>Tethys</li>
+        </ul>
+    </li>
+    <li>Uranus</li>
+    <li>
+        <ol>
+            <li>Titania</li>
+            <li>Oberon</li>
+        </ol>
+    </li>
+</ol>


### PR DESCRIPTION
Interactive examples for pseudo-classes [:not](https://developer.mozilla.org/en-US/docs/Web/CSS/:not), [:is](https://developer.mozilla.org/en-US/docs/Web/CSS/:is), [:where](https://developer.mozilla.org/en-US/docs/Web/CSS/:where).

![image](https://user-images.githubusercontent.com/100634371/176956855-037ea943-bced-44f5-bc4d-b58b4a8a9815.png)

![image](https://user-images.githubusercontent.com/100634371/176957358-f3030099-b75d-49fb-a7b7-7dd7e93abcce.png)

![image](https://user-images.githubusercontent.com/100634371/176957381-9db76dfb-6005-4206-8a3b-c59a4aa8eae6.png)
