### PR TITLE
fix(stage-deploy): build main with local bob

### DIFF
--- a/.github/workflows/stage-deploy.yml
+++ b/.github/workflows/stage-deploy.yml
@@ -14,14 +14,6 @@ jobs:
 
         steps:
             - uses: actions/checkout@v3
-              with:
-                  path: examples
-
-            - uses: actions/checkout@v3
-              with:
-                  repository: mdn/bob
-                  ref: stage
-                  path: bob
 
             - name: Setup Node.js environment
               uses: actions/setup-node@v3
@@ -30,15 +22,10 @@ jobs:
                   cache: yarn
 
             - name: Install all yarn packages
-              run: yarn --production --frozen-lockfile
-              working-directory: bob
+              run: yarn --frozen-lockfile
 
             - name: Build all
-              # TODO: bob uses relative paths in bundles. For now we just symlink.
-              run: |
-                  ln -s ../bob/node_modules .
-                  node ../bob/lib/mdn-bob.js
-              working-directory: examples
+              run: yarn build
 
             - name: Configure AWS credentials for stage
               uses: aws-actions/configure-aws-credentials@v1
@@ -48,6 +35,4 @@ jobs:
                   aws-region: us-east-1
 
             - name: Deploy pages
-              run: |
-                  aws s3 sync docs/ s3://interactive-examples-stage-ce3e7ea385c68f44/
-              working-directory: examples
+              run: aws s3 sync docs/ s3://interactive-examples-stage-ce3e7ea385c68f44/

--- a/.github/workflows/stage-deploy.yml
+++ b/.github/workflows/stage-deploy.yml
@@ -4,9 +4,9 @@ on:
     workflow_dispatch:
         inputs:
             notes:
-              description: "Notes"
-              required: false
-              default: ""
+                description: 'Notes'
+                required: false
+                default: ''
 
 jobs:
     build:
@@ -35,7 +35,7 @@ jobs:
 
             - name: Build all
               # TODO: bob uses relative paths in bundles. For now we just symlink.
-              run:  |
+              run: |
                   ln -s ../bob/node_modules .
                   node ../bob/lib/mdn-bob.js
               working-directory: examples

--- a/.github/workflows/stage-deploy.yml
+++ b/.github/workflows/stage-deploy.yml
@@ -1,6 +1,10 @@
 name: Stage Deployment
 
 on:
+    push:
+        branches:
+            - main
+
     workflow_dispatch:
         inputs:
             notes:


### PR DESCRIPTION
1. Fixes the `stage-deploy` by using `mdn-bob` as specified in the `package.json` / `yarn.lock`.
2. Run the workflow on pushes to `main` (continuous deployment).
3. Format the workflow file with prettier (`npx prettier -w`).

~~Depends on https://github.com/mdn/interactive-examples/pull/2388.~~