### PR TITLE
Add clarity to assignment behavior

### DIFF
--- a/live-examples/js-examples/object/object-assign.js
+++ b/live-examples/js-examples/object/object-assign.js
@@ -8,3 +8,6 @@ console.log(target);
 
 console.log(returnedTarget);
 // expected output: Object { a: 1, b: 4, c: 5 }
+
+console.log(returnedTarget === target)
+// expected output: true

--- a/live-examples/js-examples/object/object-assign.js
+++ b/live-examples/js-examples/object/object-assign.js
@@ -6,8 +6,5 @@ const returnedTarget = Object.assign(target, source);
 console.log(target);
 // expected output: Object { a: 1, b: 4, c: 5 }
 
-console.log(returnedTarget);
-// expected output: Object { a: 1, b: 4, c: 5 }
-
 console.log(returnedTarget === target)
 // expected output: true

--- a/live-examples/js-examples/object/object-assign.js
+++ b/live-examples/js-examples/object/object-assign.js
@@ -6,5 +6,5 @@ const returnedTarget = Object.assign(target, source);
 console.log(target);
 // expected output: Object { a: 1, b: 4, c: 5 }
 
-console.log(returnedTarget === target)
+console.log(returnedTarget === target);
 // expected output: true


### PR DESCRIPTION
Use a strict equality comparison to emphasize that `returnedTarget` is the same as the original `target` parameter. 