### PR TITLE
Only throw Error objects in examples

### DIFF
--- a/live-examples/js-examples/expressions/expressions-newtarget.js
+++ b/live-examples/js-examples/expressions/expressions-newtarget.js
@@ -1,10 +1,10 @@
 function Foo() {
-  if (!new.target) { throw 'TypeError: calling Foo constructor without new is invalid'; }
+  if (!new.target) { throw new TypeError('calling Foo constructor without new is invalid'); }
 }
 
 try {
   Foo();
 } catch (e) {
   console.log(e);
-  // expected output: "TypeError: calling Foo constructor without new is invalid"
+  // expected output: TypeError: calling Foo constructor without new is invalid
 }

--- a/live-examples/js-examples/promise/promise-catch.js
+++ b/live-examples/js-examples/promise/promise-catch.js
@@ -1,8 +1,8 @@
 const promise1 = new Promise((resolve, reject) => {
-  throw 'Uh-oh!';
+  throw new Error('Uh-oh!');
 });
 
 promise1.catch((error) => {
   console.error(error);
 });
-// expected output: Uh-oh!
+// expected output: Error: Uh-oh!

--- a/live-examples/js-examples/statement/statement-throw.js
+++ b/live-examples/js-examples/statement/statement-throw.js
@@ -1,6 +1,6 @@
 function getRectArea(width, height) {
   if (isNaN(width) || isNaN(height)) {
-    throw 'Parameter is not a number!';
+    throw new Error('Parameter is not a number!');
   }
 }
 
@@ -8,5 +8,5 @@ try {
   getRectArea(3, 'A');
 } catch (e) {
   console.error(e);
-  // expected output: "Parameter is not a number!"
+  // expected output: Error: Parameter is not a number!
 }


### PR DESCRIPTION
Changes 3 examples in which string is thrown, instead of an object of exception.