### PR TITLE
Refreshing CONTRIBUTING page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,36 +98,31 @@ Once you're satisfied, the final step is to [submit your pull request](https://h
 After your pull request is reviewed and merged, you can publish your example on MDN Web Docs. On the page that corresponds to the example, add the following to the page source (typically after the introductory paragraph):
 
 ```html
-<div>{{EmbedInteractiveExample("pages/TYPE/FILENAME")}}</div>
-
-<p class="hidden">
-  The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the
-  interactive examples project, please clone
-  <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a
-  pull request.
-</p>
+{{EmbedInteractiveExample("pages/TYPE/FILENAME", HEIGHT)}}
 ```
 
-where `TYPE` is the kind of example (such as `js`, `css`, or `tabbed`) and `FILENAME` is the name of the file that contains the example (like `margin.html` or `date-constructor.html`).
+- **TYPE** corresponds to the value of the `type` property in `meta.json` of the example. Possible values are `js`, `css`, and `tabbed`.
+- **FILENAME** corresponds to the value of `fileName` property in `meta.json`. For example `input-color.html`.
 
-### Short or tall examples
+### **HEIGHT** argument
 
-For HTML and JS examples, there are three different possible heights for the editor: short, standard, and tall. If your example is short or tall you need to pass an extra parameter to `EmbedInteractiveExample`, like this:
-
+For CSS examples this argument must always be skipped. To include the margin example, the following code should be placed:
 ```plain
-{{EmbedInteractiveExample("pages/js/reflect-deleteproperty.html", "taller")}}
+{{EmbedInteractiveExample("pages/css/margin.html")}}
 ```
 
-or
-
+For HTML examples or any other `tabbed` type, the value of **HEIGHT** argument should match the value of property `height` in `meta.json` of the example. Possible values are: `"tabbed-shorter"`, `"tabbed-standard"` and `"tabbed-taller"`, so `EmbedInteractiveExample` might look like any of those:
 ```plain
-{{EmbedInteractiveExample("pages/js/string-length.html", "shorter")}}
+{{EmbedInteractiveExample("pages/tabbed/dfn.html", "tabbed-shorter")}}
+```
+```plain
+{{EmbedInteractiveExample("pages/tabbed/del.html", "tabbed-standard")}}
+```
+```plain
+{{EmbedInteractiveExample("pages/tabbed/colgroup.html", "tabbed-taller")}}
 ```
 
-How do you know if your example is short or tall?
-
-- for HTML examples, this is a thing you set explicitly, by supplying a CSS class in the example source. See [Changing the editor height](CONTRIBUTING-HTML.md#changing-the-editor-height).
-- for JS examples, short or tall editors are selected automatically for you:
+For JS examples, the editor is automatically selecting the appropriate height, based on the amount of lines in the example:
   - Examples less than 7 lines long get the short editor, so you should provide the `"shorter"` argument to `EmbedInteractiveExample`
   - Examples 7-12 lines inclusive get the standard editor, so you should not provide any extra argument to `EmbedInteractiveExample`
   - Examples 13 or more lines long get the tall editor, so you should provide the `"taller"` argument to `EmbedInteractiveExample`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,19 +8,11 @@ If you're interested in contributing to this project, great! This file should he
 
 There are many ways you can help improve this repository! For example:
 
-- **Write a brand-new example:** for example, you might notice that there are no
-  examples for a particular [CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference).
-- **Improve an existing example:** for example,
-  you might notice a problem with an existing example, or some way it could be made more helpful.
-- **Fix a bug:** we have a list of [issues](https://github.com/mdn/interactive-examples/issues),
-  or maybe you found your own.
+- **Write a brand-new example.** There are still many pages missing an interactive example, but which could benefit from it. Look for HTML, CSS or JS pages, describing a specific feature, such as HTML attribute, CSS property, JS function. Make sure this feature is supported by a stable version of Chrome and Firefox browsers.
+- **Improve an existing example.** You could add new CSS value, which is well supported by browsers, improve color contrast, fix typos or add some other changes which would make example more helpful to the users.
+- **Fix a bug:** we have a list of [issues](https://github.com/mdn/interactive-examples/issues), or maybe you found your own.
 
 This guide focuses on contributing examples, although we welcome contributions to the [editor and infrastructure code as well](https://github.com/mdn/bob).
-
-## Good first issues
-
-- [Examples needed](https://github.com/mdn/interactive-examples/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22example+needed%22+no%3Aassignee)
-- [Help wanted](https://github.com/mdn/interactive-examples/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22help+wanted%22+no%3Aassignee)
 
 ## Setup
 


### PR DESCRIPTION
Removed unnecessary html tags, in the example, showing how to publish an interactive example. I have also corrected the explanation of how to add tabbed examples and written how to publish CSS examples.

I have also added more details, as to what exactly people can contribute.

Fixes #2360 