### PR TITLE
Remove word-spacing percentage

### DIFF
--- a/live-examples/css-examples/text/word-spacing.html
+++ b/live-examples/css-examples/text/word-spacing.html
@@ -21,13 +21,6 @@
 </div>
 
 <div class="example-choice">
-<pre><code class="language-css">word-spacing: 120%;</code></pre>
-<button type="button" class="copy hidden" aria-hidden="true">
-    <span class="visually-hidden">Copy to Clipboard</span>
-</button>
-</div>
-
-<div class="example-choice">
 <pre><code class="language-css">word-spacing: -.4ch;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>


### PR DESCRIPTION
See https://github.com/mdn/content/pull/21861 and https://developer.mozilla.org/en-US/docs/Web/CSS/word-spacing#formal_syntax - it looks like `<percentage>` isn't a valid value for `word-spacing` any more, so this PR removes it from the example.