### PR TITLE
Removing closing tags in `source` and `img` tags in `picture` example

### DIFF
--- a/live-examples/html-examples/embedded-content/picture.html
+++ b/live-examples/html-examples/embedded-content/picture.html
@@ -2,6 +2,6 @@
 
 <picture>
     <source srcset="/media/cc0-images/surfer-240-200.jpg"
-            media="(min-width: 800px)" />
-    <img src="/media/cc0-images/painted-hand-298-332.jpg" alt="" />
+            media="(min-width: 800px)" >
+    <img src="/media/cc0-images/painted-hand-298-332.jpg" alt="" >
 </picture>

--- a/live-examples/html-examples/embedded-content/picture.html
+++ b/live-examples/html-examples/embedded-content/picture.html
@@ -2,6 +2,6 @@
 
 <picture>
     <source srcset="/media/cc0-images/surfer-240-200.jpg"
-            media="(min-width: 800px)">
+            media="(min-width: 800px)" />
     <img src="/media/cc0-images/painted-hand-298-332.jpg" alt="" />
 </picture>

--- a/live-examples/html-examples/embedded-content/picture.html
+++ b/live-examples/html-examples/embedded-content/picture.html
@@ -2,6 +2,6 @@
 
 <picture>
     <source srcset="/media/cc0-images/surfer-240-200.jpg"
-            media="(min-width: 800px)" >
-    <img src="/media/cc0-images/painted-hand-298-332.jpg" alt="" >
+            media="(min-width: 800px)">
+    <img src="/media/cc0-images/painted-hand-298-332.jpg" alt="">
 </picture>


### PR DESCRIPTION
Example is visible on this page: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture