### PR TITLE
Rewrite header example

### DIFF
--- a/live-examples/html-examples/content-sectioning/css/header.css
+++ b/live-examples/html-examples/content-sectioning/css/header.css
@@ -1,19 +1,18 @@
-header.page-header {
-    background: no-repeat left/cover url(/media/examples/puppy-header-logo.jpg);
+.logo {
+    background: left / cover url(/media/examples/puppy-header-logo.jpg);
     display: flex;
     height: 120px;
-    min-width: 120px;
     align-items: center;
-    color: #fff;
-    text-shadow: #000 0 0 .2em;
+    justify-content: center;
+    font: bold calc(1em + 2 * (100vw - 120px) / 100) 'Dancing Script', fantasy;
+    color: #ff0083;
+    text-shadow: #000 2px 2px 0.2rem;
 }
 
-header.page-header > h1 {
-    font: bold calc(1em + 2 * (100vw - 120px) / 100) 'Dancing Script', cursive,
-        fantasy;
-    margin: 2%;
+header > h1 {
+    margin-bottom: 0px;
 }
 
-main {
-    font: 1rem 'Fira Sans', sans-serif;
+header > time {
+    font: italic 0.7rem sans-serif;
 }

--- a/live-examples/html-examples/content-sectioning/header.html
+++ b/live-examples/html-examples/content-sectioning/header.html
@@ -1,7 +1,11 @@
-<header class="page-header">
-    <h1>Cute Puppies Express!</h1>
+<header>
+    <a class="logo" href="#">Cute Puppies Express!</a>
 </header>
 
-<main>
+<article>
+    <header>
+        <h1>Beagles</h1>
+        <time>08.12.2014</time>
+    </header>
     <p>I love beagles <em>so</em> much! Like, really, a lot. They’re adorable and their ears are so, so snuggly soft!</p>
-</main>
+</article>


### PR DESCRIPTION
This PR changes [header](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) example, so it fixes out of place `h1`, adds another use of `header` and fixes contrast of `Cute Puppies Express!` text.

![image](https://user-images.githubusercontent.com/100634371/196007537-f8d577df-a236-441b-9380-549c33582359.png)

[@KaiPrince](https://github.com/KaiPrince) could you check if it meets your expectations?
Fixes #2311 