### PR TITLE
Fix invalid data-property values

### DIFF
--- a/live-examples/css-examples/basic-user-interface/appearance.html
+++ b/live-examples/css-examples/basic-user-interface/appearance.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list">
+<section id="example-choice-list" class="example-choice-list" data-property="appearance">
   <div class="example-choice">
     <pre><code class="language-css">
         appearance: none;</code></pre>

--- a/live-examples/css-examples/fonts/font-optical-sizing.html
+++ b/live-examples/css-examples/fonts/font-optical-sizing.html
@@ -1,4 +1,4 @@
-<section id="example-choice-list" class="example-choice-list" data-property="font-size">
+<section id="example-choice-list" class="example-choice-list" data-property="font-optical-sizing">
     <div class="example-choice">
         <pre><code class="language-css">font-optical-sizing: auto;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">


### PR DESCRIPTION
This PR fixes invalid value of "data-property" attribute in two css properties. That attribute is used by BOB to determine whether browser supports presented property, so it can show examples instead of a fallback dialog.