### PR TITLE
feat(html): Add example of `exportparts` attribute

### DIFF
--- a/live-examples/html-examples/global-attributes/attribute-exportparts.html
+++ b/live-examples/html-examples/global-attributes/attribute-exportparts.html
@@ -1,0 +1,21 @@
+<template id="shadowStructure">
+    <p part="paragraph">
+        This paragraph is in Shadow Tree and can be reached because part attribute is set.
+    </p>
+    <p class="not-exported-paragraph">
+        This paragraph is in Shadow Tree and cannot be reached because part attribute is NOT set.
+    </p>
+
+    <template id="nestedShadowStructure">
+        <p part="nested-paragraph">
+            This paragraph exists in nested Shadow Tree and can be reached because its part is set and exported.
+        </p>
+        <p part="skipped-nested-paragraph">
+            This paragraph exists in nested Shadow Tree but its part is NOT exported.
+        </p>
+    </template>
+
+    <div id="nestedShadowHost" exportparts="nested-paragraph"></div>
+</template>
+
+<div id="shadowHost"></div>

--- a/live-examples/html-examples/global-attributes/attribute-exportparts.html
+++ b/live-examples/html-examples/global-attributes/attribute-exportparts.html
@@ -1,17 +1,17 @@
 <template id="shadowStructure">
     <p part="paragraph">
-        This paragraph is in Shadow Tree and can be reached because part attribute is set.
+        This paragraph is in a shadow tree and can be reached because the <code>part</code> attribute is set.
     </p>
     <p class="not-exported-paragraph">
-        This paragraph is in Shadow Tree and cannot be reached because part attribute is NOT set.
+        This paragraph is in a shadow tree and cannot be reached because the <code>part</code> attribute is <em>not</em> set.
     </p>
 
     <template id="nestedShadowStructure">
         <p part="nested-paragraph">
-            This paragraph exists in nested Shadow Tree and can be reached because its part is set and exported.
+            This paragraph exists in a nested shadow tree and can be reached because its <code>part</code> attribute is set and exported.
         </p>
         <p part="skipped-nested-paragraph">
-            This paragraph exists in nested Shadow Tree but its part is NOT exported.
+            This paragraph exists in a nested shadow tree but its <code>part</code> attribute is <em>not</em> exported.
         </p>
     </template>
 

--- a/live-examples/html-examples/global-attributes/css/attribute-exportparts.css
+++ b/live-examples/html-examples/global-attributes/css/attribute-exportparts.css
@@ -3,8 +3,8 @@
 }
 
 .not-exported-paragraph {
-    /* This value will not be applied, because selector
-       cannot find elements present in Shadow DOM */
+    /* This value will not be applied, because the selector
+       cannot find elements present in the shadow DOM */
     color: red;
 }
 

--- a/live-examples/html-examples/global-attributes/css/attribute-exportparts.css
+++ b/live-examples/html-examples/global-attributes/css/attribute-exportparts.css
@@ -1,0 +1,18 @@
+#shadowHost::part(paragraph) {
+    color: green;
+}
+
+.not-exported-paragraph {
+    /* This value will not be applied, because selector
+       cannot find elements present in Shadow DOM */
+    color: red;
+}
+
+#shadowHost::part(nested-paragraph) {
+    color: coral;
+    font-weight: bold;
+}
+
+#shadowHost::part(skipped-nested-paragraph) {
+    color: red;
+}

--- a/live-examples/html-examples/global-attributes/js/attribute-exportparts.js
+++ b/live-examples/html-examples/global-attributes/js/attribute-exportparts.js
@@ -1,0 +1,12 @@
+const shadowStructure = document.getElementById('shadowStructure');
+const shadowHost = document.getElementById('shadowHost');
+
+shadowHost.attachShadow({ mode: "open" });
+shadowHost.shadowRoot.appendChild(shadowStructure.content);
+
+const root = shadowHost.shadowRoot;
+const nestedShadowStructure = root.getElementById('nestedShadowStructure');
+const nestedShadowHost = root.getElementById('nestedShadowHost');
+
+nestedShadowHost.attachShadow({ mode: "open" });
+nestedShadowHost.shadowRoot.appendChild(nestedShadowStructure.content);

--- a/live-examples/html-examples/global-attributes/meta.json
+++ b/live-examples/html-examples/global-attributes/meta.json
@@ -48,6 +48,17 @@
             "type": "tabbed",
             "height": "tabbed-shorter"
         },
+        "exportparts": {
+            "exampleCode": "./live-examples/html-examples/global-attributes/attribute-exportparts.html",
+            "cssExampleSrc": "./live-examples/html-examples/global-attributes/css/attribute-exportparts.css",
+            "jsExampleSrc": "./live-examples/html-examples/global-attributes/js/attribute-exportparts.js",
+            "fileName": "attribute-exportparts.html",
+            "title": "HTML Demo: exportparts",
+            "type": "tabbed",
+            "defaultTab": "html",
+            "tabs": "html,css,js",
+            "height": "tabbed-taller"
+        },
         "hidden": {
             "exampleCode": "./live-examples/html-examples/global-attributes/attribute-hidden.html",
             "cssExampleSrc": "./live-examples/html-examples/global-attributes/css/attribute-hidden.css",


### PR DESCRIPTION
This is interactive example for [exportparts](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/exportparts) attribute.

![image](https://user-images.githubusercontent.com/100634371/179721105-e7628bbe-a1c4-4a0a-83e3-52c785b35dea.png)
