### PR TITLE
Fix JavaScript sample for wat/call

### DIFF
--- a/live-examples/wat-examples/statements/meta.json
+++ b/live-examples/wat-examples/statements/meta.json
@@ -16,7 +16,7 @@
         },
         "call": {
             "watExampleCode": "./live-examples/wat-examples/statements/call.wat",
-            "jsExampleCode": "./live-examples/wat-examples/console.js",
+            "jsExampleCode": "./live-examples/wat-examples/statements/call.js",
             "fileName": "call.html",
             "title": "Wat Demo: call",
             "type": "wat"


### PR DESCRIPTION
The `meta.json` is pointing at the wrong JS file.