### PR TITLE
feat(css): Add example of `:modal`

### DIFF
--- a/live-examples/css-examples/pseudo-class/meta.json
+++ b/live-examples/css-examples/pseudo-class/meta.json
@@ -189,6 +189,17 @@
             "defaultTab": "css",
             "height": "tabbed-shorter"
         },
+        "modal": {
+            "exampleCode": "./live-examples/css-examples/pseudo-class/modal.html",
+            "cssExampleSrc": "./live-examples/css-examples/pseudo-class/modal.css",
+            "jsExampleSrc": "./live-examples/css-examples/pseudo-class/modal.js",
+            "fileName": "pseudo-class-modal.html",
+            "title": "HTML Demo: :modal",
+            "type": "tabbed",
+            "defaultTab": "css",
+            "tabs": "html,css,js",
+            "height": "tabbed-shorter"
+        },
         "not": {
             "cssExampleSrc": "./live-examples/css-examples/pseudo-class/not.css",
             "exampleCode": "./live-examples/css-examples/pseudo-class/not.html",

--- a/live-examples/css-examples/pseudo-class/modal.css
+++ b/live-examples/css-examples/pseudo-class/modal.css
@@ -1,0 +1,12 @@
+button {
+    display: block;
+    margin: auto;
+    width: 10rem;
+    height: 2rem;
+}
+
+:modal {
+    background-color: beige;
+    border: 2px solid burlywood;
+    border-radius: 5px;
+}

--- a/live-examples/css-examples/pseudo-class/modal.html
+++ b/live-examples/css-examples/pseudo-class/modal.html
@@ -1,4 +1,4 @@
-<p>Would you like to see new random number?</p>
+<p>Would you like to see a new random number?</p>
 <button id="showNumber">Show me</button>
 
 <dialog id="favDialog">

--- a/live-examples/css-examples/pseudo-class/modal.html
+++ b/live-examples/css-examples/pseudo-class/modal.html
@@ -1,0 +1,9 @@
+<p>Would you like to see new random number?</p>
+<button id="showNumber">Show me</button>
+
+<dialog id="favDialog">
+    <form method="dialog">
+        <p>Lucky number is: <strong id="number"></strong></p>
+        <button>Close dialog</button>
+    </form>
+</dialog>

--- a/live-examples/css-examples/pseudo-class/modal.js
+++ b/live-examples/css-examples/pseudo-class/modal.js
@@ -1,0 +1,8 @@
+const showNumber = document.getElementById('showNumber');
+const favDialog = document.getElementById('favDialog');
+const number = document.getElementById('number');
+
+showNumber.addEventListener('click', () => {
+    number.innerText = Math.floor(Math.random() * 1000);
+    favDialog.showModal();
+});


### PR DESCRIPTION
This PR adds interactive example to [:modal](https://developer.mozilla.org/en-US/docs/Web/CSS/:modal).

![image](https://user-images.githubusercontent.com/100634371/196539603-5ba54308-ba69-4e64-8e67-d15fef6f1cd7.png)
