### PR TITLE
Array/TypedArray .findLast and findLastInded examples

### DIFF
--- a/live-examples/js-examples/array/array-findlast.js
+++ b/live-examples/js-examples/array/array-findlast.js
@@ -1,6 +1,6 @@
 const array1 = [5, 12, 50, 130, 44];
 
-const found = array1.findLast(element => element > 45);
+const found = array1.findLast((element) => element > 45);
 
 console.log(found);
 // expected output: 130

--- a/live-examples/js-examples/array/array-findlast.js
+++ b/live-examples/js-examples/array/array-findlast.js
@@ -1,0 +1,6 @@
+const array1 = [5, 12, 50, 130, 44];
+
+const found = array1.findLast(element => element > 45);
+
+console.log(found);
+// expected output: 130

--- a/live-examples/js-examples/array/array-findlastindex.js
+++ b/live-examples/js-examples/array/array-findlastindex.js
@@ -1,0 +1,6 @@
+const array1 = [5, 12, 50, 130, 44];
+
+const isLargeNumber = (element) => element > 45;
+
+console.log(array1.findLastIndex(isLargeNumber));
+// expected output: 3  (of element with value: 30)

--- a/live-examples/js-examples/array/meta.json
+++ b/live-examples/js-examples/array/meta.json
@@ -48,10 +48,22 @@
             "title": "JavaScript Demo: Array.find()",
             "type": "js"
         },
+        "arrayFindLast": {
+            "exampleCode": "./live-examples/js-examples/array/array-findlast.js",
+            "fileName": "array-findlast.html",
+            "title": "JavaScript Demo: Array.findLast()",
+            "type": "js"
+        },
         "arrayFindIndex": {
             "exampleCode": "./live-examples/js-examples/array/array-findindex.js",
             "fileName": "array-findindex.html",
             "title": "JavaScript Demo: Array.findIndex()",
+            "type": "js"
+        },
+        "arrayFindLastIndex": {
+            "exampleCode": "./live-examples/js-examples/array/array-findlastindex.js",
+            "fileName": "array-findlastindex.html",
+            "title": "JavaScript Demo: Array.findLastIndex()",
             "type": "js"
         },
         "arrayFlat": {

--- a/live-examples/js-examples/typedarray/meta.json
+++ b/live-examples/js-examples/typedarray/meta.json
@@ -66,10 +66,22 @@
             "title": "JavaScript Demo: TypedArray.find()",
             "type": "js"
         },
+        "typedarrayFindLast": {
+            "exampleCode": "./live-examples/js-examples/typedarray/typedarray-findlast.js",
+            "fileName": "typedarray-findlast.html",
+            "title": "JavaScript Demo: TypedArray.findLast()",
+            "type": "js"
+        },
         "typedarrayFindIndex": {
             "exampleCode": "./live-examples/js-examples/typedarray/typedarray-findindex.js",
             "fileName": "typedarray-findindex.html",
             "title": "JavaScript Demo: TypedArray.findIndex()",
+            "type": "js"
+        },
+        "typedarrayFindLastIndex": {
+            "exampleCode": "./live-examples/js-examples/typedarray/typedarray-findlastindex.js",
+            "fileName": "typedarray-findlastindex.html",
+            "title": "JavaScript Demo: TypedArray.findLastIndex()",
             "type": "js"
         },
         "typedarrayFrom": {

--- a/live-examples/js-examples/typedarray/typedarray-findlast.js
+++ b/live-examples/js-examples/typedarray/typedarray-findlast.js
@@ -1,0 +1,8 @@
+function isNegative(element, index, array) {
+  return element < 0;
+}
+
+const int8 = new Int8Array([10, 0, -10, 20, -30, 40, 50]);
+
+console.log(int8.find(isNegative));
+// expected output: -30

--- a/live-examples/js-examples/typedarray/typedarray-findlast.js
+++ b/live-examples/js-examples/typedarray/typedarray-findlast.js
@@ -1,4 +1,4 @@
-function isNegative(element, index, array) {
+function isNegative(element /*, index, array */) {
   return element < 0;
 }
 

--- a/live-examples/js-examples/typedarray/typedarray-findlastindex.js
+++ b/live-examples/js-examples/typedarray/typedarray-findlastindex.js
@@ -1,0 +1,8 @@
+function isNegative(element, index, array) {
+  return element < 0;
+}
+
+const int8 = new Int8Array([10, -20, 30, -40, 50]);
+
+console.log(int8.findLastIndex(isNegative));
+// expected output: 3

--- a/live-examples/js-examples/typedarray/typedarray-findlastindex.js
+++ b/live-examples/js-examples/typedarray/typedarray-findlastindex.js
@@ -1,4 +1,4 @@
-function isNegative(element, index, array) {
+function isNegative(element /*, index, array */) {
   return element < 0;
 }
 


### PR DESCRIPTION
This adds examples for the Array and TypedArray methods `findL:ast()` and `findLastIndex()`. The methods are pretty much the same as find and findIndex, and the examples therefore follow the pattern of those examples.

This is part of documenting the methods for FF103, which can be tracked in https://github.com/mdn/content/issues/17473