### PR TITLE
Attribute size

### DIFF
--- a/live-examples/html-examples/form-attributes/attribute-size.html
+++ b/live-examples/html-examples/form-attributes/attribute-size.html
@@ -1,0 +1,17 @@
+<label for="firstName">First Name:</label>
+<input name="firstName"
+       type="text"
+       size="10">
+
+<label for="lastName">Last Name:</label>
+<input name="lastName"
+       type="text"
+       size="20">
+
+<label for="shirtSize">Size of T-Shirt:</label>
+<select name="shirtSize"
+        size="2">
+	<option>Small</option>
+	<option>Medium</option>
+	<option>Large</option>
+</select>

--- a/live-examples/html-examples/form-attributes/attribute-size.html
+++ b/live-examples/html-examples/form-attributes/attribute-size.html
@@ -8,10 +8,10 @@
        type="text"
        size="20">
 
-<label for="shirtSize">Size of T-Shirt:</label>
-<select name="shirtSize"
+<label for="fruit">Favourite fruit:</label>
+<select name="fruit"
         size="2">
-	<option>Small</option>
-	<option>Medium</option>
-	<option>Large</option>
+	<option>Orange</option>
+	<option>Banana</option>
+	<option>Apple</option>
 </select>

--- a/live-examples/html-examples/form-attributes/css/attribute-size.css
+++ b/live-examples/html-examples/form-attributes/css/attribute-size.css
@@ -1,0 +1,4 @@
+label {
+    display: block;
+    margin-top: 1rem;
+}

--- a/live-examples/html-examples/form-attributes/meta.json
+++ b/live-examples/html-examples/form-attributes/meta.json
@@ -78,6 +78,14 @@
             "type": "tabbed",
             "height": "tabbed-shorter"
         },
+        "size": {
+            "exampleCode": "./live-examples/html-examples/form-attributes/attribute-size.html",
+            "cssExampleSrc": "./live-examples/html-examples/form-attributes/css/attribute-size.css",
+            "fileName": "attribute-size.html",
+            "title": "HTML Demo: size",
+            "type": "tabbed",
+            "height": "tabbed-standard"
+        },
         "step": {
             "exampleCode": "./live-examples/html-examples/form-attributes/attribute-step.html",
             "cssExampleSrc": "./live-examples/html-examples/form-attributes/css/attribute-step.css",


### PR DESCRIPTION
This PR adds interactive example for attribute [size](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size).

![image](https://user-images.githubusercontent.com/100634371/195715631-cf0b32c0-8236-4745-80d6-1f1b2591b014.png)
