### PR TITLE
Remove closing tag from void elements

### DIFF
--- a/live-examples/css-examples/basic-box-model/overscroll-behavior.html
+++ b/live-examples/css-examples/basic-box-model/overscroll-behavior.html
@@ -28,8 +28,8 @@
         <div class="example-container">
             <div class="box">
                 This is a scrollable container. Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather. As much mud in the streets as if the waters had but newly retired from the face of the earth.
-                <br/><br/>
-                Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. 
+                <br><br>
+                Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.
             </div>
             <div id="example-element">
                 This is the inner container. Focus on this container, scroll to the bottom and when you reach the bottom keep scrolling.

--- a/live-examples/css-examples/compositing-and-blending/mix-blend-mode.html
+++ b/live-examples/css-examples/compositing-and-blending/mix-blend-mode.html
@@ -31,7 +31,7 @@
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
         <div class="example-container">
-            <img id="example-element" src="../../media/examples/firefox-logo.svg" width="200" />
+            <img id="example-element" src="../../media/examples/firefox-logo.svg" width="200">
         </div>
     </section>
 </div>

--- a/live-examples/css-examples/filter-effects/filter.html
+++ b/live-examples/css-examples/filter-effects/filter.html
@@ -44,6 +44,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/filter-effects/function-blur.html
+++ b/live-examples/css-examples/filter-effects/function-blur.html
@@ -23,6 +23,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/filter-effects/function-brightness.html
+++ b/live-examples/css-examples/filter-effects/function-brightness.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/filter-effects/function-contrast.html
+++ b/live-examples/css-examples/filter-effects/function-contrast.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/filter-effects/function-drop-shadow.html
+++ b/live-examples/css-examples/filter-effects/function-drop-shadow.html
@@ -23,6 +23,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/filter-effects/function-grayscale.html
+++ b/live-examples/css-examples/filter-effects/function-grayscale.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/filter-effects/function-hue-rotate.html
+++ b/live-examples/css-examples/filter-effects/function-hue-rotate.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/filter-effects/function-invert.html
+++ b/live-examples/css-examples/filter-effects/function-invert.html
@@ -37,6 +37,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/filter-effects/function-opacity.html
+++ b/live-examples/css-examples/filter-effects/function-opacity.html
@@ -37,6 +37,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/filter-effects/function-saturate.html
+++ b/live-examples/css-examples/filter-effects/function-saturate.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/filter-effects/function-sepia.html
+++ b/live-examples/css-examples/filter-effects/function-sepia.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/images/aspect-ratio.html
+++ b/live-examples/css-examples/images/aspect-ratio.html
@@ -32,6 +32,6 @@
 
 <div id="output" class="output hidden">
     <section id="default-example">
-        <img id="example-element" src="../../media/examples/plumeria.jpg" class="transition-all" width="466" height="640"/>
+        <img id="example-element" src="../../media/examples/plumeria.jpg" class="transition-all" width="466" height="640">
     </section>
 </div>

--- a/live-examples/css-examples/images/image-rendering.html
+++ b/live-examples/css-examples/images/image-rendering.html
@@ -23,6 +23,6 @@
 
 <div id="output" class="output hidden">
     <section id="default-example">
-        <img id="example-element" src="../../media/examples/lizard.png" class="transition-all" />
+        <img id="example-element" src="../../media/examples/lizard.png" class="transition-all">
     </section>
 </div>

--- a/live-examples/css-examples/images/object-fit.html
+++ b/live-examples/css-examples/images/object-fit.html
@@ -37,6 +37,6 @@
 
 <div id="output" class="output hidden">
     <section id="default-example">
-      <img  id="example-element" src="../../media/examples/plumeria.jpg" class="transition-all"/>
+      <img id="example-element" src="../../media/examples/plumeria.jpg" class="transition-all">
     </section>
 </div>

--- a/live-examples/css-examples/images/object-position.html
+++ b/live-examples/css-examples/images/object-position.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output hidden">
     <section id="default-example">
-        <img id="example-element" src="../../media/examples/moon.jpg" class="transition-all" />
+        <img id="example-element" src="../../media/examples/moon.jpg" class="transition-all">
     </section>
 </div>

--- a/live-examples/css-examples/masking/clip-path.html
+++ b/live-examples/css-examples/masking/clip-path.html
@@ -31,7 +31,7 @@
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
         <div class="example-container">
-            <img id="example-element" class="transition-all" src="/media/examples/balloon-small.jpg" width="150" />
+            <img id="example-element" class="transition-all" src="/media/examples/balloon-small.jpg" width="150">
             We had agreed, my companion and I, that I should call for him at his house, after dinner, not later than eleven o’clock. This athletic young Frenchman belongs to a small set of Parisian sportsmen, who have taken up “ballooning” as a pastime. After having exhausted all the sensations that are to be found in ordinary sports, even those of “automobiling” at a breakneck speed, the members of the “Aéro Club” now seek in the air, where they indulge in all kinds of daring feats, the nerve-racking excitement that they have ceased to find on earth.
         </div>
     </section>

--- a/live-examples/css-examples/masking/mask-type.html
+++ b/live-examples/css-examples/masking/mask-type.html
@@ -16,7 +16,7 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
-        <img class="box" src="/media/examples/balloon-small.jpg" />
+        <img class="box" src="/media/examples/balloon-small.jpg">
         <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="0" height="0">
             <defs>
                 <mask id="example-element" maskContentUnits="objectBoundingBox">

--- a/live-examples/css-examples/positioned-layout/position.html
+++ b/live-examples/css-examples/positioned-layout/position.html
@@ -41,8 +41,8 @@ top: 20px;</code></pre>
             <p class="clear">To see the effect of <code>sticky</code> positioning, select the <code>position: sticky</code> option and scroll this container.</p>
             <p>The element will scroll along with its container, until it is at the top of the container (or reaches the offset specified in <code>top</code>), and will then stop scrolling, so it stays visible.</p>
             <p>The rest of this text is only supplied to make sure the container overflows, so as to enable you to scroll it and see the effect.</p>
-            <hr/>
             <p>Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a small unregarded yellow sun. Orbiting this at a distance of roughly ninety-two million miles is an utterly insignificant little blue green planet whose ape-descended life forms are so amazingly primitive that they still think digital watches are a pretty neat idea.</p> 
+            <hr>
         </div>
     </section>
 </div>

--- a/live-examples/css-examples/positioned-layout/position.html
+++ b/live-examples/css-examples/positioned-layout/position.html
@@ -41,8 +41,8 @@ top: 20px;</code></pre>
             <p class="clear">To see the effect of <code>sticky</code> positioning, select the <code>position: sticky</code> option and scroll this container.</p>
             <p>The element will scroll along with its container, until it is at the top of the container (or reaches the offset specified in <code>top</code>), and will then stop scrolling, so it stays visible.</p>
             <p>The rest of this text is only supplied to make sure the container overflows, so as to enable you to scroll it and see the effect.</p>
-            <p>Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a small unregarded yellow sun. Orbiting this at a distance of roughly ninety-two million miles is an utterly insignificant little blue green planet whose ape-descended life forms are so amazingly primitive that they still think digital watches are a pretty neat idea.</p> 
             <hr>
+            <p>Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a small unregarded yellow sun. Orbiting this at a distance of roughly ninety-two million miles is an utterly insignificant little blue green planet whose ape-descended life forms are so amazingly primitive that they still think digital watches are a pretty neat idea.</p> 
         </div>
     </section>
 </div>

--- a/live-examples/css-examples/pseudo-element/cue.html
+++ b/live-examples/css-examples/pseudo-element/cue.html
@@ -3,6 +3,6 @@
     <track default
            kind="captions"
            srclang="en"
-           src="/media/examples/friday.vtt" />
+           src="/media/examples/friday.vtt">
     Sorry, your browser doesn't support embedded videos.
 </video>

--- a/live-examples/css-examples/shapes/shape-outside.html
+++ b/live-examples/css-examples/shapes/shape-outside.html
@@ -31,7 +31,7 @@
 <div id="output" class="output large hidden">
     <section id="default-example" class="default-example">
         <div class="example-container">
-            <img id="example-element" class="transition-all" src="/media/examples/round-balloon.png" width="150" />
+            <img id="example-element" class="transition-all" src="/media/examples/round-balloon.png" width="150">
             We had agreed, my companion and I, that I should call for him at his house, after dinner, not later than eleven o’clock. This athletic young Frenchman belongs to a small set of Parisian sportsmen, who have taken up “ballooning” as a pastime. After having exhausted all the sensations that are to be found in ordinary sports, even those of “automobiling” at a breakneck speed, the members of the “Aéro Club” now seek in the air, where they indulge in all kinds of daring feats, the nerve-racking excitement that they have ceased to find on earth.
         </div>
     </section>

--- a/live-examples/css-examples/transforms/function-matrix.html
+++ b/live-examples/css-examples/transforms/function-matrix.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/transforms/function-matrix3d.html
+++ b/live-examples/css-examples/transforms/function-matrix3d.html
@@ -24,6 +24,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/transforms/function-rotate.html
+++ b/live-examples/css-examples/transforms/function-rotate.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/transforms/function-rotateX.html
+++ b/live-examples/css-examples/transforms/function-rotateX.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/transforms/function-rotateY.html
+++ b/live-examples/css-examples/transforms/function-rotateY.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/transforms/function-rotateZ.html
+++ b/live-examples/css-examples/transforms/function-rotateZ.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/transforms/function-scale.html
+++ b/live-examples/css-examples/transforms/function-scale.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/transforms/function-scaleX.html
+++ b/live-examples/css-examples/transforms/function-scaleX.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/transforms/function-scaleY.html
+++ b/live-examples/css-examples/transforms/function-scaleY.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/transforms/function-skew.html
+++ b/live-examples/css-examples/transforms/function-skew.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/transforms/function-skewX.html
+++ b/live-examples/css-examples/transforms/function-skewX.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/transforms/function-skewY.html
+++ b/live-examples/css-examples/transforms/function-skewY.html
@@ -30,6 +30,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/transforms/function-translate.html
+++ b/live-examples/css-examples/transforms/function-translate.html
@@ -30,7 +30,7 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="static-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="static-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/transforms/function-translateX.html
+++ b/live-examples/css-examples/transforms/function-translateX.html
@@ -30,7 +30,7 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="static-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="static-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/transforms/function-translateY.html
+++ b/live-examples/css-examples/transforms/function-translateY.html
@@ -30,7 +30,7 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="static-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="static-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/css-examples/transforms/transform-origin.html
+++ b/live-examples/css-examples/transforms/transform-origin.html
@@ -32,7 +32,7 @@
     <section id="default-example">
         <div id="example-container">
             <div id="example-element">Rotate me!</div>
-            <img id="crosshair" src="../../media/examples/crosshair.svg" width="24px" />
+            <img id="crosshair" src="../../media/examples/crosshair.svg" width="24px">
             <div id="static-element"></div>
         </div>
     </section>

--- a/live-examples/css-examples/transforms/transform.html
+++ b/live-examples/css-examples/transforms/transform.html
@@ -44,6 +44,6 @@
 
 <div id="output" class="output large hidden">
     <section id="default-example">
-        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200" />
+        <img id="example-element" class="transition-all" src="../../media/examples/firefox-logo.svg" width="200">
     </section>
 </div>

--- a/live-examples/html-examples/embedded-content/picture.html
+++ b/live-examples/html-examples/embedded-content/picture.html
@@ -3,5 +3,5 @@
 <picture>
     <source srcset="/media/cc0-images/surfer-240-200.jpg"
             media="(min-width: 800px)">
-    <img src="/media/cc0-images/painted-hand-298-332.jpg" alt="" />
+    <img src="/media/cc0-images/painted-hand-298-332.jpg" alt="">
 </picture>

--- a/live-examples/html-examples/forms/datalist.html
+++ b/live-examples/html-examples/forms/datalist.html
@@ -1,5 +1,5 @@
 <label for="ice-cream-choice">Choose a flavor:</label>
-<input list="ice-cream-flavors" id="ice-cream-choice" name="ice-cream-choice" />
+<input list="ice-cream-flavors" id="ice-cream-choice" name="ice-cream-choice">
 
 <datalist id="ice-cream-flavors">
     <option value="Chocolate">

--- a/live-examples/html-examples/forms/fieldset.html
+++ b/live-examples/html-examples/forms/fieldset.html
@@ -3,10 +3,10 @@
     <legend>Choose your favorite monster</legend>
 
     <input type="radio" id="kraken" name="monster">
-    <label for="kraken">Kraken</label><br/>
+    <label for="kraken">Kraken</label><br>
 
     <input type="radio" id="sasquatch" name="monster">
-    <label for="sasquatch">Sasquatch</label><br/>
+    <label for="sasquatch">Sasquatch</label><br>
 
     <input type="radio" id="mothman" name="monster">
     <label for="mothman">Mothman</label>

--- a/live-examples/html-examples/forms/legend.html
+++ b/live-examples/html-examples/forms/legend.html
@@ -2,10 +2,10 @@
     <legend>Choose your favorite monster</legend>
 
     <input type="radio" id="kraken" name="monster">
-    <label for="kraken">Kraken</label><br/>
+    <label for="kraken">Kraken</label><br>
 
     <input type="radio" id="sasquatch" name="monster">
-    <label for="sasquatch">Sasquatch</label><br/>
+    <label for="sasquatch">Sasquatch</label><br>
 
     <input type="radio" id="mothman" name="monster">
     <label for="mothman">Mothman</label>

--- a/live-examples/html-examples/image-and-multimedia/area.html
+++ b/live-examples/html-examples/image-and-multimedia/area.html
@@ -1,24 +1,24 @@
 <map name="infographic">
     <area shape="rect" coords="184,6,253,27"
           href="https://mozilla.org"
-          target="_blank" alt="Mozilla" />
+          target="_blank" alt="Mozilla">
     <area shape="circle" coords="130,136,60"
           href="https://developer.mozilla.org/"
-          target="_blank" alt="MDN" />
+          target="_blank" alt="MDN">
     <area shape="poly" coords="130,6,253,96,223,106,130,39"
           href="https://developer.mozilla.org/docs/Web/Guide/Graphics"
-          target="_blank" alt="Graphics" />
+          target="_blank" alt="Graphics">
     <area shape="poly" coords="253,96,207,241,189,217,223,103"
           href="https://developer.mozilla.org/docs/Web/HTML"
-          target="_blank" alt="HTML" />
+          target="_blank" alt="HTML">
     <area shape="poly" coords="207,241,54,241,72,217,189,217"
           href="https://developer.mozilla.org/docs/Web/JavaScript"
-          target="_blank" alt="JavaScript" />
+          target="_blank" alt="JavaScript">
     <area shape="poly" coords="54,241,6,97,36,107,72,217"
           href="https://developer.mozilla.org/docs/Web/API"
-          target="_blank" alt="Web APIs" />
+          target="_blank" alt="Web APIs">
     <area shape="poly" coords="6,97,130,6,130,39,36,107"
           href="https://developer.mozilla.org/docs/Web/CSS"
-          target="_blank" alt="CSS" />
+          target="_blank" alt="CSS">
 </map>
-<img usemap="#infographic" src="/media/examples/mdn-info.png" alt="MDN infographic" />
+<img usemap="#infographic" src="/media/examples/mdn-info.png" alt="MDN infographic">

--- a/live-examples/html-examples/image-and-multimedia/map.html
+++ b/live-examples/html-examples/image-and-multimedia/map.html
@@ -1,12 +1,12 @@
 <map name="infographic">
     <area shape="poly" coords="130,147,200,107,254,219,130,228"
           href="https://developer.mozilla.org/docs/Web/HTML"
-          target="_blank" alt="HTML" />
+          target="_blank" alt="HTML">
     <area shape="poly" coords="130,147,130,228,6,219,59,107"
           href="https://developer.mozilla.org/docs/Web/CSS"
-          target="_blank" alt="CSS" />
+          target="_blank" alt="CSS">
     <area shape="poly" coords="130,147,200,107,130,4,59,107"
           href="https://developer.mozilla.org/docs/Web/JavaScript"
-          target="_blank" alt="JavaScript" />
+          target="_blank" alt="JavaScript">
 </map>
-<img usemap="#infographic" src="/media/examples/mdn-info2.png" alt="MDN infographic" />
+<img usemap="#infographic" src="/media/examples/mdn-info2.png" alt="MDN infographic">

--- a/live-examples/html-examples/image-and-multimedia/track.html
+++ b/live-examples/html-examples/image-and-multimedia/track.html
@@ -3,6 +3,6 @@
     <track default
            kind="captions"
            srclang="en"
-           src="/media/examples/friday.vtt" />
+           src="/media/examples/friday.vtt">
     Sorry, your browser doesn't support embedded videos.
 </video>

--- a/live-examples/html-examples/input/reset.html
+++ b/live-examples/html-examples/input/reset.html
@@ -2,7 +2,7 @@
     <div class="controls">
 
         <label for="id">User ID:</label>
-        <input type="text" id="id" name="id" />
+        <input type="text" id="id" name="id">
 
         <input type="reset" value="Reset">
         <input type="submit" value="Submit">


### PR DESCRIPTION
I have removed closing tags from all void elements, to make it consistent across all html files. All void elements were checked, but there were problems only with: br, hr, img, track, input, area