### PR TITLE
feat(webapi): Add 16 `URL` examples

### DIFF
--- a/live-examples/webapi-examples/url/meta.json
+++ b/live-examples/webapi-examples/url/meta.json
@@ -1,0 +1,100 @@
+{
+    "pages": {
+        "url": {
+            "exampleCode": "./live-examples/webapi-examples/url/url.js",
+            "fileName": "url.html",
+            "title": "JavaScript Demo: URL",
+            "type": "js"
+        },
+        "urlConstructor": {
+            "exampleCode": "./live-examples/webapi-examples/url/url-constructor.js",
+            "fileName": "url-constructor.html",
+            "title": "JavaScript Demo: URL Constructor",
+            "type": "js"
+        },
+        "urlPrototypeHash": {
+            "exampleCode": "./live-examples/webapi-examples/url/url-prototype-hash.js",
+            "fileName": "url-prototype-hash.html",
+            "title": "JavaScript Demo: URL.prototype.hash",
+            "type": "js"
+        },
+        "urlPrototypeHost": {
+            "exampleCode": "./live-examples/webapi-examples/url/url-prototype-host.js",
+            "fileName": "url-prototype-host.html",
+            "title": "JavaScript Demo: URL.prototype.host",
+            "type": "js"
+        },
+        "urlPrototypeHostname": {
+            "exampleCode": "./live-examples/webapi-examples/url/url-prototype-hostname.js",
+            "fileName": "url-prototype-hostname.html",
+            "title": "JavaScript Demo: URL.prototype.hostname",
+            "type": "js"
+        },
+        "urlPrototypeHref": {
+            "exampleCode": "./live-examples/webapi-examples/url/url-prototype-href.js",
+            "fileName": "url-prototype-href.html",
+            "title": "JavaScript Demo: URL.prototype.href",
+            "type": "js"
+        },
+        "urlPrototypeOrigin": {
+            "exampleCode": "./live-examples/webapi-examples/url/url-prototype-origin.js",
+            "fileName": "url-prototype-origin.html",
+            "title": "JavaScript Demo: URL.prototype.origin",
+            "type": "js"
+        },
+        "urlPrototypePassword": {
+            "exampleCode": "./live-examples/webapi-examples/url/url-prototype-password.js",
+            "fileName": "url-prototype-password.html",
+            "title": "JavaScript Demo: URL.prototype.password",
+            "type": "js"
+        },
+        "urlPrototypePathname": {
+            "exampleCode": "./live-examples/webapi-examples/url/url-prototype-pathname.js",
+            "fileName": "url-prototype-pathname.html",
+            "title": "JavaScript Demo: URL.prototype.pathname",
+            "type": "js"
+        },
+        "urlPrototypePort": {
+            "exampleCode": "./live-examples/webapi-examples/url/url-prototype-port.js",
+            "fileName": "url-prototype-port.html",
+            "title": "JavaScript Demo: URL.prototype.port",
+            "type": "js"
+        },
+        "urlPrototypeProtocol": {
+            "exampleCode": "./live-examples/webapi-examples/url/url-prototype-protocol.js",
+            "fileName": "url-prototype-protocol.html",
+            "title": "JavaScript Demo: URL.prototype.protocol",
+            "type": "js"
+        },
+        "urlPrototypeSearch": {
+            "exampleCode": "./live-examples/webapi-examples/url/url-prototype-search.js",
+            "fileName": "url-prototype-search.html",
+            "title": "JavaScript Demo: URL.prototype.search",
+            "type": "js"
+        },
+        "urlPrototypeSearchParams": {
+            "exampleCode": "./live-examples/webapi-examples/url/url-prototype-searchparams.js",
+            "fileName": "url-prototype-searchparams.html",
+            "title": "JavaScript Demo: URL.prototype.searchParams",
+            "type": "js"
+        },
+        "urlPrototypeToJSON": {
+            "exampleCode": "./live-examples/webapi-examples/url/url-prototype-tojson.js",
+            "fileName": "url-prototype-tojson.html",
+            "title": "JavaScript Demo: URL.prototype.toJSON()",
+            "type": "js"
+        },
+        "urlPrototypeToString": {
+            "exampleCode": "./live-examples/webapi-examples/url/url-prototype-tostring.js",
+            "fileName": "url-prototype-tostring.html",
+            "title": "JavaScript Demo: URL.prototype.toString()",
+            "type": "js"
+        },
+        "urlPrototypeUsername": {
+            "exampleCode": "./live-examples/webapi-examples/url/url-prototype-username.js",
+            "fileName": "url-prototype-username.html",
+            "title": "JavaScript Demo: URL.prototype.username",
+            "type": "js"
+        }
+    }
+}

--- a/live-examples/webapi-examples/url/meta.json
+++ b/live-examples/webapi-examples/url/meta.json
@@ -3,97 +3,97 @@
         "url": {
             "exampleCode": "./live-examples/webapi-examples/url/url.js",
             "fileName": "url.html",
-            "title": "JavaScript Demo: URL",
+            "title": "Web API Demo: URL",
             "type": "js"
         },
         "urlConstructor": {
             "exampleCode": "./live-examples/webapi-examples/url/url-constructor.js",
             "fileName": "url-constructor.html",
-            "title": "JavaScript Demo: URL Constructor",
+            "title": "Web API Demo: URL Constructor",
             "type": "js"
         },
         "urlPrototypeHash": {
             "exampleCode": "./live-examples/webapi-examples/url/url-prototype-hash.js",
             "fileName": "url-prototype-hash.html",
-            "title": "JavaScript Demo: URL.prototype.hash",
+            "title": "Web API Demo: URL.prototype.hash",
             "type": "js"
         },
         "urlPrototypeHost": {
             "exampleCode": "./live-examples/webapi-examples/url/url-prototype-host.js",
             "fileName": "url-prototype-host.html",
-            "title": "JavaScript Demo: URL.prototype.host",
+            "title": "Web API Demo: URL.prototype.host",
             "type": "js"
         },
         "urlPrototypeHostname": {
             "exampleCode": "./live-examples/webapi-examples/url/url-prototype-hostname.js",
             "fileName": "url-prototype-hostname.html",
-            "title": "JavaScript Demo: URL.prototype.hostname",
+            "title": "Web API Demo: URL.prototype.hostname",
             "type": "js"
         },
         "urlPrototypeHref": {
             "exampleCode": "./live-examples/webapi-examples/url/url-prototype-href.js",
             "fileName": "url-prototype-href.html",
-            "title": "JavaScript Demo: URL.prototype.href",
+            "title": "Web API Demo: URL.prototype.href",
             "type": "js"
         },
         "urlPrototypeOrigin": {
             "exampleCode": "./live-examples/webapi-examples/url/url-prototype-origin.js",
             "fileName": "url-prototype-origin.html",
-            "title": "JavaScript Demo: URL.prototype.origin",
+            "title": "Web API Demo: URL.prototype.origin",
             "type": "js"
         },
         "urlPrototypePassword": {
             "exampleCode": "./live-examples/webapi-examples/url/url-prototype-password.js",
             "fileName": "url-prototype-password.html",
-            "title": "JavaScript Demo: URL.prototype.password",
+            "title": "Web API Demo: URL.prototype.password",
             "type": "js"
         },
         "urlPrototypePathname": {
             "exampleCode": "./live-examples/webapi-examples/url/url-prototype-pathname.js",
             "fileName": "url-prototype-pathname.html",
-            "title": "JavaScript Demo: URL.prototype.pathname",
+            "title": "Web API Demo: URL.prototype.pathname",
             "type": "js"
         },
         "urlPrototypePort": {
             "exampleCode": "./live-examples/webapi-examples/url/url-prototype-port.js",
             "fileName": "url-prototype-port.html",
-            "title": "JavaScript Demo: URL.prototype.port",
+            "title": "Web API Demo: URL.prototype.port",
             "type": "js"
         },
         "urlPrototypeProtocol": {
             "exampleCode": "./live-examples/webapi-examples/url/url-prototype-protocol.js",
             "fileName": "url-prototype-protocol.html",
-            "title": "JavaScript Demo: URL.prototype.protocol",
+            "title": "Web API Demo: URL.prototype.protocol",
             "type": "js"
         },
         "urlPrototypeSearch": {
             "exampleCode": "./live-examples/webapi-examples/url/url-prototype-search.js",
             "fileName": "url-prototype-search.html",
-            "title": "JavaScript Demo: URL.prototype.search",
+            "title": "Web API Demo: URL.prototype.search",
             "type": "js"
         },
         "urlPrototypeSearchParams": {
             "exampleCode": "./live-examples/webapi-examples/url/url-prototype-searchparams.js",
             "fileName": "url-prototype-searchparams.html",
-            "title": "JavaScript Demo: URL.prototype.searchParams",
+            "title": "Web API Demo: URL.prototype.searchParams",
             "type": "js"
         },
         "urlPrototypeToJSON": {
             "exampleCode": "./live-examples/webapi-examples/url/url-prototype-tojson.js",
             "fileName": "url-prototype-tojson.html",
-            "title": "JavaScript Demo: URL.prototype.toJSON()",
+            "title": "Web API Demo: URL.prototype.toJSON()",
             "type": "js"
         },
         "urlPrototypeToString": {
             "exampleCode": "./live-examples/webapi-examples/url/url-prototype-tostring.js",
             "fileName": "url-prototype-tostring.html",
-            "title": "JavaScript Demo: URL.prototype.toString()",
+            "title": "Web API Demo: URL.prototype.toString()",
             "type": "js"
         },
         "urlPrototypeUsername": {
             "exampleCode": "./live-examples/webapi-examples/url/url-prototype-username.js",
             "fileName": "url-prototype-username.html",
-            "title": "JavaScript Demo: URL.prototype.username",
+            "title": "Web API Demo: URL.prototype.username",
             "type": "js"
         }
     }

--- a/live-examples/webapi-examples/url/url-constructor.js
+++ b/live-examples/webapi-examples/url/url-constructor.js
@@ -1,0 +1,7 @@
+const url1 = new URL('https://en.wikipedia.org/wiki/Mozilla#Software');
+console.log(url1.toString());
+// expected output: "https://en.wikipedia.org/wiki/Mozilla#Software"
+
+const url2 = new URL('wiki/Mozilla#Software', 'https://en.wikipedia.org');
+console.log(url2.toString());
+// expected output: "https://en.wikipedia.org/wiki/Mozilla#Software"

--- a/live-examples/webapi-examples/url/url-prototype-hash.js
+++ b/live-examples/webapi-examples/url/url-prototype-hash.js
@@ -1,0 +1,3 @@
+const url = new URL('https://en.wikipedia.org:443/wiki/Mozilla#Software');
+console.log(url.hash);
+// expected output: "#Software"

--- a/live-examples/webapi-examples/url/url-prototype-host.js
+++ b/live-examples/webapi-examples/url/url-prototype-host.js
@@ -1,0 +1,7 @@
+const url1 = new URL('https://en.wikipedia.org:443/wiki/Mozilla#Software');
+console.log(url1.host);
+// expected output: "en.wikipedia.org"
+
+const url2 = new URL('https://en.wikipedia.org:8080/wiki/Mozilla#Software');
+console.log(url2.host);
+// expected output: "en.wikipedia.org:8080"

--- a/live-examples/webapi-examples/url/url-prototype-hostname.js
+++ b/live-examples/webapi-examples/url/url-prototype-hostname.js
@@ -1,0 +1,7 @@
+const url1 = new URL('https://en.wikipedia.org:443/wiki/Mozilla#Software');
+console.log(url1.hostname);
+// expected output: "en.wikipedia.org"
+
+const url2 = new URL('https://en.wikipedia.org:8080/wiki/Mozilla#Software');
+console.log(url2.hostname);
+// expected output: "en.wikipedia.org"

--- a/live-examples/webapi-examples/url/url-prototype-href.js
+++ b/live-examples/webapi-examples/url/url-prototype-href.js
@@ -1,0 +1,3 @@
+const url = new URL('https://en.wikipedia.org:443/wiki/Mozilla#Software');
+console.log(url.href);
+// expected output: "https://en.wikipedia.org/wiki/Mozilla#Software"

--- a/live-examples/webapi-examples/url/url-prototype-origin.js
+++ b/live-examples/webapi-examples/url/url-prototype-origin.js
@@ -1,0 +1,3 @@
+const url = new URL('https://en.wikipedia.org:443/wiki/Mozilla#Software');
+console.log(url.origin);
+// expected output: "https://en.wikipedia.org"

--- a/live-examples/webapi-examples/url/url-prototype-password.js
+++ b/live-examples/webapi-examples/url/url-prototype-password.js
@@ -1,0 +1,3 @@
+const url = new URL('https://admin:test@en.wikipedia.org:443/wiki/Mozilla#Software');
+console.log(url.password);
+// expected output: "test"

--- a/live-examples/webapi-examples/url/url-prototype-pathname.js
+++ b/live-examples/webapi-examples/url/url-prototype-pathname.js
@@ -1,0 +1,3 @@
+const url = new URL('https://en.wikipedia.org:443/wiki/Mozilla#Software');
+console.log(url.pathname);
+// expected output: "/wiki/Mozilla"

--- a/live-examples/webapi-examples/url/url-prototype-port.js
+++ b/live-examples/webapi-examples/url/url-prototype-port.js
@@ -1,0 +1,7 @@
+const url1 = new URL('https://en.wikipedia.org:443/wiki/Mozilla#Software');
+console.log(url1.port);
+// expected output: ""
+
+const url2 = new URL('https://en.wikipedia.org:8080/wiki/Mozilla#Software');
+console.log(url2.port);
+// expected output: "8080"

--- a/live-examples/webapi-examples/url/url-prototype-protocol.js
+++ b/live-examples/webapi-examples/url/url-prototype-protocol.js
@@ -1,0 +1,3 @@
+const url = new URL('https://en.wikipedia.org:443/wiki/Mozilla#Software');
+console.log(url.protocol);
+// expected output: "https:"

--- a/live-examples/webapi-examples/url/url-prototype-search.js
+++ b/live-examples/webapi-examples/url/url-prototype-search.js
@@ -1,0 +1,3 @@
+const url = new URL('https://en.wikipedia.org/w/index.php?title=Mozilla&action=edit');
+console.log(url.search);
+// expected output: "?title=Mozilla&action=edit"

--- a/live-examples/webapi-examples/url/url-prototype-searchparams.js
+++ b/live-examples/webapi-examples/url/url-prototype-searchparams.js
@@ -1,0 +1,6 @@
+const url = new URL('https://en.wikipedia.org/w/index.php?title=Mozilla&action=edit');
+const params = url.searchParams;
+
+params.forEach((value, key) => console.log(`${key} - ${value}`));
+// expected output: "title - Mozilla"
+// expected output: "action - edit"

--- a/live-examples/webapi-examples/url/url-prototype-tojson.js
+++ b/live-examples/webapi-examples/url/url-prototype-tojson.js
@@ -1,0 +1,3 @@
+const url = new URL('https://en.wikipedia.org:443/wiki/Mozilla#Software');
+console.log(url.toJSON());
+// expected output: "https://en.wikipedia.org/wiki/Mozilla#Software"

--- a/live-examples/webapi-examples/url/url-prototype-tostring.js
+++ b/live-examples/webapi-examples/url/url-prototype-tostring.js
@@ -1,0 +1,3 @@
+const url = new URL('https://en.wikipedia.org:443/wiki/Mozilla#Software');
+console.log(url.toString());
+// expected output: "https://en.wikipedia.org/wiki/Mozilla#Software"

--- a/live-examples/webapi-examples/url/url-prototype-username.js
+++ b/live-examples/webapi-examples/url/url-prototype-username.js
@@ -1,0 +1,3 @@
+const url = new URL('https://admin:test@en.wikipedia.org:443/wiki/Mozilla#Software');
+console.log(url.username);
+// expected output: "admin"

--- a/live-examples/webapi-examples/url/url.js
+++ b/live-examples/webapi-examples/url/url.js
@@ -1,0 +1,12 @@
+const url = new URL('https://en.wikipedia.org/wiki/Mozilla#Software');
+console.log(url.protocol);
+// expected output: "https:"
+
+console.log(url.hostname);
+// expected output: "en.wikipedia.org"
+
+console.log(url.pathname);
+// expected output: "/wiki/Mozilla"
+
+console.log(url.hash);
+// expected output: "#Software"


### PR DESCRIPTION
Those are interactive examples for [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL), its constructor, all of its properties and methods. It doesn't include static methods [createObjectURL](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL) and [revokeObjectURL](https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL), which cannot be shown in simple JS editor.