### PR TITLE
Include audio/video fallback downloads.

### DIFF
--- a/live-examples/html-examples/embedded-content/source.html
+++ b/live-examples/html-examples/embedded-content/source.html
@@ -9,6 +9,6 @@
     Download the
     <a href="/media/cc0-videos/flower.webm">WEBM</a>
     or
-    <a href="/media/cc0-videos/flower.webm">MP4</a>
+    <a href="/media/cc0-videos/flower.mp4">MP4</a>
     video.
 </video>

--- a/live-examples/html-examples/embedded-content/source.html
+++ b/live-examples/html-examples/embedded-content/source.html
@@ -6,5 +6,9 @@
             type="video/webm">
     <source src="/media/cc0-videos/flower.mp4"
             type="video/mp4">
-    This browser does not support the HTML5 video element.
+    Download the
+    <a href="/media/cc0-videos/flower.webm">WEBM</a>
+    or
+    <a href="/media/cc0-videos/flower.webm">MP4</a>
+    video.
 </video>

--- a/live-examples/html-examples/image-and-multimedia/audio.html
+++ b/live-examples/html-examples/image-and-multimedia/audio.html
@@ -3,7 +3,8 @@
     <audio
         controls
         src="/media/cc0-audio/t-rex-roar.mp3">
-            Your browser does not support the
-            <code>audio</code> element.
+            <a href="/media/cc0-audio/t-rex-roar.mp3">
+                Download audio
+            </a>
     </audio>
 </figure>

--- a/live-examples/html-examples/image-and-multimedia/track.html
+++ b/live-examples/html-examples/image-and-multimedia/track.html
@@ -4,5 +4,8 @@
            kind="captions"
            srclang="en"
            src="/media/examples/friday.vtt" />
-    Sorry, your browser doesn't support embedded videos.
+    Download the
+    <a href="/media/cc0-videos/friday.mp4">MP4</a>
+    video, and
+    <a href="/media/examples/friday.vtt">subtitles</a>.
 </video>

--- a/live-examples/html-examples/image-and-multimedia/video.html
+++ b/live-examples/html-examples/image-and-multimedia/video.html
@@ -9,6 +9,6 @@
     Download the
     <a href="/media/cc0-videos/flower.webm">WEBM</a>
     or
-    <a href="/media/cc0-videos/flower.webm">MP4</a>
+    <a href="/media/cc0-videos/flower.mp4">MP4</a>
     video.
 </video>

--- a/live-examples/html-examples/image-and-multimedia/video.html
+++ b/live-examples/html-examples/image-and-multimedia/video.html
@@ -6,5 +6,9 @@
     <source src="/media/cc0-videos/flower.mp4"
             type="video/mp4">
 
-    Sorry, your browser doesn't support embedded videos.
+    Download the
+    <a href="/media/cc0-videos/flower.webm">WEBM</a>
+    or
+    <a href="/media/cc0-videos/flower.webm">MP4</a>
+    video.
 </video>


### PR DESCRIPTION
As per e.g. the MDN audio help, “it's a good practice to provide some
content (such as the direct download link) as a fallback for viewers”
so include this good practice in the examples.

Links with https://github.com/mdn/content/pull/19790 to update other similar content on the page.