### PR TITLE
Remove invalid data in meta.json of property all

### DIFF
--- a/live-examples/css-examples/cascading-and-inheritance/meta.json
+++ b/live-examples/css-examples/cascading-and-inheritance/meta.json
@@ -5,9 +5,7 @@
             "exampleCode": "./live-examples/css-examples/cascading-and-inheritance/all.html",
             "fileName": "all.html",
             "title": "CSS Demo: all",
-            "type": "css",
-            "defaultTab": "css",
-            "height": "tabbed-shorter"
+            "type": "css"
         },
         "media": {
             "cssExampleSrc": "./live-examples/css-examples/cascading-and-inheritance/at-rule-media.css",


### PR DESCRIPTION
I commited "defaultTab" & "height" properties of CSS property" all in PR #2209. CSS properties are not supposed to have those settings, so this PR reverts this change. It won't have any visual impact whatsoever.