### PR TITLE
Run prettier, multiple minor fixes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,13 @@
 {
     "singleQuote": true,
     "tabWidth": 4,
-    "printWidth": 120
+    "printWidth": 120,
+    "overrides": [
+        {
+            "files": "*.md",
+            "options": {
+                "tabWidth": 2
+            }
+        }
+    ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,39 +2,35 @@
 
 ## [1.0.2](https://github.com/mdn/interactive-examples/compare/v1.0.1...v1.0.2) (2022-08-22)
 
-
 ### Bug Fixes
 
-* typo ([0b72146](https://github.com/mdn/interactive-examples/commit/0b721460e6493cafbb240de51e98bb84d2521f5b))
-* typo in live example of array-findlastindex.js ([#2255](https://github.com/mdn/interactive-examples/issues/2255)) ([0b72146](https://github.com/mdn/interactive-examples/commit/0b721460e6493cafbb240de51e98bb84d2521f5b))
+- typo ([0b72146](https://github.com/mdn/interactive-examples/commit/0b721460e6493cafbb240de51e98bb84d2521f5b))
+- typo in live example of array-findlastindex.js ([#2255](https://github.com/mdn/interactive-examples/issues/2255)) ([0b72146](https://github.com/mdn/interactive-examples/commit/0b721460e6493cafbb240de51e98bb84d2521f5b))
 
 ### [1.0.1](https://github.com/mdn/interactive-examples/compare/v1.0.0...v1.0.1) (2022-05-19)
 
-
 ### Bug Fixes
 
-* Update Date.setTime() ([#2123](https://github.com/mdn/interactive-examples/issues/2123)) ([0b56481](https://github.com/mdn/interactive-examples/commit/0b5648128f6a94e96fe964a746b320922deb4b8e))
+- Update Date.setTime() ([#2123](https://github.com/mdn/interactive-examples/issues/2123)) ([0b56481](https://github.com/mdn/interactive-examples/commit/0b5648128f6a94e96fe964a746b320922deb4b8e))
 
 ## 1.0.0 (2022-05-15)
 
-
 ### Features
 
-* add logical properties example for float ([#1897](https://github.com/mdn/interactive-examples/issues/1897)) ([4d918f4](https://github.com/mdn/interactive-examples/commit/4d918f4aa7b8cb0cd0a0e3506f9de99c97cb52d4))
-* create codeql-analysis.yml ([#2149](https://github.com/mdn/interactive-examples/issues/2149)) ([44c5565](https://github.com/mdn/interactive-examples/commit/44c55650f908dc98226402074a562b2df640f6c1))
-
+- add logical properties example for float ([#1897](https://github.com/mdn/interactive-examples/issues/1897)) ([4d918f4](https://github.com/mdn/interactive-examples/commit/4d918f4aa7b8cb0cd0a0e3506f9de99c97cb52d4))
+- create codeql-analysis.yml ([#2149](https://github.com/mdn/interactive-examples/issues/2149)) ([44c5565](https://github.com/mdn/interactive-examples/commit/44c55650f908dc98226402074a562b2df640f6c1))
 
 ### Bug Fixes
 
-* change title attribute example ([66c1895](https://github.com/mdn/interactive-examples/commit/66c189582fbf8dc55c30ac2e4418c6cee109a142)), closes [#1822](https://github.com/mdn/interactive-examples/issues/1822)
-* Clarify string-endswith examples ([#1705](https://github.com/mdn/interactive-examples/issues/1705)) ([f670798](https://github.com/mdn/interactive-examples/commit/f670798b647f865dfbf32ddcc3da95c325c65a00))
-* deploy workflow ([#2142](https://github.com/mdn/interactive-examples/issues/2142)) ([e574640](https://github.com/mdn/interactive-examples/commit/e57464069e0e5e1802fbc40329d4a2ca794e1553))
-* deploy workflow ([#2143](https://github.com/mdn/interactive-examples/issues/2143)) ([d10117f](https://github.com/mdn/interactive-examples/commit/d10117f67c6f71525b52f0a19c42a1c26f22a87c))
-* deploy workflow ([#2144](https://github.com/mdn/interactive-examples/issues/2144)) ([ee49883](https://github.com/mdn/interactive-examples/commit/ee49883d6de6ed4e7ddffdcdc758fdd71b51902c))
-* deploy workflow ([#2144](https://github.com/mdn/interactive-examples/issues/2144)) ([#2145](https://github.com/mdn/interactive-examples/issues/2145)) ([b543cac](https://github.com/mdn/interactive-examples/commit/b543caccc4980791a436741161ea044a91a50e67))
-* only run deploy action if labeled release ([#2139](https://github.com/mdn/interactive-examples/issues/2139)) ([c2b8638](https://github.com/mdn/interactive-examples/commit/c2b863819a4e940cf66db0fde7ee0b5e7119df4c)), closes [#2138](https://github.com/mdn/interactive-examples/issues/2138)
-* remove expression syntax from if conditional ([#2150](https://github.com/mdn/interactive-examples/issues/2150)) ([5c2b632](https://github.com/mdn/interactive-examples/commit/5c2b6327ef1415d16333a1c2fffb729dba6edb39))
-* remove runs-on ([#2146](https://github.com/mdn/interactive-examples/issues/2146)) ([725e368](https://github.com/mdn/interactive-examples/commit/725e3688af8cbdd85fcf060dce7b35c4d1b8a644))
-* tabSize live-example for Firefox ([#1811](https://github.com/mdn/interactive-examples/issues/1811)) ([eae189b](https://github.com/mdn/interactive-examples/commit/eae189bc34864e088494c134570682deac053997))
-* Update publish-release.yml ([#2152](https://github.com/mdn/interactive-examples/issues/2152)) ([e3a69de](https://github.com/mdn/interactive-examples/commit/e3a69dee905c71c0b2e92d2186004686ca347006))
-* use js file not html for js examples ([#2148](https://github.com/mdn/interactive-examples/issues/2148)) ([79792f9](https://github.com/mdn/interactive-examples/commit/79792f9e5fdbe3b5ba606097ff843a3217cdad89))
+- change title attribute example ([66c1895](https://github.com/mdn/interactive-examples/commit/66c189582fbf8dc55c30ac2e4418c6cee109a142)), closes [#1822](https://github.com/mdn/interactive-examples/issues/1822)
+- Clarify string-endswith examples ([#1705](https://github.com/mdn/interactive-examples/issues/1705)) ([f670798](https://github.com/mdn/interactive-examples/commit/f670798b647f865dfbf32ddcc3da95c325c65a00))
+- deploy workflow ([#2142](https://github.com/mdn/interactive-examples/issues/2142)) ([e574640](https://github.com/mdn/interactive-examples/commit/e57464069e0e5e1802fbc40329d4a2ca794e1553))
+- deploy workflow ([#2143](https://github.com/mdn/interactive-examples/issues/2143)) ([d10117f](https://github.com/mdn/interactive-examples/commit/d10117f67c6f71525b52f0a19c42a1c26f22a87c))
+- deploy workflow ([#2144](https://github.com/mdn/interactive-examples/issues/2144)) ([ee49883](https://github.com/mdn/interactive-examples/commit/ee49883d6de6ed4e7ddffdcdc758fdd71b51902c))
+- deploy workflow ([#2144](https://github.com/mdn/interactive-examples/issues/2144)) ([#2145](https://github.com/mdn/interactive-examples/issues/2145)) ([b543cac](https://github.com/mdn/interactive-examples/commit/b543caccc4980791a436741161ea044a91a50e67))
+- only run deploy action if labeled release ([#2139](https://github.com/mdn/interactive-examples/issues/2139)) ([c2b8638](https://github.com/mdn/interactive-examples/commit/c2b863819a4e940cf66db0fde7ee0b5e7119df4c)), closes [#2138](https://github.com/mdn/interactive-examples/issues/2138)
+- remove expression syntax from if conditional ([#2150](https://github.com/mdn/interactive-examples/issues/2150)) ([5c2b632](https://github.com/mdn/interactive-examples/commit/5c2b6327ef1415d16333a1c2fffb729dba6edb39))
+- remove runs-on ([#2146](https://github.com/mdn/interactive-examples/issues/2146)) ([725e368](https://github.com/mdn/interactive-examples/commit/725e3688af8cbdd85fcf060dce7b35c4d1b8a644))
+- tabSize live-example for Firefox ([#1811](https://github.com/mdn/interactive-examples/issues/1811)) ([eae189b](https://github.com/mdn/interactive-examples/commit/eae189bc34864e088494c134570682deac053997))
+- Update publish-release.yml ([#2152](https://github.com/mdn/interactive-examples/issues/2152)) ([e3a69de](https://github.com/mdn/interactive-examples/commit/e3a69dee905c71c0b2e92d2186004686ca347006))
+- use js file not html for js examples ([#2148](https://github.com/mdn/interactive-examples/issues/2148)) ([79792f9](https://github.com/mdn/interactive-examples/commit/79792f9e5fdbe3b5ba606097ff843a3217cdad89))

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,4 +5,5 @@ For more details, please read the
 [Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/).
 
 ## How to Report
+
 For more information on how to report violations of the Community Participation Guidelines, please read our [How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/) page.

--- a/CONTRIBUTING-CSS.md
+++ b/CONTRIBUTING-CSS.md
@@ -8,18 +8,18 @@ Inside this newly created file, copy and paste the following code:
 
 ```html
 <section id="example-choice-list" class="example-choice-list large" data-property="border-radius">
-    <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">Your CSS goes here</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
+  <div class="example-choice" initial-choice="true">
+    <pre><code class="language-css">Your CSS goes here</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
 </section>
 
 <div id="output" class="output large hidden">
-    <section id="default-example" class="default-example">
-        <div id="example-element" class="transition-all"></div>
-    </section>
+  <section id="default-example" class="default-example">
+    <div id="example-element" class="transition-all"></div>
+  </section>
 </div>
 ```
 
@@ -27,9 +27,9 @@ This is the base starting point for all CSS examples.
 
 It consists of two main pieces:
 
--   **The example CSS**: the `section#example-choice-list` contains one or more `div.example-choice` elements. These are the choices that will be presented to the user on the left-hand side of the editor. Each choice contains some CSS declarations that will be applied to the example element when the user selects that choice.
+- **The example CSS**: the `section#example-choice-list` contains one or more `div.example-choice` elements. These are the choices that will be presented to the user on the left-hand side of the editor. Each choice contains some CSS declarations that will be applied to the example element when the user selects that choice.
 
--   **The example element**: the `section#default-example` contains all the markup for the editor's output pane. At a minimum this will contain a node with `id="example-element"`: this is the element that the chosen example CSS will be applied to.
+- **The example element**: the `section#default-example` contains all the markup for the editor's output pane. At a minimum this will contain a node with `id="example-element"`: this is the element that the chosen example CSS will be applied to.
 
 Let's fill this in for `border-radius`.
 
@@ -37,9 +37,9 @@ First, we'll specify the example element. For `border-radius` it makes sense to 
 
 ```html
 <div id="output" class="output large hidden">
-    <section id="default-example" class="default-example">
-        <div id="example-element" class="transition-all">Style Me!</div>
-    </section>
+  <section id="default-example" class="default-example">
+    <div id="example-element" class="transition-all">Style Me!</div>
+  </section>
 </div>
 ```
 
@@ -49,26 +49,26 @@ Next, let's add the example CSS choices. Think of a few different ways that `bor
 
 ```html
 <section id="example-choice-list" class="example-choice-list large" data-property="border-radius">
-    <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">border-radius: 10px;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
+  <div class="example-choice" initial-choice="true">
+    <pre><code class="language-css">border-radius: 10px;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
 
-    <div class="example-choice">
-        <pre><code class="language-css">border-radius: 10px 50%;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
+  <div class="example-choice">
+    <pre><code class="language-css">border-radius: 10px 50%;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
 
-    <div class="example-choice">
-        <pre><code class="language-css">border-radius: 10px 5px 6em / 20px 25px 30%;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
+  <div class="example-choice">
+    <pre><code class="language-css">border-radius: 10px 5px 6em / 20px 25px 30%;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
 </section>
 ```
 
@@ -80,32 +80,32 @@ Now we've finished writing the HTML for the example. The final version of `borde
 
 ```html
 <section id="example-choice-list" class="example-choice-list large" data-property="border-radius">
-    <div class="example-choice" initial-choice="true">
-        <pre><code class="language-css">border-radius: 10px;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
+  <div class="example-choice" initial-choice="true">
+    <pre><code class="language-css">border-radius: 10px;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
 
-    <div class="example-choice">
-        <pre><code class="language-css">border-radius: 10px 50%;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
+  <div class="example-choice">
+    <pre><code class="language-css">border-radius: 10px 50%;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
 
-    <div class="example-choice">
-        <pre><code class="language-css">border-radius: 10px 5px 6em / 20px 25px 30%;</code></pre>
-        <button type="button" class="copy hidden" aria-hidden="true">
-            <span class="visually-hidden">Copy to Clipboard</span>
-        </button>
-    </div>
+  <div class="example-choice">
+    <pre><code class="language-css">border-radius: 10px 5px 6em / 20px 25px 30%;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
 </section>
 
 <div id="output" class="output large hidden">
-    <section id="default-example" class="default-example">
-        <div id="example-element" class="transition-all">Style Me!</div>
-    </section>
+  <section id="default-example" class="default-example">
+    <div id="example-element" class="transition-all">Style Me!</div>
+  </section>
 </div>
 ```
 
@@ -115,8 +115,8 @@ When you're writing examples, please make sure that they conform to the [CSS Exa
 
 In general, to add an example for a property, it should be supported by most browser engines. Sometimes browser engines require a vendor prefix for the property, like `-webkit-` or `-moz-`. In this situation, you should:
 
--   supply all relevant variants in the `data-property` attribute
--   include all relevant variants in the example choices.
+- supply all relevant variants in the `data-property` attribute
+- include all relevant variants in the example choices.
 
 For example, suppose you want to add an example for [`box-decoration-break`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-decoration-break). This is supported unprefixed by Firefox but requires the `-webkit-` prefix in Chrome. To deal with this you would set `data-property` like this:
 
@@ -130,12 +130,12 @@ You would then use both variants in the example choices:
 
 ```html
 <div class="example-choice">
-    <pre><code class="language-css">box-decoration-break: clone;
+  <pre><code class="language-css">box-decoration-break: clone;
 -webkit-box-decoration-break: clone;
 box-shadow: 8px 8px 10px 0 #ff1492, -5px -5px 5px 0 #00f, 5px 5px 15px 0 #ff0;</code></pre>
-    <button type="button" class="copy hidden" aria-hidden="true">
-        <span class="visually-hidden">Copy to Clipboard</span>
-    </button>
+  <button type="button" class="copy hidden" aria-hidden="true">
+    <span class="visually-hidden">Copy to Clipboard</span>
+  </button>
 </div>
 ```
 
@@ -145,9 +145,9 @@ Next, let's provide some extra styling for the example element. Create a new CSS
 
 ```css
 #example-element {
-    background-color: #74992e;
-    width: 250px;
-    height: 80px;
+  background-color: #74992e;
+  width: 250px;
+  height: 80px;
 }
 ```
 
@@ -183,8 +183,8 @@ The `title` property is displayed above the editor, and should be of the form: "
 
 The guidance above assumes you're documenting a CSS property. But you can also write examples for CSS functions, like [`linear-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient), or types, like [`angle`](https://developer.mozilla.org/en-US/docs/Web/CSS/angle). If you do this, there are a couple of special considerations.
 
--   the name of the HTML file you write must be prefixed with `function-` for functions, or `type-` for types.
--   in the meta.json file, the name of the output HTML file must be prefixed in the same way.
+- the name of the HTML file you write must be prefixed with `function-` for functions, or `type-` for types.
+- in the meta.json file, the name of the output HTML file must be prefixed in the same way.
 
 So the meta.json entry for a function would look like:
 

--- a/CONTRIBUTING-HTML.md
+++ b/CONTRIBUTING-HTML.md
@@ -6,8 +6,6 @@ The left-hand side contains, minimally, a code editor containing some HTML. It w
 
 The right-hand side contains the rendered HTML, styled according to any CSS that was provided.
 
-![Example screenshot for `<table>`](https://screenshotscdn.firefoxusercontent.com/images/fff1dc63-ad6c-4a97-b20a-52b605e7994c.png)
-
 To write an interactive HTML example, you need to write the HTML and, if you need it, the CSS. You then need to update some metadata to tell the site builder about the new example.
 
 In this section we'll walk through creating an example for the [`<td>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td) element.
@@ -16,18 +14,18 @@ In this section we'll walk through creating an example for the [`<td>`](https://
 
 HTML examples are all stored under "./live-examples/html-examples". Under there, they are grouped into directories according to the categorization in the [HTML elements reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element):
 
--   main-root
--   document-metadata
--   sectioning-root
--   content-sectioning
--   text-content
--   ...and so on
+- main-root
+- document-metadata
+- sectioning-root
+- content-sectioning
+- text-content
+- ...and so on
 
 Each of these directories contains:
 
--   a file called "meta.json", which is a kind of manifest for all the examples in that directory.
--   an HTML file for each example, whose name is the name of the element, for example "td.html"
--   a directory called "css" that contains CSS files for each example, whose name is the name of the element, for example "td.css".
+- a file called "meta.json", which is a kind of manifest for all the examples in that directory.
+- an HTML file for each example, whose name is the name of the element, for example "td.html"
+- a directory called "css" that contains CSS files for each example, whose name is the name of the element, for example "td.css".
 
 ## Example walkthrough
 
@@ -37,36 +35,36 @@ In this section we'll go through the basic steps needed to add an HTML interacti
 
 The `<td>` element is in the ["Table content"](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#Table_content) category. So let's navigate to "./live-examples/html-examples/table-content". If "table-content" doesn't exist, create it.
 
-```
+```bash
 mkdir live-examples/html-examples/table-content
 cd live-examples/html-examples/table-content
 ```
 
 Create a new file whose name is the name of the element or attribute you are demonstrating, and give it an "html" suffix:
 
-```
+```bash
 touch td.html
 ```
 
 In this file we'll add the HTML fragment that will be displayed in the HTML editor. The fragment will need to include all the extra HTML needed to render the example, and should use good practices as far as possible. For example, in this case we'll include a complete `<table>` element:
 
-```
+```html
 <table>
-    <thead>
-         <tr>
-            <th colspan="3">Table heading</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td rowspan="2">2-row cell</td>
-            <td>A cell value</td>
-            <td>Another cell</td>
-        </tr>
-        <tr>
-            <td colspan="2">2-column cell</td>
-        </tr>
-    </tbody>
+  <thead>
+    <tr>
+      <th colspan="3">Table heading</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="2">2-row cell</td>
+      <td>A cell value</td>
+      <td>Another cell</td>
+    </tr>
+    <tr>
+      <td colspan="2">2-column cell</td>
+    </tr>
+  </tbody>
 </table>
 ```
 
@@ -76,7 +74,7 @@ Often the example will want some CSS. In this case, the table will be much easie
 
 To add CSS, create a new file under "./live-examples/html-examples/table-content/css". Give it the same name as the HTML file, but with a ".css" prefix.
 
-```
+```bash
 cd live-examples/html-examples/table-content/css
 touch td.css
 ```
@@ -85,16 +83,16 @@ touch td.css
 
 For the `<td>` example, we could do something like this:
 
-```
+```css
 table,
 td {
-    border: 1px solid #333;
-    padding: .5rem;
+  border: 1px solid #333;
+  padding: 0.5rem;
 }
 
 thead {
-    background-color: #333;
-    color: #fff;
+  background-color: #333;
+  color: #fff;
 }
 ```
 
@@ -106,23 +104,23 @@ In "./live-examples/html-examples/table-content/" you'll need a file called "met
 
 It contains a JSON object whose most interesting property is an object called `pages`. Each property of `pages` is a page we want the site builder to build:
 
-```
+```json
 {
-    "pages": {
-        "table": {
-            "exampleCode": "./live-examples/html-examples/table-content/table.html",
-            "cssExampleSrc": "./live-examples/html-examples/table-content/css/table.css",
-            "fileName": "table.html",
-            "title": "HTML Demo: <table>",
-            "type": "tabbed"
-        }
+  "pages": {
+    "table": {
+      "exampleCode": "./live-examples/html-examples/table-content/table.html",
+      "cssExampleSrc": "./live-examples/html-examples/table-content/css/table.css",
+      "fileName": "table.html",
+      "title": "HTML Demo: <table>",
+      "type": "tabbed"
     }
+  }
 }
 ```
 
 Add a property under `pages` describing your example. The example for `<td>` could look like this:
 
-```
+```json
 "td": {
     "exampleCode": "./live-examples/html-examples/table-content/td.html",
     "cssExampleSrc": "./live-examples/html-examples/table-content/css/td.css",
@@ -132,11 +130,11 @@ Add a property under `pages` describing your example. The example for `<td>` cou
 }
 ```
 
--   `"exampleCode"` is the path to the file containing the example HTML.
--   `"cssExampleSrc"` is the path to the file containing the CSS for the example.
--   `"fileName"` is the filename of the final (output) page that will contain this HTML example.
--   `"title"` is the title to show in the example. For HTML element examples it should be `"HTML Demo: <{name}>"` where `{name}` is the name of the element.
--   `"type"` describes the type of example to create. All HTML examples should put "tabbed" here.
+- `"exampleCode"` is the path to the file containing the example HTML.
+- `"cssExampleSrc"` is the path to the file containing the CSS for the example.
+- `"fileName"` is the filename of the final (output) page that will contain this HTML example.
+- `"title"` is the title to show in the example. For HTML element examples it should be `"HTML Demo: <{name}>"` where `{name}` is the name of the element.
+- `"type"` describes the type of example to create. All HTML examples should put "tabbed" here.
 
 Note that entries in `pages` are in alphabetical order, please preserve that when adding your page.
 
@@ -150,8 +148,8 @@ The final example should look something like this:
 
 This section describes some guidelines to follow when writing HTML examples. It's split into two sections:
 
--   **Formal guidelines** cover formal aspects of the example, such as how long it should be.
--   **Content guidelines** cover the actual content of the example: that is, what it should include or exclude.
+- **Formal guidelines** cover formal aspects of the example, such as how long it should be.
+- **Content guidelines** cover the actual content of the example: that is, what it should include or exclude.
 
 Sometimes formal and content guidelines are at odds. For example, sometimes writing a useful example means making it longer than the formal guidelines ask. Usually, when this happens, we should prioritize content guidelines.
 
@@ -159,46 +157,56 @@ Sometimes formal and content guidelines are at odds. For example, sometimes writ
 
 In general: try out your example using `yarn start` and see what it looks like with a browser window width of 1000px.
 
--   Can the user see the whole example source without having to scroll?
+- Can the user see the whole example source without having to scroll?
 
--   Is the example source readable?
+- Is the example source readable?
 
--   Does the source look messed up because of how it's wrapped?
+- Does the source look messed up because of how it's wrapped?
 
--   Does the output fit properly in the output pane?
+- Does the output fit properly in the output pane?
 
--   Does the layout break at narrower widths?
+- Does the layout break at narrower widths?
 
 In particular, see the following guidelines for the HTML source and the output:
 
 #### HTML source formal guidelines
 
--   **Keep the line count short**: a maximum of 13 lines if possible. By default the editor will show 13 lines, so if the example is more than that, the user will need to scroll to see the whole thing, and this isn't ideal. It's not always possible to keep to this: if you have to, you can increase the editor height to 22 lines (see [Changing the editor height](#changing-the-editor-height)), but don't do this unless you have to.
+- **Keep the line count short**: a maximum of 13 lines if possible. By default the editor will show 13 lines, so if the example is more than that, the user will need to scroll to see the whole thing, and this isn't ideal. It's not always possible to keep to this: if you have to, you can increase the editor height to 22 lines (see [Changing the editor height](#changing-the-editor-height)), but don't do this unless you have to.
 
--   **Keep line length short**: as a rule of thumb, try to keep lines under 64 characters.
+- **Keep line length short**: as a rule of thumb, try to keep lines under 64 characters.
 
--   **Use 4-space indent**
+- **Use 4-space indent**
 
--   **Use line breaks for readability**: keep in mind that at different browser widths longer lines will wrap and this can hurt readability. By including line breaks you can make the example more readable at different browser widths. For example, consider an example like this:
+- **Use line breaks for readability**: keep in mind that at different browser widths longer lines will wrap and this can hurt readability. By including line breaks you can make the example more readable at different browser widths. For example, consider an example like this:
 
-```
-<img class="fit-picture" src="/media/examples/Grapefruit_Slice--332x332.jpg" alt="Grapefruit slice atop a pile of other slices"/>
+```html
+<img
+  class="fit-picture"
+  src="/media/examples/Grapefruit_Slice--332x332.jpg"
+  alt="Grapefruit slice atop a pile of other slices"
+/>
 ```
 
 With a browser window width of 1000 pixels, this will wrap like this:
 
-```
-<img class="fit-picture" src="/media/examples
-/Grapefruit_Slice--332x332.jpg" alt="Grapefruit slice atop a pile
-of other slices"/>
+```html
+<img
+  class="fit-picture"
+  src="/media/examples
+/Grapefruit_Slice--332x332.jpg"
+  alt="Grapefruit slice atop a pile
+of other slices"
+/>
 ```
 
 If we add line breaks after each attribute, the example is much more readable:
 
-```
-<img class="fit-picture"
-     src="/media/examples/Grapefruit_Slice--332x332.jpg"
-     alt="Grapefruit slice atop a pile of other slices"/>
+```html
+<img
+  class="fit-picture"
+  src="/media/examples/Grapefruit_Slice--332x332.jpg"
+  alt="Grapefruit slice atop a pile of other slices"
+/>
 ```
 
 #### HTML output formal guidelines
@@ -217,18 +225,18 @@ However, illustrate the main concept of the item, not every possible usage of it
 
 For example, here's an example for the `<button>` element:
 
-```
+```html
 <p><button>Default button</button></p>
 
 <p><button disabled>Disabled button</button></p>
 
 <p>
-  <button name="submit" type="submit" value="submit-true">
-    Form submit button
-  </button>
+  <button name="submit" type="submit" value="submit-true">Form submit button</button>
 </p>
 
-<p><button accesskey="a">Button with <u>A</u>ccesskey</button></p>
+<p>
+  <button accesskey="a">Button with <u>A</u>ccesskey</button>
+</p>
 
 <p><button class="styled">Fancy styled button</button></p>
 ```
@@ -243,44 +251,48 @@ Although the example should be simple it should illustrate good practice. For ex
 
 For example, `<input>` element examples should include `<label>` elements:
 
-```
+```html
 <label for="pet-select">Choose a pet:</label>
 
 <select id="pet-select">
-    <option value="">--Please choose an option--</option>
-    <option value="dog">Dog</option>
-    <option value="cat">Cat</option>
-    <option value="hamster">Hamster</option>
-    <option value="parrot">Parrot</option>
-    <option value="spider">Spider</option>
-    <option value="goldfish">Goldfish</option>
+  <option value="">--Please choose an option--</option>
+  <option value="dog">Dog</option>
+  <option value="cat">Cat</option>
+  <option value="hamster">Hamster</option>
+  <option value="parrot">Parrot</option>
+  <option value="spider">Spider</option>
+  <option value="goldfish">Goldfish</option>
 </select>
 ```
 
 This also applies to semantics: for example, the example for `<aside>` should not just be:
 
-```
+```html
 <aside>
-    <p>I'm an aside!.</p>
+  <p>I'm an aside!.</p>
 </aside>
 ```
 
 This doesn't tell the reader anything about how they should use the element. The element should be shown in a context that shows its semantic purpose. For example, one use for `<aside>` is for a pull quote, so we might try this:
 
-```
-<p>When cut in half we see they are filled with a pure white substance,
-like the inside of a young puff-ball. We learn from Professor Peck that
-it is called Calostoma cinnabarinus.</p>
+```html
+<p>
+  When cut in half we see they are filled with a pure white substance, like the inside of a young puff-ball. We learn
+  from Professor Peck that it is called Calostoma cinnabarinus.
+</p>
 
 <aside>
-    <p>We are not responsible for the names given to plants, but cannot
-    help wishing that some might be changed or shortened.</p>
+  <p>
+    We are not responsible for the names given to plants, but cannot help wishing that some might be changed or
+    shortened.
+  </p>
 </aside>
 
-<p>Calostoma is a Greek word meaning beautiful mouth, and cinnabarinus
-is taken from cinnabaris, which means dragon’s-blood. We are not
-responsible for the names given to plants, but cannot help wishing that
-some might be changed or shortened.</p>
+<p>
+  Calostoma is a Greek word meaning beautiful mouth, and cinnabarinus is taken from cinnabaris, which means
+  dragon’s-blood. We are not responsible for the names given to plants, but cannot help wishing that some might be
+  changed or shortened.
+</p>
 ```
 
 ## Extra features
@@ -289,13 +301,13 @@ some might be changed or shortened.</p>
 
 For the HTML editor there are three CSS classes that can be applied to the editor container element. This allows the editor to by taller or shorter than it’s standard height. The classes are as follows:
 
--   `tabbed-shorter` - ~11 visible lines of code
--   `tabbed-standard` - ~14 visible lines of code
--   `tabbed-taller` - ~23 visible lines of code
+- `tabbed-shorter` - ~11 visible lines of code
+- `tabbed-standard` - ~14 visible lines of code
+- `tabbed-taller` - ~23 visible lines of code
 
 Usage is as follows. When adding the meta information for your example, set the `height` property to one of the classes specified above. For example:
 
-```
+```json
 "abbr": {
     "exampleCode":
         "./live-examples/html-examples/inline-text-semantics/abbr.html",
@@ -312,7 +324,7 @@ Usage is as follows. When adding the meta information for your example, set the 
 
 When an HTML interactive example is loaded, the HTML tab will be opened by default. We can change the default open tab to either `css` or `js`, by setting that value in the `defaultTab` property. For example:
 
-```
+```json
 "before": {
     "exampleCode": "./live-examples/css-examples/pseudo-element/before.html",
     "cssExampleSrc": "./live-examples/css-examples/pseudo-element/before.css",
@@ -348,9 +360,9 @@ To see this in action, see the example for [`<wbr>`](https://interactive-example
 
 Because the editor uses Shadow DOM to isolate the example, you can't use `@font-face` to include extra fonts in your example. We've included a number of extra fonts in the [shadow-fonts.css](https://github.com/mdn/interactive-examples/blob/main/css/editor-libs/shadow-fonts.css) file, and you can use these with a normal `font-family` declaration:
 
-```
+```css
 p {
-    font-family: 'molot';
+  font-family: 'molot';
 }
 ```
 

--- a/CONTRIBUTING-JavaScript.md
+++ b/CONTRIBUTING-JavaScript.md
@@ -19,7 +19,7 @@ Please make sure the example conforms to the [JS Example Style Guide](JS-Example
 
 All that remains is to tell the page generator about our new example. To do this, open up `meta.json` in the current folder (i.e. at "./live-examples/js-examples/array/meta.json"). This file contains a single JSON object `pages`, with one property for each example. Add a property for the new example, keeping the properties of `pages` in alphabetical order:
 
-```
+```json
 "arrayFrom": {
     "exampleCode": "./live-examples/js-examples/array/array-from.js",
     "fileName": "array-from.html",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,19 +8,19 @@ If you're interested in contributing to this project, great! This file should he
 
 There are many ways you can help improve this repository! For example:
 
--   **Write a brand-new example:** for example, you might notice that there are no
-    examples for a particular [CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference).
--   **Improve an existing example:** for example,
-    you might notice a problem with an existing example, or some way it could be made more helpful.
--   **Fix a bug:** we have a list of [issues](https://github.com/mdn/interactive-examples/issues),
-    or maybe you found your own.
+- **Write a brand-new example:** for example, you might notice that there are no
+  examples for a particular [CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference).
+- **Improve an existing example:** for example,
+  you might notice a problem with an existing example, or some way it could be made more helpful.
+- **Fix a bug:** we have a list of [issues](https://github.com/mdn/interactive-examples/issues),
+  or maybe you found your own.
 
 This guide focuses on contributing examples, although we welcome contributions to the [editor and infrastructure code as well](https://github.com/mdn/bob).
 
 ## Good first issues
 
--   [Examples needed](https://github.com/mdn/interactive-examples/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22example+needed%22+no%3Aassignee)
--   [Help wanted](https://github.com/mdn/interactive-examples/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22help+wanted%22+no%3Aassignee)
+- [Examples needed](https://github.com/mdn/interactive-examples/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22example+needed%22+no%3Aassignee)
+- [Help wanted](https://github.com/mdn/interactive-examples/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22help+wanted%22+no%3Aassignee)
 
 ## Setup
 
@@ -40,7 +40,7 @@ Next up, you need to fork and clone the repo to be able to contribute to it. You
 
 Finally, change into the new directory created by the clone and run the following command:
 
-```
+```bash
 yarn install
 ```
 
@@ -48,9 +48,9 @@ This will ensure that you have all the required development modules installed to
 
 We've written separate guides to contributing each type of example:
 
--   [Contributing a CSS example](CONTRIBUTING-CSS.md)
--   [Contributing an HTML example](CONTRIBUTING-HTML.md)
--   [Contributing a JavaScript example](CONTRIBUTING-JavaScript.md)
+- [Contributing a CSS example](CONTRIBUTING-CSS.md)
+- [Contributing an HTML example](CONTRIBUTING-HTML.md)
+- [Contributing a JavaScript example](CONTRIBUTING-JavaScript.md)
 
 ## Testing
 
@@ -58,19 +58,19 @@ Once you've written an example you can run a local server to try it out.
 
 From your command line run:
 
-```
+```bash
 yarn run build
 ```
 
 Once this completes run:
 
-```
+```bash
 yarn start
 ```
 
 This should give you some output including lines like:
 
-```
+```plain
 Starting up http-server, serving ./docs
 Available on:
   http://127.0.0.1:9090
@@ -79,16 +79,17 @@ Available on:
 
 Point your browser to either of those URLs, then click on the `pages` link. In the page that appears:
 
--   CSS examples are under `css`
--   JavaScript examples are under `js`
--   HTML examples are under `tabbed`
+- CSS examples are under `css`
+- JavaScript examples are under `js`
+- HTML examples are under `tabbed`
 
 Find your example and try it out.
 
 > **Note** On Linux, you might also run the automatic tests used by our continuous integration system.
->  ```
->  yarn test
->  ```
+>
+> ```bash
+> yarn test
+> ```
 
 Once you're satisfied, the final step is to [submit your pull request](https://help.github.com/articles/creating-a-pull-request/).
 
@@ -96,10 +97,15 @@ Once you're satisfied, the final step is to [submit your pull request](https://h
 
 After your pull request is reviewed and merged, you can publish your example on MDN Web Docs. On the page that corresponds to the example, add the following to the page source (typically after the introductory paragraph):
 
-```
+```html
 <div>{{EmbedInteractiveExample("pages/TYPE/FILENAME")}}</div>
 
-<p class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
+<p class="hidden">
+  The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the
+  interactive examples project, please clone
+  <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a
+  pull request.
+</p>
 ```
 
 where `TYPE` is the kind of example (such as `js`, `css`, or `tabbed`) and `FILENAME` is the name of the file that contains the example (like `margin.html` or `date-constructor.html`).
@@ -108,24 +114,24 @@ where `TYPE` is the kind of example (such as `js`, `css`, or `tabbed`) and `FILE
 
 For HTML and JS examples, there are three different possible heights for the editor: short, standard, and tall. If your example is short or tall you need to pass an extra parameter to `EmbedInteractiveExample`, like this:
 
-```
+```plain
 {{EmbedInteractiveExample("pages/js/reflect-deleteproperty.html", "taller")}}
 ```
 
 or
 
-```
+```plain
 {{EmbedInteractiveExample("pages/js/string-length.html", "shorter")}}
 ```
 
 How do you know if your example is short or tall?
 
--   for HTML examples, this is a thing you set explicitly, by supplying a CSS class in the example source. See [Changing the editor height](CONTRIBUTING-HTML.md#changing-the-editor-height).
--   for JS examples, short or tall editors are selected automatically for you:
-    -   Examples less than 7 lines long get the short editor, so you should provide the `"shorter"` argument to `EmbedInteractiveExample`
-    -   Examples 7-12 lines inclusive get the standard editor, so you should not provide any extra argument to `EmbedInteractiveExample`
-    -   Examples 13 or more lines long get the tall editor, so you should provide the `"taller"` argument to `EmbedInteractiveExample`
+- for HTML examples, this is a thing you set explicitly, by supplying a CSS class in the example source. See [Changing the editor height](CONTRIBUTING-HTML.md#changing-the-editor-height).
+- for JS examples, short or tall editors are selected automatically for you:
+  - Examples less than 7 lines long get the short editor, so you should provide the `"shorter"` argument to `EmbedInteractiveExample`
+  - Examples 7-12 lines inclusive get the standard editor, so you should not provide any extra argument to `EmbedInteractiveExample`
+  - Examples 13 or more lines long get the tall editor, so you should provide the `"taller"` argument to `EmbedInteractiveExample`
 
-## Thank you!
+## Thank you
 
-Thank you for your contribution ~ o/\o
+Thank you for your contribution! ~ o/\o

--- a/CSS-Example-Style-Guide.md
+++ b/CSS-Example-Style-Guide.md
@@ -4,9 +4,9 @@ A style guide for people contributing interactive CSS examples. To learn the mec
 
 CSS examples consist of:
 
--   an DOM element whose ID is `"example-element"`
+- an DOM element whose ID is `"example-element"`
 
--   a set of _choices_, where each choice is one or more [CSS `property: value;` declarations](). One of these choices is selected initially, and the user can select a different choice. When a choice is selected, all the CSS declarations it contains will be applied to "example-element".
+- a set of _choices_, where each choice is one or more [CSS `property: value;` declarations](https://developer.mozilla.org/en-US/docs/Web/CSS/Syntax#css_declarations). One of these choices is selected initially, and the user can select a different choice. When a choice is selected, all the CSS declarations it contains will be applied to "example-element".
 
 You can also supply additional DOM elements, where that makes sense. For example, the [`position`](https://interactive-examples.mdn.mozilla.net/pages/css/position.html) example has one box which is the "example-element", but also includes extra boxes to show how setting the `position` property for an element interacts with the other elements in a layout.
 
@@ -16,10 +16,10 @@ You can also provide extra CSS both for the example element and any additional e
 
 The most basic form of the CSS choices is a group of one-line CSS style declarations, where each line illustrates a different form of the property. For example:
 
--   [`transform`](https://interactive-examples.mdn.mozilla.net/pages/css/transform.html)
--   [`filter`](https://interactive-examples.mdn.mozilla.net/pages/css/filter.html)
--   [`font`](https://interactive-examples.mdn.mozilla.net/pages/css/font.html)
--   [`text-overflow`](https://interactive-examples.mdn.mozilla.net/pages/css/text-overflow.html)
+- [`transform`](https://interactive-examples.mdn.mozilla.net/pages/css/transform.html)
+- [`filter`](https://interactive-examples.mdn.mozilla.net/pages/css/filter.html)
+- [`font`](https://interactive-examples.mdn.mozilla.net/pages/css/font.html)
+- [`text-overflow`](https://interactive-examples.mdn.mozilla.net/pages/css/text-overflow.html)
 
 This is the recommended style for most examples.
 
@@ -55,23 +55,23 @@ Since vertical space is at a premium, avoid comments unless they are really need
 
 By default, the first choice will be selected. You can override this by adding `initial-choice="true"` to the `example-choice` DIV:
 
-    <div class="example-choice" initial-choice="true">
-        ...
-    </div>
+```html
+<div class="example-choice" initial-choice="true">...</div>
+```
 
-## Colour
+## Color
 
-The CSS interactive examples are visual in nature. Because of this, you will often need to make use of shapes, borders, lines etc. as part of your example. To maintain consistency with the [MDN Web Docs](https://developer.mozilla.org) branding, please always refer to the [colour style guide](https://schalkneethling.github.io/mdn-fiori/patterns/scss/variables/) when choosing colours.
+The CSS interactive examples are visual in nature. Because of this, you will often need to make use of shapes, borders, lines etc. as part of your example. To maintain consistency with the [MDN Web Docs](https://developer.mozilla.org) branding, please always refer to the [color style guide](https://schalkneethling.github.io/mdn-fiori/patterns/scss/variables/) when choosing colors.
 
-We do acknowledge that this specific set of colours might not always work for your intended purpose. The above is therefore a guide, and is not meant to be hard and fast rules. Should you find that these colours cause legibility, and/or contrast problems, feel free to use a suitable substitute and make note of it in your pull request.
+We do acknowledge that this specific set of colors might not always work for your intended purpose. The above is therefore a guide, and is not meant to be hard and fast rules. Should you find that these colors cause legibility, and/or contrast problems, feel free to use a suitable substitute and make note of it in your pull request.
 
 ## Specifying images
 
 Sometimes you'll want to include images with the example. If you do:
 
--   make sure their license allows you to use them. It's difficult for us to satisfy an attribution requirement with the editor, so try to use images that have a very permissive license such as [CC0](https://creativecommons.org/share-your-work/public-domain/cc0/).
--   run them through https://tinypng.com or https://imageoptim.com, to reduce the page weight of the examples.
--   For `SVG`, run the code through (SVGOMG)[https://jakearchibald.github.io/svgomg/], and ensure that the `SVG` file has an empty line at the end of the file
+- make sure their license allows you to use them. It's difficult for us to satisfy an attribution requirement with the editor, so try to use images that have a very permissive license such as [CC0](https://creativecommons.org/share-your-work/public-domain/cc0/).
+- run them through <https://tinypng.com> or <https://imageoptim.com>, to reduce the page weight of the examples.
+- For `SVG`, run the code through [SVGOMG](https://jakearchibald.github.io/svgomg/), and ensure that the `SVG` file has an empty line at the end of the file
 
 ## Output width considerations
 

--- a/JS-Example-Style-Guide.md
+++ b/JS-Example-Style-Guide.md
@@ -47,12 +47,12 @@ This may make more sense in the context of the following example:
 
 ```js
 const collatorDe = new Intl.Collator('de', {
-    usage: 'search',
-    sensitivity: 'base',
+  usage: 'search',
+  sensitivity: 'base',
 });
 const collatorFr = new Intl.Collator('fr', {
-    usage: 'search',
-    sensitivity: 'base',
+  usage: 'search',
+  sensitivity: 'base',
 });
 ```
 
@@ -74,16 +74,16 @@ For example:
 
 ```js
 function monster1(disposition) {
-    this.disposition = disposition;
+  this.disposition = disposition;
 }
 
 const handler1 = {
-    construct: (target, args) => {
-        console.log('monster1 constructor called');
-        // expected output: "monster1 constructor called"
+  construct: (target, args) => {
+    console.log('monster1 constructor called');
+    // expected output: "monster1 constructor called"
 
-        return new target(...args);
-    },
+    return new target(...args);
+  },
 };
 
 const proxy1 = new Proxy(monster1, handler1);
@@ -118,10 +118,10 @@ If you wish to use an error to illustrate a method, wrap it in a `try/catch` blo
 
 ```js
 try {
-    Intl.getCanonicalLocales('EN_US');
+  Intl.getCanonicalLocales('EN_US');
 } catch (err) {
-    console.log(err);
-    // expected output: RangeError: invalid language tag: EN_US
+  console.log(err);
+  // expected output: RangeError: invalid language tag: EN_US
 }
 ```
 
@@ -176,10 +176,10 @@ For example:
 
 ```js
 construct: (target, args) => {
-    console.log('monster1 constructor called');
-    // expected output: "monster1 constructor called"
+  console.log('monster1 constructor called');
+  // expected output: "monster1 constructor called"
 
-    return new target(...args);
+  return new target(...args);
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Want to contribute to the interactive examples project? Here are a couple of goo
 
 ## Folder structure
 
--   [css] - This contains the CSS used by the base templates.
--   [js] - This contains the JS used by the base templates.
--   [live-examples] - This contains the live example CSS and JS fragments.
--   [media] - This contains images used by the live examples and templates.
--   [tmpl] - The base templates.
+- [css] - This contains the CSS used by the base templates.
+- [js] - This contains the JS used by the base templates.
+- [live-examples] - This contains the live example CSS and JS fragments.
+- [media] - This contains images used by the live examples and templates.
+- [tmpl] - The base templates.
 
 The dynamically generated pages, their dependencies, and assets are generated to the `prod` branch.
 
@@ -28,12 +28,12 @@ The dynamically generated pages, their dependencies, and assets are generated to
 
 The following is a list of browser/version combinations that are supported by the interactive editor. In browsers that do not meet the criteria, the editor degrades gracefully to displaying static examples.
 
--   Firefox - Latest three release versions.
--   Chrome - Latest three release versions.
--   Opera - Latest two release versions.
--   Safari - Latest two release versions.
--   Internet Explorer - version 11.
--   Edge - Latest release version.
+- Firefox - Latest three release versions.
+- Chrome - Latest three release versions.
+- Opera - Latest two release versions.
+- Safari - Latest two release versions.
+- Internet Explorer - version 11.
+- Edge - Latest release version.
 
 ## Contributing
 


### PR DESCRIPTION
This PR contains the following changes:

* Use tabwidth of 2 for markdown (markdownlint complains about 4 spaces for everything in md files)
* Run Prettier over the rest of the markdown files
* "Colours" -> "Colors" (prefers US English)
* Add language to code blocks

**Notes:**

* I removed a broken screenshot in CONTRIBUTING-HTML:

```
![Example screenshot for `<table>`](https://screenshotscdn.firefoxusercontent.com/images/fff1dc63-ad6c-4a97-b20a-52b605e7994c.png)
```

This should be replaced, but I'm not sure what the original had. Maybe we can check a new one into git?

* https://schalkneethling.github.io/mdn-fiori/patterns/scss/variables/ is broken :(