### PR TITLE
feat(html): Add example of `is` global attribute

### DIFF
--- a/live-examples/html-examples/global-attributes/attribute-is.html
+++ b/live-examples/html-examples/global-attributes/attribute-is.html
@@ -1,5 +1,5 @@
 <p>Please describe why would you like to work for us:</p>
 
 <div class="length-textarea-container">
-    <textarea is="length-left-textarea" maxLength="150">I would like to work for you because ...</textarea>
+    <textarea is="length-left-textarea" maxLength="150">I would like to work for you because…</textarea>
 </div>

--- a/live-examples/html-examples/global-attributes/attribute-is.html
+++ b/live-examples/html-examples/global-attributes/attribute-is.html
@@ -1,0 +1,5 @@
+<p>Please describe why would you like to work for us:</p>
+
+<div class="length-textarea-container">
+    <textarea is="length-left-textarea" maxLength="150">I would like to work for you because ...</textarea>
+</div>

--- a/live-examples/html-examples/global-attributes/css/attribute-is.css
+++ b/live-examples/html-examples/global-attributes/css/attribute-is.css
@@ -1,0 +1,19 @@
+textarea {
+    width: 100%;
+    height: 100%;
+    resize: none;
+}
+
+.length-textarea-container {
+    position: relative;
+    width: 100%;
+    height: 10em;
+}
+
+.length-textarea-container::after {
+    content: 'Characters left: ' attr(length-left);
+    position: absolute;
+    bottom: 5px;
+    right: 5px;
+    color: grey;
+}

--- a/live-examples/html-examples/global-attributes/js/attribute-is.js
+++ b/live-examples/html-examples/global-attributes/js/attribute-is.js
@@ -1,0 +1,18 @@
+class LengthLeftTextarea extends HTMLTextAreaElement {
+  constructor() {
+    super();
+
+    const updateLengthAttribute = (newContent) => {
+      const length = newContent ? newContent.length : 0;
+      const lengthLeft = this.maxLength - length;
+      this.parentNode.setAttribute('length-left', lengthLeft);
+    };
+
+    updateLengthAttribute(this.value);
+    this.addEventListener('input', (e) => {
+      updateLengthAttribute(e.target.value);
+    });
+  }
+}
+
+customElements.define('length-left-textarea', LengthLeftTextarea, { extends: 'textarea' });

--- a/live-examples/html-examples/global-attributes/meta.json
+++ b/live-examples/html-examples/global-attributes/meta.json
@@ -64,6 +64,17 @@
             "type": "tabbed",
             "height": "tabbed-shorter"
         },
+        "is": {
+            "exampleCode": "./live-examples/html-examples/global-attributes/attribute-is.html",
+            "cssExampleSrc": "./live-examples/html-examples/global-attributes/css/attribute-is.css",
+            "jsExampleSrc": "./live-examples/html-examples/global-attributes/js/attribute-is.js",
+            "fileName": "attribute-is.html",
+            "title": "HTML Demo: is",
+            "type": "tabbed",
+            "defaultTab": "html",
+            "tabs": "html,css,js",
+            "height": "tabbed-standard"
+        },
         "lang": {
             "exampleCode": "./live-examples/html-examples/global-attributes/attribute-lang.html",
             "cssExampleSrc": "./live-examples/html-examples/global-attributes/css/attribute-lang.css",


### PR DESCRIPTION
This is interactive example for [is](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/is) attribute.
This PR depends on Shadow DOM fix.

![image](https://user-images.githubusercontent.com/100634371/180767926-a275d89b-121c-4ddb-90e2-30f5fe33e60d.png)
