### PR TITLE
Bump minimum Node.js to v16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
           cache: "yarn"
 
       - name: Cache node_modules

--- a/.github/workflows/stage-deploy.yml
+++ b/.github/workflows/stage-deploy.yml
@@ -26,7 +26,7 @@ jobs:
             - name: Setup Node.js environment
               uses: actions/setup-node@v3
               with:
-                  node-version: '14'
+                  node-version: '16'
 
             - name: Install all yarn packages
               if: steps.cached-node_modules.outputs.cache-hit != 'true'

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
         "mdn",
         "mozilla"
     ],
+    "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+    },
     "devDependencies": {
         "@babel/core": "^7.19.0",
         "@babel/eslint-parser": "^7.18.9",


### PR DESCRIPTION
This PR sets the minimum Node.js requirement to v16 by bumping the CI to use v16, and add the requirements to the package.json.  This synchronizes requirements with other projects.

This is required if https://github.com/mdn/bob/pull/882 lands.
