### PR TITLE
hyphenate-character

### DIFF
--- a/live-examples/css-examples/text/hyphenate-character.css
+++ b/live-examples/css-examples/text/hyphenate-character.css
@@ -1,0 +1,7 @@
+#example-element {
+    border: 2px dashed #999;
+    font-size: 1.5rem;
+    text-align: left;
+    width: 7rem;
+    hyphens: auto;
+}

--- a/live-examples/css-examples/text/hyphenate-character.html
+++ b/live-examples/css-examples/text/hyphenate-character.html
@@ -1,0 +1,28 @@
+<section id="example-choice-list" class="example-choice-list" data-property="hyphenate-character">
+    <div class="example-choice">
+        <pre><code class="language-css">hyphenate-character: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">hyphenate-character: '=';</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">hyphenate-character: '—';</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+</section>
+
+<div id="output" class="output hidden">
+    <section id="default-example">
+        <p id="example-element">An extra&shy;ordinarily long English word!</p>
+    </section>
+</div>

--- a/live-examples/css-examples/text/meta.json
+++ b/live-examples/css-examples/text/meta.json
@@ -7,6 +7,13 @@
             "title": "CSS Demo: hanging-punctuation",
             "type": "css"
         },
+        "hyphenateCharacter": {
+            "cssExampleSrc": "./live-examples/css-examples/text/hyphenate-character.css",
+            "exampleCode": "./live-examples/css-examples/text/hyphenate-character.html",
+            "fileName": "hyphenate-character.html",
+            "title": "CSS Demo: hyphenate-character",
+            "type": "css"
+        },
         "hyphens": {
             "cssExampleSrc": "./live-examples/css-examples/text/hyphens.css",
             "exampleCode": "./live-examples/css-examples/text/hyphens.html",


### PR DESCRIPTION
This is interactive example for [hyphenate-character](https://developer.mozilla.org/en-US/docs/Web/CSS/hyphenate-character) CSS property.

![image](https://user-images.githubusercontent.com/100634371/192839423-e6225c97-f802-4557-adb4-8594a5361a54.png)
