### PR TITLE
Add CSS break-before, break-after, break-inside properties

### DIFF
--- a/live-examples/css-examples/fragmentation/break-after.css
+++ b/live-examples/css-examples/fragmentation/break-after.css
@@ -12,5 +12,5 @@
 }
 
 .hide-element {
-    display: none !important;
+    display: none;
 }

--- a/live-examples/css-examples/fragmentation/break-after.css
+++ b/live-examples/css-examples/fragmentation/break-after.css
@@ -1,0 +1,16 @@
+.box {
+    border: solid #5b6dcd 5px;
+    background-color: #5b6dcd;
+    margin: 10px 0;
+    padding: 5px;
+}
+
+#example-element {
+    border: solid 5px #ffc129;
+    background-color: #ffc129;
+    color: black;
+}
+
+.hide-element {
+    display: none !important;
+}

--- a/live-examples/css-examples/fragmentation/break-after.html
+++ b/live-examples/css-examples/fragmentation/break-after.html
@@ -27,9 +27,9 @@
             <p>The effect of this property can be noticed when the document is being printed or a preview of a print is displayed.</p>
             <button id="print-btn">Show Print Preview</button>
             <div class="box-container">
-                <div class="box">Content Before</div>
-                <div class="box" id="example-element">Content with break-after</div>
-                <div class="box">Content After</div>
+                <div class="box">Content before the property</div>
+                <div class="box" id="example-element">Content with 'break-after'</div>
+                <div class="box">Content after the property</div>
             </div>
         </div>
     </section>

--- a/live-examples/css-examples/fragmentation/break-after.html
+++ b/live-examples/css-examples/fragmentation/break-after.html
@@ -12,13 +12,6 @@
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">break-after: left;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
 </section>
 
 <div id="output" class="output large hidden">

--- a/live-examples/css-examples/fragmentation/break-after.html
+++ b/live-examples/css-examples/fragmentation/break-after.html
@@ -1,0 +1,36 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="break-after">
+    <div class="example-choice">
+        <pre><code class="language-css">break-after: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">break-after: page;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">break-after: left;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example">
+        <div>
+            <p>The effect of this property can be noticed when the document is being printed or a preview of a print is displayed.</p>
+            <button id="print-btn">Show Print Preview</button>
+            <div class="box-container">
+                <div class="box">Content Before</div>
+                <div class="box" id="example-element">Content with break-after</div>
+                <div class="box">Content After</div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/fragmentation/break-before.css
+++ b/live-examples/css-examples/fragmentation/break-before.css
@@ -12,5 +12,5 @@
 }
 
 .hide-element {
-    display: none !important;
+    display: none;
 }

--- a/live-examples/css-examples/fragmentation/break-before.css
+++ b/live-examples/css-examples/fragmentation/break-before.css
@@ -1,0 +1,16 @@
+.box {
+    border: solid #5b6dcd 5px;
+    background-color: #5b6dcd;
+    margin: 10px 0;
+    padding: 5px;
+}
+
+#example-element {
+    border: solid 5px #ffc129;
+    background-color: #ffc129;
+    color: black;
+}
+
+.hide-element {
+    display: none !important;
+}

--- a/live-examples/css-examples/fragmentation/break-before.html
+++ b/live-examples/css-examples/fragmentation/break-before.html
@@ -12,13 +12,6 @@
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">break-before: left;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
 </section>
 
 <div id="output" class="output large hidden">

--- a/live-examples/css-examples/fragmentation/break-before.html
+++ b/live-examples/css-examples/fragmentation/break-before.html
@@ -27,9 +27,9 @@
             <p>The effect of this property can be noticed when the document is being printed or a preview of a print is displayed.</p>
             <button id="print-btn">Show Print Preview</button>
             <div class="box-container">
-                <div class="box">Content Before</div>
-                <div class="box" id="example-element">Content with break-before</div>
-                <div class="box">Content After</div>
+                <div class="box">Content before the property</div>
+                <div class="box" id="example-element">Content with 'break-before'</div>
+                <div class="box">Content after the property</div>
             </div>
         </div>
     </section>

--- a/live-examples/css-examples/fragmentation/break-before.html
+++ b/live-examples/css-examples/fragmentation/break-before.html
@@ -1,0 +1,36 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="break-before">
+    <div class="example-choice">
+        <pre><code class="language-css">break-before: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">break-before: page;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">break-before: left;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example">
+        <div>
+            <p>The effect of this property can be noticed when the document is being printed or a preview of a print is displayed.</p>
+            <button id="print-btn">Show Print Preview</button>
+            <div class="box-container">
+                <div class="box">Content Before</div>
+                <div class="box" id="example-element">Content with break-before</div>
+                <div class="box">Content After</div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/fragmentation/break-inside.css
+++ b/live-examples/css-examples/fragmentation/break-inside.css
@@ -12,7 +12,7 @@
 }
 
 .hide-element {
-    display: none !important;
+    display: none;
 }
 
 @media print {

--- a/live-examples/css-examples/fragmentation/break-inside.css
+++ b/live-examples/css-examples/fragmentation/break-inside.css
@@ -1,0 +1,22 @@
+.box {
+    border: solid #5b6dcd 5px;
+    background-color: #5b6dcd;
+    margin: 10px 0;
+    padding: 5px;
+}
+
+#example-element {
+    border: solid 5px #ffc129;
+    background-color: #ffc129;
+    color: black;
+}
+
+.hide-element {
+    display: none !important;
+}
+
+@media print {
+    #example-element {
+        height: 25cm;
+    }
+}

--- a/live-examples/css-examples/fragmentation/break-inside.html
+++ b/live-examples/css-examples/fragmentation/break-inside.html
@@ -27,9 +27,9 @@
             <p>The effect of this property can be noticed when the document is being printed or a preview of a print is displayed.</p>
             <button id="print-btn">Show Print Preview</button>
             <div class="box-container">
-                <div class="box">Content Before</div>
-                <div class="box" id="example-element">Content with break-inside</div>
-                <div class="box">Content After</div>
+                <div class="box">Content before the property</div>
+                <div class="box" id="example-element">Content with 'break-inside'</div>
+                <div class="box">Content after the property</div>
             </div>
         </div>
     </section>

--- a/live-examples/css-examples/fragmentation/break-inside.html
+++ b/live-examples/css-examples/fragmentation/break-inside.html
@@ -12,13 +12,6 @@
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">break-inside: avoid-page;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
 </section>
 
 <div id="output" class="output large hidden">

--- a/live-examples/css-examples/fragmentation/break-inside.html
+++ b/live-examples/css-examples/fragmentation/break-inside.html
@@ -1,0 +1,36 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="break-inside">
+    <div class="example-choice">
+        <pre><code class="language-css">break-inside: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">break-inside: avoid;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">break-inside: avoid-page;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example">
+        <div>
+            <p>The effect of this property can be noticed when the document is being printed or a preview of a print is displayed.</p>
+            <button id="print-btn">Show Print Preview</button>
+            <div class="box-container">
+                <div class="box">Content Before</div>
+                <div class="box" id="example-element">Content with break-inside</div>
+                <div class="box">Content After</div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/fragmentation/break.js
+++ b/live-examples/css-examples/fragmentation/break.js
@@ -1,0 +1,22 @@
+const btn = document.getElementById('print-btn');
+const editorContainer = document.getElementsByClassName('css-editor-container')[0];
+const exampleHTMLElement = document.getElementById('default-example');
+
+const printableSection = document.createElement('div');
+printableSection.setAttribute('id', 'printable-section');
+printableSection.classList.add('hide-element');
+document.body.appendChild(printableSection);
+
+btn.addEventListener('click', () => {
+  const exampleContent = exampleHTMLElement.innerHTML;
+
+  editorContainer.classList.add('hide-element');
+  printableSection.innerHTML = exampleContent;
+  printableSection.classList.remove('hide-element');
+
+  window.print();
+
+  printableSection.classList.add('hide-element');
+  printableSection.innerHTML = '';
+  editorContainer.classList.remove('hide-element');
+});

--- a/live-examples/css-examples/fragmentation/meta.json
+++ b/live-examples/css-examples/fragmentation/meta.json
@@ -7,11 +7,59 @@
             "title": "CSS Demo: box-decoration-break",
             "type": "css"
         },
+        "breakAfter": {
+            "cssExampleSrc": "./live-examples/css-examples/fragmentation/break-after.css",
+            "exampleCode": "./live-examples/css-examples/fragmentation/break-after.html",
+            "jsExampleSrc": "./live-examples/css-examples/fragmentation/break.js",
+            "fileName": "break-after.html",
+            "title": "CSS Demo: break-after",
+            "type": "css"
+        },
+        "breakBefore": {
+            "cssExampleSrc": "./live-examples/css-examples/fragmentation/break-before.css",
+            "exampleCode": "./live-examples/css-examples/fragmentation/break-before.html",
+            "jsExampleSrc": "./live-examples/css-examples/fragmentation/break.js",
+            "fileName": "break-before.html",
+            "title": "CSS Demo: break-before",
+            "type": "css"
+        },
+        "breakInside": {
+            "cssExampleSrc": "./live-examples/css-examples/fragmentation/break-inside.css",
+            "exampleCode": "./live-examples/css-examples/fragmentation/break-inside.html",
+            "jsExampleSrc": "./live-examples/css-examples/fragmentation/break.js",
+            "fileName": "break-inside.html",
+            "title": "CSS Demo: break-inside",
+            "type": "css"
+        },
         "orphans": {
             "cssExampleSrc": "./live-examples/css-examples/fragmentation/orphans.css",
             "exampleCode": "./live-examples/css-examples/fragmentation/orphans.html",
             "fileName": "orphans.html",
             "title": "CSS Demo: orphans",
+            "type": "css"
+        },
+        "pageBreakAfter": {
+            "cssExampleSrc": "./live-examples/css-examples/fragmentation/page-break-after.css",
+            "exampleCode": "./live-examples/css-examples/fragmentation/page-break-after.html",
+            "jsExampleSrc": "./live-examples/css-examples/fragmentation/break.js",
+            "fileName": "page-break-after.html",
+            "title": "CSS Demo: page-break-after",
+            "type": "css"
+        },
+        "pageBreakBefore": {
+            "cssExampleSrc": "./live-examples/css-examples/fragmentation/page-break-before.css",
+            "exampleCode": "./live-examples/css-examples/fragmentation/page-break-before.html",
+            "jsExampleSrc": "./live-examples/css-examples/fragmentation/break.js",
+            "fileName": "page-break-before.html",
+            "title": "CSS Demo: page-break-before",
+            "type": "css"
+        },
+        "pageBreakInside": {
+            "cssExampleSrc": "./live-examples/css-examples/fragmentation/page-break-inside.css",
+            "exampleCode": "./live-examples/css-examples/fragmentation/page-break-inside.html",
+            "jsExampleSrc": "./live-examples/css-examples/fragmentation/break.js",
+            "fileName": "page-break-inside.html",
+            "title": "CSS Demo: page-break-inside",
             "type": "css"
         },
         "widows": {

--- a/live-examples/css-examples/fragmentation/page-break-after.css
+++ b/live-examples/css-examples/fragmentation/page-break-after.css
@@ -12,5 +12,5 @@
 }
 
 .hide-element {
-    display: none !important;
+    display: none;
 }

--- a/live-examples/css-examples/fragmentation/page-break-after.css
+++ b/live-examples/css-examples/fragmentation/page-break-after.css
@@ -1,0 +1,16 @@
+.box {
+    border: solid #5b6dcd 5px;
+    background-color: #5b6dcd;
+    margin: 10px 0;
+    padding: 5px;
+}
+
+#example-element {
+    border: solid 5px #ffc129;
+    background-color: #ffc129;
+    color: black;
+}
+
+.hide-element {
+    display: none !important;
+}

--- a/live-examples/css-examples/fragmentation/page-break-after.html
+++ b/live-examples/css-examples/fragmentation/page-break-after.html
@@ -12,13 +12,6 @@
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">page-break-after: left;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
 </section>
 
 <div id="output" class="output large hidden">

--- a/live-examples/css-examples/fragmentation/page-break-after.html
+++ b/live-examples/css-examples/fragmentation/page-break-after.html
@@ -27,9 +27,9 @@
             <p>The effect of this property can be noticed when the document is being printed or a preview of a print is displayed.</p>
             <button id="print-btn">Show Print Preview</button>
             <div class="box-container">
-                <div class="box">Content Before</div>
-                <div class="box" id="example-element">Content with page-break-after</div>
-                <div class="box">Content After</div>
+                <div class="box">Content before the property</div>
+                <div class="box" id="example-element">Content with 'page-break-after'</div>
+                <div class="box">Content after the property</div>
             </div>
         </div>
     </section>

--- a/live-examples/css-examples/fragmentation/page-break-after.html
+++ b/live-examples/css-examples/fragmentation/page-break-after.html
@@ -1,0 +1,36 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="page-break-after">
+    <div class="example-choice">
+        <pre><code class="language-css">page-break-after: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">page-break-after: always;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">page-break-after: left;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example">
+        <div>
+            <p>The effect of this property can be noticed when the document is being printed or a preview of a print is displayed.</p>
+            <button id="print-btn">Show Print Preview</button>
+            <div class="box-container">
+                <div class="box">Content Before</div>
+                <div class="box" id="example-element">Content with page-break-after</div>
+                <div class="box">Content After</div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/fragmentation/page-break-before.css
+++ b/live-examples/css-examples/fragmentation/page-break-before.css
@@ -12,5 +12,5 @@
 }
 
 .hide-element {
-    display: none !important;
+    display: none;
 }

--- a/live-examples/css-examples/fragmentation/page-break-before.css
+++ b/live-examples/css-examples/fragmentation/page-break-before.css
@@ -1,0 +1,16 @@
+.box {
+    border: solid #5b6dcd 5px;
+    background-color: #5b6dcd;
+    margin: 10px 0;
+    padding: 5px;
+}
+
+#example-element {
+    border: solid 5px #ffc129;
+    background-color: #ffc129;
+    color: black;
+}
+
+.hide-element {
+    display: none !important;
+}

--- a/live-examples/css-examples/fragmentation/page-break-before.html
+++ b/live-examples/css-examples/fragmentation/page-break-before.html
@@ -27,9 +27,9 @@
             <p>The effect of this property can be noticed when the document is being printed or a preview of a print is displayed.</p>
             <button id="print-btn">Show Print Preview</button>
             <div class="box-container">
-                <div class="box">Content Before</div>
-                <div class="box" id="example-element">Content with page-break-before</div>
-                <div class="box">Content After</div>
+                <div class="box">Content before the property</div>
+                <div class="box" id="example-element">Content with 'page-break-before'</div>
+                <div class="box">Content after the property</div>
             </div>
         </div>
     </section>

--- a/live-examples/css-examples/fragmentation/page-break-before.html
+++ b/live-examples/css-examples/fragmentation/page-break-before.html
@@ -12,13 +12,6 @@
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>
     </div>
-
-    <div class="example-choice">
-        <pre><code class="language-css">page-break-before: left;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
 </section>
 
 <div id="output" class="output large hidden">

--- a/live-examples/css-examples/fragmentation/page-break-before.html
+++ b/live-examples/css-examples/fragmentation/page-break-before.html
@@ -1,0 +1,36 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="page-break-before">
+    <div class="example-choice">
+        <pre><code class="language-css">page-break-before: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">page-break-before: always;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">page-break-before: left;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example">
+        <div>
+            <p>The effect of this property can be noticed when the document is being printed or a preview of a print is displayed.</p>
+            <button id="print-btn">Show Print Preview</button>
+            <div class="box-container">
+                <div class="box">Content Before</div>
+                <div class="box" id="example-element">Content with page-break-before</div>
+                <div class="box">Content After</div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/live-examples/css-examples/fragmentation/page-break-inside.css
+++ b/live-examples/css-examples/fragmentation/page-break-inside.css
@@ -12,7 +12,7 @@
 }
 
 .hide-element {
-    display: none !important;
+    display: none;
 }
 
 @media print {

--- a/live-examples/css-examples/fragmentation/page-break-inside.css
+++ b/live-examples/css-examples/fragmentation/page-break-inside.css
@@ -1,0 +1,22 @@
+.box {
+    border: solid #5b6dcd 5px;
+    background-color: #5b6dcd;
+    margin: 10px 0;
+    padding: 5px;
+}
+
+#example-element {
+    border: solid 5px #ffc129;
+    background-color: #ffc129;
+    color: black;
+}
+
+.hide-element {
+    display: none !important;
+}
+
+@media print {
+    #example-element {
+        height: 25cm;
+    }
+}

--- a/live-examples/css-examples/fragmentation/page-break-inside.html
+++ b/live-examples/css-examples/fragmentation/page-break-inside.html
@@ -20,9 +20,9 @@
             <p>The effect of this property can be noticed when the document is being printed or a preview of a print is displayed.</p>
             <button id="print-btn">Show Print Preview</button>
             <div class="box-container">
-                <div class="box">Content Before</div>
-                <div class="box" id="example-element">Content with page-break-inside</div>
-                <div class="box">Content After</div>
+                <div class="box">Content before the property</div>
+                <div class="box" id="example-element">Content with 'page-break-inside'</div>
+                <div class="box">Content after the property</div>
             </div>
         </div>
     </section>

--- a/live-examples/css-examples/fragmentation/page-break-inside.html
+++ b/live-examples/css-examples/fragmentation/page-break-inside.html
@@ -1,0 +1,29 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="page-break-inside">
+    <div class="example-choice">
+        <pre><code class="language-css">page-break-inside: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">page-break-inside: avoid;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example">
+        <div>
+            <p>The effect of this property can be noticed when the document is being printed or a preview of a print is displayed.</p>
+            <button id="print-btn">Show Print Preview</button>
+            <div class="box-container">
+                <div class="box">Content Before</div>
+                <div class="box" id="example-element">Content with page-break-inside</div>
+                <div class="box">Content After</div>
+            </div>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
Those are interactive examples for CSS properties [break-before](https://developer.mozilla.org/en-US/docs/Web/CSS/break-before), [break-after](https://developer.mozilla.org/en-US/docs/Web/CSS/break-after), [break-inside](https://developer.mozilla.org/en-US/docs/Web/CSS/break-inside), [page-break-before](https://developer.mozilla.org/en-US/docs/Web/CSS/page-break-before), [page-break-after](https://developer.mozilla.org/en-US/docs/Web/CSS/page-break-after), [page-break-inside](https://developer.mozilla.org/en-US/docs/Web/CSS/page-break-inside).

![image](https://user-images.githubusercontent.com/100634371/179369524-5b949ae5-3e68-49b4-96bd-a843fdc4b62f.png)
When button is pressed and value page or left is selected, first page looks like that:
![image](https://user-images.githubusercontent.com/100634371/179369536-1901030f-0722-4ef4-a52b-fedcd2e44311.png)
Second page looks like that:
![image](https://user-images.githubusercontent.com/100634371/179369540-b29b361f-85f2-4f21-92dc-5da205d2f1e8.png)

![image](https://user-images.githubusercontent.com/100634371/179369564-ab9d01b4-0609-42d7-a90b-141ff8d7046a.png)

![image](https://user-images.githubusercontent.com/100634371/179369571-43c94837-a327-48bd-a86a-ad85922404fc.png)

![image](https://user-images.githubusercontent.com/100634371/179369579-1d977138-4b8e-4cf0-a416-de7d724e569b.png)

![image](https://user-images.githubusercontent.com/100634371/179369580-9c8f68f8-e5fb-486f-8d6a-6669285515be.png)

![image](https://user-images.githubusercontent.com/100634371/179369584-49355e65-3ae9-4d4c-8803-6dde7a2c7aa7.png)

In break-inside & page-break-inside, middle box has very big height when document is in print preview. Value avoid looks like that:
![image](https://user-images.githubusercontent.com/100634371/179369621-ff24c856-e350-40f9-bdcb-995c4033bc23.png)
