### PR TITLE
Proper contrast in min() & max()

### DIFF
--- a/live-examples/css-examples/values-and-units/function-max.html
+++ b/live-examples/css-examples/values-and-units/function-max.html
@@ -24,7 +24,7 @@
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
       <div id="example-element" class="transition-all">
-        <img src="../../media/examples/dino.svg" alt="MDN Dino logo" class="logo">
+        <img src="../../media/examples/firefox-logo.svg" alt="MDN Dino logo" class="logo">
       </div>
     </section>
 </div>

--- a/live-examples/css-examples/values-and-units/function-max.html
+++ b/live-examples/css-examples/values-and-units/function-max.html
@@ -24,7 +24,7 @@
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
       <div id="example-element" class="transition-all">
-        <img src="../../media/examples/firefox-logo.svg" alt="MDN Dino logo" class="logo">
+        <img src="../../media/examples/firefox-logo.svg" alt="Firefox logo" class="logo">
       </div>
     </section>
 </div>

--- a/live-examples/css-examples/values-and-units/function-min.html
+++ b/live-examples/css-examples/values-and-units/function-min.html
@@ -24,7 +24,7 @@
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
       <div id="example-element" class="transition-all">
-        <img src="../../media/examples/dino.svg" alt="MDN Dino logo" class="logo">
+        <img src="../../media/examples/firefox-logo.svg" alt="MDN Dino logo" class="logo">
       </div>
     </section>
 </div>

--- a/live-examples/css-examples/values-and-units/function-min.html
+++ b/live-examples/css-examples/values-and-units/function-min.html
@@ -24,7 +24,7 @@
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
       <div id="example-element" class="transition-all">
-        <img src="../../media/examples/firefox-logo.svg" alt="MDN Dino logo" class="logo">
+        <img src="../../media/examples/firefox-logo.svg" alt="Firefox logo" class="logo">
       </div>
     </section>
 </div>


### PR DESCRIPTION
This PR changes image used in [min()](https://developer.mozilla.org/en-US/docs/Web/CSS/min) and [max()](https://developer.mozilla.org/en-US/docs/Web/CSS/max) examples. First I thought to change color of the image, but it's also used in other places.

Before:
![image](https://user-images.githubusercontent.com/100634371/181579625-2da5ae65-fc19-40f8-9834-f620372399f1.png)

After:
![image](https://user-images.githubusercontent.com/100634371/181579671-b3ec4cc8-7425-414c-af82-ce5c2c21a04c.png)
