### PR TITLE
Add timezone to create the same output for all users.

### DIFF
--- a/live-examples/js-examples/intl/intl-datetimeformat.js
+++ b/live-examples/js-examples/intl/intl-datetimeformat.js
@@ -10,5 +10,5 @@ console.log(new Intl.DateTimeFormat(['ban', 'id']).format(date));
 // expected output: "20/12/2020"
 
 // Specify date and time format using "style" options (i.e. full, long, medium, short)
-console.log(new Intl.DateTimeFormat('en-GB', { dateStyle: 'full', timeStyle: 'long' }).format(date));
+console.log(new Intl.DateTimeFormat('en-GB', { dateStyle: 'full', timeStyle: 'long', timeZone: 'Australia/Sydney' }).format(date));
 // Expected output "Sunday, 20 December 2020 at 14:23:16 GMT+11"


### PR DESCRIPTION
Currently  the output doesn't match the expected output when a user is in a different timezone, e.g. for me it outputs

> "Sunday, 20 December 2020 at 04:23:16 CET"
