### PR TITLE
Deploy workflow requirements

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -4,6 +4,12 @@ on:
     push:
         branches:
             - 'main'
+        paths:
+            - './bin/**'
+            - './live-examples/**'
+            - './media/**'
+            - 'Jenkinsfile'
+            - 'package.json'
     workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Makes `prod-deploy` workflow run automatically, only when one of the following paths has changed:
- `./bin/**`
- `./live-examples/**`
- `./media/**`
- `Jenkinsfile`
- `package.json`

Fixes #2364 