### PR TITLE
Change text-underline-offset examples

### DIFF
--- a/live-examples/css-examples/text-decoration/text-underline-offset.html
+++ b/live-examples/css-examples/text-decoration/text-underline-offset.html
@@ -22,6 +22,6 @@
 
 <div id="output" class="output hidden">
 	<section id="default-example">
-		<p id="example-element">And after all we're only ordinary men</p>
+		<p id="example-element">And after all we are only ordinary</p>
 	</section>
 </div>

--- a/live-examples/css-examples/text-decoration/text-underline-offset.html
+++ b/live-examples/css-examples/text-decoration/text-underline-offset.html
@@ -1,28 +1,27 @@
 <section id="example-choice-list" class="example-choice-list" data-property="text-underline-offset">
-<div class="example-choice" initial-choice="true">
-<pre><code class="language-css">text-underline-offset: 3px;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true">
-    <span class="visually-hidden">Copy to Clipboard</span>
-</button>
-</div>
+	<div class="example-choice" initial-choice="true">
+		<pre><code class="language-css">text-underline-offset: auto;</code></pre>
+		<button type="button" class="copy hidden" aria-hidden="true">
+			<span class="visually-hidden">Copy to Clipboard</span>
+		</button>
+	</div>
 
-<div class="example-choice">
-<pre><code class="language-css">text-underline-offset: 1rem;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true">
-    <span class="visually-hidden">Copy to Clipboard</span>
-</button>
-</div>
-<div class="example-choice">
-<pre><code class="language-css">text-underline-offset: from-font;
-font-size: 2rem;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true">
-    <span class="visually-hidden">Copy to Clipboard</span>
-</button>
-</div>
+	<div class="example-choice">
+		<pre><code class="language-css">text-underline-offset: 8px;</code></pre>
+		<button type="button" class="copy hidden" aria-hidden="true">
+			<span class="visually-hidden">Copy to Clipboard</span>
+		</button>
+	</div>
+	<div class="example-choice">
+		<pre><code class="language-css">text-underline-offset: -0.5rem;</code></pre>
+		<button type="button" class="copy hidden" aria-hidden="true">
+			<span class="visually-hidden">Copy to Clipboard</span>
+		</button>
+	</div>
 </section>
 
 <div id="output" class="output hidden">
-    <section id="default-example">
-        <p id="example-element">And after all we're only ordinary men</p>
-    </section>
+	<section id="default-example">
+		<p id="example-element">And after all we're only ordinary men</p>
+	</section>
 </div>


### PR DESCRIPTION
This PR changes examples in [text-underline-offset](https://developer.mozilla.org/en-US/docs/Web/CSS/text-underline-offset), especially to remove `text-underline-offset: from-font;` which is not supported on Chrome or Firefox.

![image](https://user-images.githubusercontent.com/100634371/195079595-7adea8ad-55f2-4e5e-95df-48483124cb86.png)

Fixes #2307 