### PR TITLE
feat(html): Add `crossorigin` attribute

### DIFF
--- a/live-examples/html-examples/other-attributes/attribute-crossorigin.html
+++ b/live-examples/html-examples/other-attributes/attribute-crossorigin.html
@@ -1,0 +1,6 @@
+<script src="http://ddvdiow.cluster031.hosting.ovh.net/throwError.js"></script>
+
+<script src="http://ddvdiow.cluster031.hosting.ovh.net/throwError.js" crossorigin></script>
+
+<label for="logBox">Caught Errors:</label>
+<textarea id="logBox" readonly></textarea>

--- a/live-examples/html-examples/other-attributes/css/attribute-crossorigin.css
+++ b/live-examples/html-examples/other-attributes/css/attribute-crossorigin.css
@@ -1,0 +1,11 @@
+label {
+    font-weight: bold;
+}
+
+#logBox {
+    height: 200px;
+    width: 250px;
+    resize: none;
+    outline: none;
+    margin-top: 10px;
+}

--- a/live-examples/html-examples/other-attributes/js/attribute-crossorigin.js
+++ b/live-examples/html-examples/other-attributes/js/attribute-crossorigin.js
@@ -1,0 +1,7 @@
+const logBox = document.getElementById('logBox');
+let errorIndex = 1;
+
+window.addEventListener("error", event => {
+  logBox.textContent += `Error ${errorIndex}: ${event.message}\n\n`;
+  errorIndex ++;
+});

--- a/live-examples/html-examples/other-attributes/meta.json
+++ b/live-examples/html-examples/other-attributes/meta.json
@@ -9,7 +9,7 @@
             "type": "tabbed",
             "defaultTab": "html",
             "tabs": "html,css,js",
-            "height": "tabbed-standard"
+            "height": "tabbed-shorter"
         }
     }
 }

--- a/live-examples/html-examples/other-attributes/meta.json
+++ b/live-examples/html-examples/other-attributes/meta.json
@@ -1,0 +1,15 @@
+{
+    "pages": {
+        "crossorigin": {
+            "exampleCode": "./live-examples/html-examples/other-attributes/attribute-crossorigin.html",
+            "cssExampleSrc": "./live-examples/html-examples/other-attributes/css/attribute-crossorigin.css",
+            "jsExampleSrc": "./live-examples/html-examples/other-attributes/js/attribute-crossorigin.js",
+            "fileName": "attribute-crossorigin.html",
+            "title": "HTML Demo: crossorigin",
+            "type": "tabbed",
+            "defaultTab": "html",
+            "tabs": "html,css,js",
+            "height": "tabbed-standard"
+        }
+    }
+}


### PR DESCRIPTION
This PR adds interactive example for [crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) attribute. I chose to show how it works with script element, because showing how tainted canvas work would require long and complex JS code, while crossorigin in `<link>` effect can be seen mostly in network devtools tab.

**Currently my private host is used to store cross-origin JS code, so this PR shouldn't be merged.** I won't be able to store it indefinitely, so we need server owned by Mozilla with `Access-Control-Allow-Origin:  *` HTTP header which can store following JS file:
```js
setTimeout(() => {
    throw new Error('Secret message of error inside cross-origin script.');
}, 500);
```

![image](https://user-images.githubusercontent.com/100634371/196251582-59185a06-1307-412e-bc4d-fcccf83be80a.png)