### PR TITLE
Add JS example: Symbol.prototype.valueOf()

### DIFF
--- a/live-examples/js-examples/symbol/meta.json
+++ b/live-examples/js-examples/symbol/meta.json
@@ -60,6 +60,12 @@
             "title": "JavaScript Demo: Symbol.prototype.toString()",
             "type": "js"
         },
+        "symbolPrototypeValueOf": {
+            "exampleCode": "./live-examples/js-examples/symbol/symbol-prototype-valueof.js",
+            "fileName": "symbol-prototype-valueof.html",
+            "title": "JavaScript Demo: Symbol.prototype.valueOf()",
+            "type": "js"
+        },
         "symbolReplace": {
             "exampleCode": "./live-examples/js-examples/symbol/symbol-replace.js",
             "fileName": "symbol-replace.html",

--- a/live-examples/js-examples/symbol/symbol-prototype-valueof.js
+++ b/live-examples/js-examples/symbol/symbol-prototype-valueof.js
@@ -1,0 +1,7 @@
+const symbol1 = Symbol('foo');
+
+console.log(typeof Object(symbol1));
+// expected output: "object"
+
+console.log(typeof Object(symbol1).valueOf());
+// expected output: "symbol"


### PR DESCRIPTION
Interactive example for [Symbol.prototype.valueOf()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/valueOf).

![image](https://user-images.githubusercontent.com/100634371/204342553-59415691-6a33-4b08-a6af-c67770628ca7.png)
