### PR TITLE
scroll-snap-stop

### DIFF
--- a/live-examples/css-examples/scroll-snap/meta.json
+++ b/live-examples/css-examples/scroll-snap/meta.json
@@ -154,6 +154,13 @@
             "title": "CSS Demo: scroll-padding-top",
             "type": "css"
         },
+        "scrollSnapStop": {
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-snap-stop.css",
+            "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-snap-stop.html",
+            "fileName": "scroll-snap-stop.html",
+            "title": "CSS Demo: scroll-snap-stop",
+            "type": "css"
+        },
         "scrollSnapType": {
             "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-snap-type.css",
             "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-snap-type.html",

--- a/live-examples/css-examples/scroll-snap/scroll-snap-stop.css
+++ b/live-examples/css-examples/scroll-snap/scroll-snap-stop.css
@@ -1,0 +1,45 @@
+.default-example {
+    flex-direction: column;
+}
+
+.explanation {
+    margin-top: 0;
+}
+
+.keyword {
+    color: darkorange;
+}
+
+.default-example .info {
+    width: 100%;
+    padding: .5em 0;
+    font-size: 90%;
+}
+
+.snap-container {
+    text-align: left;
+    width: 250px;
+    height: 250px;
+    overflow-x: scroll;
+    display: flex;
+    box-sizing: border-box;
+    border: 1px solid black;
+    scroll-snap-type: x mandatory;
+}
+
+.snap-container > div {
+    flex: 0 0 250px;
+    width: 250px;
+    background-color: rebeccapurple;
+    color: #fff;
+    font-size: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    scroll-snap-align: start;
+}
+
+.snap-container > div:nth-child(even) {
+    background-color: #fff;
+    color: rebeccapurple;
+}

--- a/live-examples/css-examples/scroll-snap/scroll-snap-stop.html
+++ b/live-examples/css-examples/scroll-snap/scroll-snap-stop.html
@@ -1,0 +1,29 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="scroll-snap-stop">
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">scroll-snap-stop: normal;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">scroll-snap-stop: always;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output large hidden">
+
+    <section id="default-example" class="default-example">
+        <p class="explanation">The effect of this property can be noticed on devices with a touchpad. Try to scroll through all items with a single swing. Value <b class="keyword">'normal'</b> should pass through all pages, while <b class="keyword">'always'</b> will stop at the second page.</p>
+        <div class="snap-container">
+            <div>1</div>
+            <div id="example-element">2</div>
+            <div>3</div>
+        </div>
+
+        <div class="info">Scroll &raquo;</div>
+    </section>
+</div>


### PR DESCRIPTION
This is interactive example for [scroll-snap-stop](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-stop).
It comes in firefox 103 and was requested in [#17469](https://github.com/mdn/content/issues/17469).

![image](https://user-images.githubusercontent.com/100634371/180602940-5f02d415-3c6f-4723-ad55-95c64824d2c3.png)
