### PR TITLE
chore: remove direct ajv dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "devDependencies": {
         "@babel/core": "^7.20.5",
         "@babel/eslint-parser": "^7.19.1",
-        "ajv": "^8.11.2",
         "chokidar-cli": "^3.0.0",
         "eslint": "^8.29.0",
         "http-server": "^14.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -453,7 +453,7 @@ ajv@^6.0.1, ajv@^6.10.0, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.1, ajv@^8.11.2:
+ajv@^8.0.1:
   version "8.11.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.2.tgz#aecb20b50607acf2569b6382167b65a96008bb78"
   integrity sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==


### PR DESCRIPTION
I included this in the ESLint PR, but I thought I'd split it out. AJV can be used to validate JSON files, but it doesn't appear to be directly used in this project right now.