### PR TITLE
Vertical layout in scroll-padding & scroll-margin

### DIFF
--- a/live-examples/css-examples/scroll-snap/meta.json
+++ b/live-examples/css-examples/scroll-snap/meta.json
@@ -1,7 +1,7 @@
 {
     "pages": {
         "scrollMargin": {
-            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-margin.css",
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-margin-top.css",
             "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-margin.html",
             "fileName": "scroll-margin.html",
             "title": "CSS Demo: scroll-margin",
@@ -78,7 +78,7 @@
             "type": "css"
         },
         "scrollPadding": {
-            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-padding.css",
+            "cssExampleSrc": "./live-examples/css-examples/scroll-snap/scroll-padding-top.css",
             "exampleCode": "./live-examples/css-examples/scroll-snap/scroll-padding.html",
             "fileName": "scroll-padding.html",
             "title": "CSS Demo: scroll-padding",


### PR DESCRIPTION
Changes examples in [scroll-padding](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding) & [scroll-margin](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin) to vertical representation, so they can be easily scrolled with a mouse wheel.

![image](https://user-images.githubusercontent.com/100634371/192372621-496744ea-08b4-49e3-92e1-32cf60dcc51e.png)

![image](https://user-images.githubusercontent.com/100634371/192372656-6152f132-5490-4dc4-bce3-6fae547950e3.png)


Fixes #2263 