### PR TITLE
Make comments start with upper case letter

### DIFF
--- a/live-examples/js-examples/array/array-copywithin.js
+++ b/live-examples/js-examples/array/array-copywithin.js
@@ -1,9 +1,9 @@
 const array1 = ['a', 'b', 'c', 'd', 'e'];
 
-// copy to index 0 the element at index 3
+// Copy to index 0 the element at index 3
 console.log(array1.copyWithin(0, 3, 4));
 // expected output: Array ["d", "b", "c", "d", "e"]
 
-// copy to index 1 all elements from index 3 to the end
+// Copy to index 1 all elements from index 3 to the end
 console.log(array1.copyWithin(1, 3));
 // expected output: Array ["d", "d", "e", "d", "e"]

--- a/live-examples/js-examples/array/array-fill.js
+++ b/live-examples/js-examples/array/array-fill.js
@@ -1,10 +1,10 @@
 const array1 = [1, 2, 3, 4];
 
-// fill with 0 from position 2 until position 4
+// Fill with 0 from position 2 until position 4
 console.log(array1.fill(0, 2, 4));
 // expected output: Array [1, 2, 0, 0]
 
-// fill with 5 from position 1
+// Fill with 5 from position 1
 console.log(array1.fill(5, 1));
 // expected output: Array [1, 5, 5, 5]
 

--- a/live-examples/js-examples/array/array-findlastindex.js
+++ b/live-examples/js-examples/array/array-findlastindex.js
@@ -4,4 +4,4 @@ const isLargeNumber = (element) => element > 45;
 
 console.log(array1.findLastIndex(isLargeNumber));
 // expected output: 3
-// (index of element with value: 130)
+// (Index of element with value: 130)

--- a/live-examples/js-examples/array/array-findlastindex.js
+++ b/live-examples/js-examples/array/array-findlastindex.js
@@ -4,4 +4,4 @@ const isLargeNumber = (element) => element > 45;
 
 console.log(array1.findLastIndex(isLargeNumber));
 // expected output: 3
-// (Index of element with value: 130)
+// Index of element with value: 130

--- a/live-examples/js-examples/array/array-indexof.js
+++ b/live-examples/js-examples/array/array-indexof.js
@@ -3,7 +3,7 @@ const beasts = ['ant', 'bison', 'camel', 'duck', 'bison'];
 console.log(beasts.indexOf('bison'));
 // expected output: 1
 
-// start from index 2
+// Start from index 2
 console.log(beasts.indexOf('bison', 2));
 // expected output: 4
 

--- a/live-examples/js-examples/array/array-map.js
+++ b/live-examples/js-examples/array/array-map.js
@@ -1,6 +1,6 @@
 const array1 = [1, 4, 9, 16];
 
-// pass a function to map
+// Pass a function to map
 const map1 = array1.map(x => x * 2);
 
 console.log(map1);

--- a/live-examples/js-examples/array/array-some.js
+++ b/live-examples/js-examples/array/array-some.js
@@ -1,6 +1,6 @@
 const array = [1, 2, 3, 4, 5];
 
-// checks whether an element is even
+// Checks whether an element is even
 const even = (element) => element % 2 === 0;
 
 console.log(array.some(even));

--- a/live-examples/js-examples/array/array-splice.js
+++ b/live-examples/js-examples/array/array-splice.js
@@ -1,10 +1,10 @@
 const months = ['Jan', 'March', 'April', 'June'];
 months.splice(1, 0, 'Feb');
-// inserts at index 1
+// Inserts at index 1
 console.log(months);
 // expected output: Array ["Jan", "Feb", "March", "April", "June"]
 
 months.splice(4, 1, 'May');
-// replaces 1 element at index 4
+// Replaces 1 element at index 4
 console.log(months);
 // expected output: Array ["Jan", "Feb", "March", "April", "May"]

--- a/live-examples/js-examples/arraybuffer/arraybuffer-bytelength.js
+++ b/live-examples/js-examples/arraybuffer/arraybuffer-bytelength.js
@@ -1,7 +1,7 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(8);
 
-// use byteLength to check the size
+// Use byteLength to check the size
 const bytes = buffer.byteLength;
 
 console.log(bytes);

--- a/live-examples/js-examples/arraybuffer/arraybuffer-constructor.js
+++ b/live-examples/js-examples/arraybuffer/arraybuffer-constructor.js
@@ -1,4 +1,4 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(8);
 
 console.log(buffer.byteLength);

--- a/live-examples/js-examples/arraybuffer/arraybuffer-isview.js
+++ b/live-examples/js-examples/arraybuffer/arraybuffer-isview.js
@@ -1,4 +1,4 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 console.log(ArrayBuffer.isView(new Int32Array()));

--- a/live-examples/js-examples/arraybuffer/arraybuffer-slice.js
+++ b/live-examples/js-examples/arraybuffer/arraybuffer-slice.js
@@ -1,11 +1,11 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 const int32View = new Int32Array(buffer);
-// produces Int32Array [0, 0, 0, 0]
+// Produces Int32Array [0, 0, 0, 0]
 
 int32View[1] = 42;
 const sliced = new Int32Array(buffer.slice(4, 12));
-// produces Int32Array [42, 0]
+// Produces Int32Array [42, 0]
 
 console.log(sliced[0]);
 // expected output: 42

--- a/live-examples/js-examples/atomics/atomics-add.js
+++ b/live-examples/js-examples/atomics/atomics-add.js
@@ -1,4 +1,4 @@
-// create a SharedArrayBuffer with a size in bytes
+// Create a SharedArrayBuffer with a size in bytes
 const buffer = new SharedArrayBuffer(16);
 const uint8 = new Uint8Array(buffer);
 uint8[0] = 7;

--- a/live-examples/js-examples/atomics/atomics-and.js
+++ b/live-examples/js-examples/atomics/atomics-and.js
@@ -1,4 +1,4 @@
-// create a SharedArrayBuffer with a size in bytes
+// Create a SharedArrayBuffer with a size in bytes
 const buffer = new SharedArrayBuffer(16);
 const uint8 = new Uint8Array(buffer);
 uint8[0] = 7;

--- a/live-examples/js-examples/atomics/atomics-compareexchange.js
+++ b/live-examples/js-examples/atomics/atomics-compareexchange.js
@@ -1,12 +1,12 @@
-// create a SharedArrayBuffer with a size in bytes
+// Create a SharedArrayBuffer with a size in bytes
 const buffer = new SharedArrayBuffer(16);
 const uint8 = new Uint8Array(buffer);
 uint8[0] = 5;
 
-Atomics.compareExchange(uint8, 0, 5, 2); // returns 5
+Atomics.compareExchange(uint8, 0, 5, 2); // Returns 5
 console.log(Atomics.load(uint8, 0));
 // expected output: 2
 
-Atomics.compareExchange(uint8, 0, 5, 4); // returns 2
+Atomics.compareExchange(uint8, 0, 5, 4); // Returns 2
 console.log(Atomics.load(uint8, 0));
 // expected output: 2

--- a/live-examples/js-examples/atomics/atomics-exchange.js
+++ b/live-examples/js-examples/atomics/atomics-exchange.js
@@ -1,4 +1,4 @@
-// create a SharedArrayBuffer with a size in bytes
+// Create a SharedArrayBuffer with a size in bytes
 const buffer = new SharedArrayBuffer(16);
 const uint8 = new Uint8Array(buffer);
 uint8[0] = 5;
@@ -6,6 +6,6 @@ uint8[0] = 5;
 console.log(Atomics.load(uint8, 0));
 // expected output: 5
 
-Atomics.exchange(uint8, 0, 2); // returns 5
+Atomics.exchange(uint8, 0, 2); // Returns 5
 console.log(Atomics.load(uint8, 0));
 // expected output: 2

--- a/live-examples/js-examples/atomics/atomics-load.js
+++ b/live-examples/js-examples/atomics/atomics-load.js
@@ -1,4 +1,4 @@
-// create a SharedArrayBuffer with a size in bytes
+// Create a SharedArrayBuffer with a size in bytes
 const buffer = new SharedArrayBuffer(16);
 const uint8 = new Uint8Array(buffer);
 uint8[0] = 5;

--- a/live-examples/js-examples/atomics/atomics-or.js
+++ b/live-examples/js-examples/atomics/atomics-or.js
@@ -1,4 +1,4 @@
-// create a SharedArrayBuffer with a size in bytes
+// Create a SharedArrayBuffer with a size in bytes
 const buffer = new SharedArrayBuffer(16);
 const uint8 = new Uint8Array(buffer);
 uint8[0] = 5;

--- a/live-examples/js-examples/atomics/atomics-store.js
+++ b/live-examples/js-examples/atomics/atomics-store.js
@@ -1,4 +1,4 @@
-// create a SharedArrayBuffer with a size in bytes
+// Create a SharedArrayBuffer with a size in bytes
 const buffer = new SharedArrayBuffer(16);
 const uint8 = new Uint8Array(buffer);
 uint8[0] = 5;

--- a/live-examples/js-examples/atomics/atomics-sub.js
+++ b/live-examples/js-examples/atomics/atomics-sub.js
@@ -1,4 +1,4 @@
-// create a SharedArrayBuffer with a size in bytes
+// Create a SharedArrayBuffer with a size in bytes
 const buffer = new SharedArrayBuffer(16);
 const uint8 = new Uint8Array(buffer);
 uint8[0] = 7;

--- a/live-examples/js-examples/atomics/atomics-xor.js
+++ b/live-examples/js-examples/atomics/atomics-xor.js
@@ -1,4 +1,4 @@
-// create a SharedArrayBuffer with a size in bytes
+// Create a SharedArrayBuffer with a size in bytes
 const buffer = new SharedArrayBuffer(16);
 const uint8 = new Uint8Array(buffer);
 uint8[0] = 7;

--- a/live-examples/js-examples/bigint/bigint-tolocalestring.js
+++ b/live-examples/js-examples/bigint/bigint-tolocalestring.js
@@ -4,6 +4,6 @@ const bigint = 123456789123456789n;
 console.log(bigint.toLocaleString('de-DE'));
 // expected output: "123.456.789.123.456.789"
 
-// request a currency format
+// Request a currency format
 console.log(bigint.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' }));
 // expected output: "123.456.789.123.456.789,00 €"

--- a/live-examples/js-examples/dataview/dataview-buffer.js
+++ b/live-examples/js-examples/dataview/dataview-buffer.js
@@ -1,4 +1,4 @@
-// create an ArrayBuffer
+// Create an ArrayBuffer
 const buffer = new ArrayBuffer(123);
 
 // Create a view

--- a/live-examples/js-examples/dataview/dataview-bytelength.js
+++ b/live-examples/js-examples/dataview/dataview-bytelength.js
@@ -1,8 +1,8 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view1 = new DataView(buffer);
-const view2 = new DataView(buffer, 12, 4); // from byte 12 for the next 4 bytes
+const view2 = new DataView(buffer, 12, 4); // From byte 12 for the next 4 bytes
 
 console.log(view1.byteLength + view2.byteLength); // 16 + 4
 // expected output: 20

--- a/live-examples/js-examples/dataview/dataview-byteoffset.js
+++ b/live-examples/js-examples/dataview/dataview-byteoffset.js
@@ -1,7 +1,7 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
-const view = new DataView(buffer, 12, 4); // from byte 12 for the next 4 bytes
+const view = new DataView(buffer, 12, 4); // From byte 12 for the next 4 bytes
 
 console.log(view.byteOffset);
 // expected output: 12

--- a/live-examples/js-examples/dataview/dataview-constructor.js
+++ b/live-examples/js-examples/dataview/dataview-constructor.js
@@ -1,10 +1,10 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 // Create a couple of views
 const view1 = new DataView(buffer);
-const view2 = new DataView(buffer, 12, 4); // from byte 12 for the next 4 bytes
-view1.setInt8(12, 42); // put 42 in slot 12
+const view2 = new DataView(buffer, 12, 4); // From byte 12 for the next 4 bytes
+view1.setInt8(12, 42); // Put 42 in slot 12
 
 console.log(view2.getInt8(0));
 // expected output: 42

--- a/live-examples/js-examples/dataview/dataview-getbigint64.js
+++ b/live-examples/js-examples/dataview/dataview-getbigint64.js
@@ -1,4 +1,4 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 // Highest possible BigInt value that fits in a signed 64-bit integer

--- a/live-examples/js-examples/dataview/dataview-getbiguint64.js
+++ b/live-examples/js-examples/dataview/dataview-getbiguint64.js
@@ -1,4 +1,4 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 // Highest possible BigInt value that fits in an unsigned 64-bit integer

--- a/live-examples/js-examples/dataview/dataview-getfloat32.js
+++ b/live-examples/js-examples/dataview/dataview-getfloat32.js
@@ -1,4 +1,4 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);

--- a/live-examples/js-examples/dataview/dataview-getfloat64.js
+++ b/live-examples/js-examples/dataview/dataview-getfloat64.js
@@ -1,4 +1,4 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);

--- a/live-examples/js-examples/dataview/dataview-getint16.js
+++ b/live-examples/js-examples/dataview/dataview-getint16.js
@@ -2,7 +2,7 @@
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setInt16(1, 32767); // (Max signed 16-bit integer)
+view.setInt16(1, 32767); // Max signed 16-bit integer
 
 console.log(view.getInt16(1));
 // expected output: 32767

--- a/live-examples/js-examples/dataview/dataview-getint16.js
+++ b/live-examples/js-examples/dataview/dataview-getint16.js
@@ -1,8 +1,8 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setInt16(1, 32767); // (max signed 16-bit integer)
+view.setInt16(1, 32767); // (Max signed 16-bit integer)
 
 console.log(view.getInt16(1));
 // expected output: 32767

--- a/live-examples/js-examples/dataview/dataview-getint32.js
+++ b/live-examples/js-examples/dataview/dataview-getint32.js
@@ -1,8 +1,8 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setInt32(1, 2147483647); // (max signed 32-bit integer)
+view.setInt32(1, 2147483647); // (Max signed 32-bit integer)
 
 console.log(view.getInt32(1));
 // expected output: 2147483647

--- a/live-examples/js-examples/dataview/dataview-getint32.js
+++ b/live-examples/js-examples/dataview/dataview-getint32.js
@@ -2,7 +2,7 @@
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setInt32(1, 2147483647); // (Max signed 32-bit integer)
+view.setInt32(1, 2147483647); // Max signed 32-bit integer
 
 console.log(view.getInt32(1));
 // expected output: 2147483647

--- a/live-examples/js-examples/dataview/dataview-getint8.js
+++ b/live-examples/js-examples/dataview/dataview-getint8.js
@@ -1,8 +1,8 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setInt8(1, 127); // (max signed 8-bit integer)
+view.setInt8(1, 127); // (Max signed 8-bit integer)
 
 console.log(view.getInt8(1));
 // expected output: 127

--- a/live-examples/js-examples/dataview/dataview-getint8.js
+++ b/live-examples/js-examples/dataview/dataview-getint8.js
@@ -2,7 +2,7 @@
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setInt8(1, 127); // (Max signed 8-bit integer)
+view.setInt8(1, 127); // Max signed 8-bit integer
 
 console.log(view.getInt8(1));
 // expected output: 127

--- a/live-examples/js-examples/dataview/dataview-getuint16.js
+++ b/live-examples/js-examples/dataview/dataview-getuint16.js
@@ -2,7 +2,7 @@
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setUint16(1, 65535); // (Max unsigned 16-bit integer)
+view.setUint16(1, 65535); // Max unsigned 16-bit integer
 
 console.log(view.getUint16(1));
 // expected output: 65535

--- a/live-examples/js-examples/dataview/dataview-getuint16.js
+++ b/live-examples/js-examples/dataview/dataview-getuint16.js
@@ -1,8 +1,8 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setUint16(1, 65535); // (max unsigned 16-bit integer)
+view.setUint16(1, 65535); // (Max unsigned 16-bit integer)
 
 console.log(view.getUint16(1));
 // expected output: 65535

--- a/live-examples/js-examples/dataview/dataview-getuint32.js
+++ b/live-examples/js-examples/dataview/dataview-getuint32.js
@@ -2,7 +2,7 @@
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setUint32(1, 4294967295); // (Max unsigned 32-bit integer)
+view.setUint32(1, 4294967295); // Max unsigned 32-bit integer
 
 console.log(view.getUint32(1));
 // expected output: 4294967295

--- a/live-examples/js-examples/dataview/dataview-getuint32.js
+++ b/live-examples/js-examples/dataview/dataview-getuint32.js
@@ -1,8 +1,8 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setUint32(1, 4294967295); // (max unsigned 32-bit integer)
+view.setUint32(1, 4294967295); // (Max unsigned 32-bit integer)
 
 console.log(view.getUint32(1));
 // expected output: 4294967295

--- a/live-examples/js-examples/dataview/dataview-getuint8.js
+++ b/live-examples/js-examples/dataview/dataview-getuint8.js
@@ -2,7 +2,7 @@
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setUint8(1, 255); // (Max unsigned 8-bit integer)
+view.setUint8(1, 255); // Max unsigned 8-bit integer
 
 console.log(view.getUint8(1));
 // expected output: 255

--- a/live-examples/js-examples/dataview/dataview-getuint8.js
+++ b/live-examples/js-examples/dataview/dataview-getuint8.js
@@ -1,8 +1,8 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setUint8(1, 255); // (max unsigned 8-bit integer)
+view.setUint8(1, 255); // (Max unsigned 8-bit integer)
 
 console.log(view.getUint8(1));
 // expected output: 255

--- a/live-examples/js-examples/dataview/dataview-setbigint64.js
+++ b/live-examples/js-examples/dataview/dataview-setbigint64.js
@@ -1,4 +1,4 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 // Highest possible BigInt value that fits in a signed 64-bit integer

--- a/live-examples/js-examples/dataview/dataview-setbiguint64.js
+++ b/live-examples/js-examples/dataview/dataview-setbiguint64.js
@@ -1,4 +1,4 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 // Highest possible BigInt value that fits in an unsigned 64-bit integer

--- a/live-examples/js-examples/dataview/dataview-setfloat32.js
+++ b/live-examples/js-examples/dataview/dataview-setfloat32.js
@@ -1,4 +1,4 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);

--- a/live-examples/js-examples/dataview/dataview-setfloat64.js
+++ b/live-examples/js-examples/dataview/dataview-setfloat64.js
@@ -1,4 +1,4 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);

--- a/live-examples/js-examples/dataview/dataview-setint16.js
+++ b/live-examples/js-examples/dataview/dataview-setint16.js
@@ -2,7 +2,7 @@
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setInt16(1, 32767); // (Max signed 16-bit integer)
+view.setInt16(1, 32767); // Max signed 16-bit integer
 
 console.log(view.getInt16(1));
 // expected output: 32767

--- a/live-examples/js-examples/dataview/dataview-setint16.js
+++ b/live-examples/js-examples/dataview/dataview-setint16.js
@@ -1,8 +1,8 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setInt16(1, 32767); // (max signed 16-bit integer)
+view.setInt16(1, 32767); // (Max signed 16-bit integer)
 
 console.log(view.getInt16(1));
 // expected output: 32767

--- a/live-examples/js-examples/dataview/dataview-setint32.js
+++ b/live-examples/js-examples/dataview/dataview-setint32.js
@@ -1,8 +1,8 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setInt32(1, 2147483647); // (max signed 32-bit integer)
+view.setInt32(1, 2147483647); // (Max signed 32-bit integer)
 
 console.log(view.getInt32(1));
 // expected output: 2147483647

--- a/live-examples/js-examples/dataview/dataview-setint32.js
+++ b/live-examples/js-examples/dataview/dataview-setint32.js
@@ -2,7 +2,7 @@
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setInt32(1, 2147483647); // (Max signed 32-bit integer)
+view.setInt32(1, 2147483647); // Max signed 32-bit integer
 
 console.log(view.getInt32(1));
 // expected output: 2147483647

--- a/live-examples/js-examples/dataview/dataview-setint8.js
+++ b/live-examples/js-examples/dataview/dataview-setint8.js
@@ -1,8 +1,8 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setInt8(1, 127); // (max signed 8-bit integer)
+view.setInt8(1, 127); // (Max signed 8-bit integer)
 
 console.log(view.getInt8(1));
 // expected output: 127

--- a/live-examples/js-examples/dataview/dataview-setint8.js
+++ b/live-examples/js-examples/dataview/dataview-setint8.js
@@ -2,7 +2,7 @@
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setInt8(1, 127); // (Max signed 8-bit integer)
+view.setInt8(1, 127); // Max signed 8-bit integer
 
 console.log(view.getInt8(1));
 // expected output: 127

--- a/live-examples/js-examples/dataview/dataview-setuint16.js
+++ b/live-examples/js-examples/dataview/dataview-setuint16.js
@@ -2,7 +2,7 @@
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setUint16(1, 65535); // (Max unsigned 16-bit integer)
+view.setUint16(1, 65535); // Max unsigned 16-bit integer
 
 console.log(view.getUint16(1));
 // expected output: 65535

--- a/live-examples/js-examples/dataview/dataview-setuint16.js
+++ b/live-examples/js-examples/dataview/dataview-setuint16.js
@@ -1,8 +1,8 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setUint16(1, 65535); // (max unsigned 16-bit integer)
+view.setUint16(1, 65535); // (Max unsigned 16-bit integer)
 
 console.log(view.getUint16(1));
 // expected output: 65535

--- a/live-examples/js-examples/dataview/dataview-setuint32.js
+++ b/live-examples/js-examples/dataview/dataview-setuint32.js
@@ -2,7 +2,7 @@
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setUint32(1, 4294967295); // (Max unsigned 32-bit integer)
+view.setUint32(1, 4294967295); // Max unsigned 32-bit integer
 
 console.log(view.getUint32(1));
 // expected output: 4294967295

--- a/live-examples/js-examples/dataview/dataview-setuint32.js
+++ b/live-examples/js-examples/dataview/dataview-setuint32.js
@@ -1,8 +1,8 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setUint32(1, 4294967295); // (max unsigned 32-bit integer)
+view.setUint32(1, 4294967295); // (Max unsigned 32-bit integer)
 
 console.log(view.getUint32(1));
 // expected output: 4294967295

--- a/live-examples/js-examples/dataview/dataview-setuint8.js
+++ b/live-examples/js-examples/dataview/dataview-setuint8.js
@@ -2,7 +2,7 @@
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setUint8(1, 255); // (Max unsigned 8-bit integer)
+view.setUint8(1, 255); // Max unsigned 8-bit integer
 
 console.log(view.getUint8(1));
 // expected output: 255

--- a/live-examples/js-examples/dataview/dataview-setuint8.js
+++ b/live-examples/js-examples/dataview/dataview-setuint8.js
@@ -1,8 +1,8 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(16);
 
 const view = new DataView(buffer);
-view.setUint8(1, 255); // (max unsigned 8-bit integer)
+view.setUint8(1, 255); // (Max unsigned 8-bit integer)
 
 console.log(view.getUint8(1));
 // expected output: 255

--- a/live-examples/js-examples/date/date-gettime.js
+++ b/live-examples/js-examples/date/date-gettime.js
@@ -1,5 +1,5 @@
 const moonLanding = new Date('July 20, 69 20:17:40 GMT+00:00');
 
-// milliseconds since Jan 1, 1970, 00:00:00.000 GMT
+// Milliseconds since Jan 1, 1970, 00:00:00.000 GMT
 console.log(moonLanding.getTime());
 // expected output: -14182940000

--- a/live-examples/js-examples/date/date-gettimezoneoffset.js
+++ b/live-examples/js-examples/date/date-gettimezoneoffset.js
@@ -3,7 +3,7 @@ const date2 = new Date('August 19, 1975 23:15:30 GMT-02:00');
 
 console.log(date1.getTimezoneOffset());
 // expected output: your local timezone offset in minutes
-// (eg -120). NOT the timezone offset of the date object.
+// (Eg -120). NOT the timezone offset of the date object.
 
 console.log(date1.getTimezoneOffset() === date2.getTimezoneOffset());
 // expected output: true

--- a/live-examples/js-examples/date/date-gettimezoneoffset.js
+++ b/live-examples/js-examples/date/date-gettimezoneoffset.js
@@ -3,7 +3,7 @@ const date2 = new Date('August 19, 1975 23:15:30 GMT-02:00');
 
 console.log(date1.getTimezoneOffset());
 // expected output: your local timezone offset in minutes
-// (Eg -120). NOT the timezone offset of the date object.
+// (e.g., -120). NOT the timezone offset of the date object.
 
 console.log(date1.getTimezoneOffset() === date2.getTimezoneOffset());
 // expected output: true

--- a/live-examples/js-examples/date/date-now.js
+++ b/live-examples/js-examples/date/date-now.js
@@ -1,4 +1,4 @@
-// this example takes 2 seconds to run
+// This example takes 2 seconds to run
 const start = Date.now();
 
 console.log('starting timer...');

--- a/live-examples/js-examples/date/date-sethours.js
+++ b/live-examples/js-examples/date/date-sethours.js
@@ -3,7 +3,7 @@ event.setHours(20);
 
 console.log(event);
 // expected output: "Tue Aug 19 1975 20:15:30 GMT+0200 (CEST)"
-// (Note: your timezone may vary)
+// Note: your timezone may vary
 
 event.setHours(20, 21, 22);
 

--- a/live-examples/js-examples/date/date-sethours.js
+++ b/live-examples/js-examples/date/date-sethours.js
@@ -3,7 +3,7 @@ event.setHours(20);
 
 console.log(event);
 // expected output: "Tue Aug 19 1975 20:15:30 GMT+0200 (CEST)"
-// (note: your timezone may vary)
+// (Note: your timezone may vary)
 
 event.setHours(20, 21, 22);
 

--- a/live-examples/js-examples/date/date-setminutes.js
+++ b/live-examples/js-examples/date/date-setminutes.js
@@ -7,4 +7,4 @@ console.log(event.getMinutes());
 
 console.log(event);
 // expected output: "Tue Aug 19 1975 23:45:30 GMT+0200 (CEST)"
-// (Note: your timezone may vary)
+// Note: your timezone may vary

--- a/live-examples/js-examples/date/date-setminutes.js
+++ b/live-examples/js-examples/date/date-setminutes.js
@@ -7,4 +7,4 @@ console.log(event.getMinutes());
 
 console.log(event);
 // expected output: "Tue Aug 19 1975 23:45:30 GMT+0200 (CEST)"
-// (note: your timezone may vary)
+// (Note: your timezone may vary)

--- a/live-examples/js-examples/date/date-setmonth.js
+++ b/live-examples/js-examples/date/date-setmonth.js
@@ -7,4 +7,4 @@ console.log(event.getMonth());
 
 console.log(event);
 // expected output: "Sat Apr 19 1975 23:15:30 GMT+0100 (CET)"
-// (Note: your timezone may vary)
+// Note: your timezone may vary

--- a/live-examples/js-examples/date/date-setmonth.js
+++ b/live-examples/js-examples/date/date-setmonth.js
@@ -7,4 +7,4 @@ console.log(event.getMonth());
 
 console.log(event);
 // expected output: "Sat Apr 19 1975 23:15:30 GMT+0100 (CET)"
-// (note: your timezone may vary)
+// (Note: your timezone may vary)

--- a/live-examples/js-examples/date/date-setseconds.js
+++ b/live-examples/js-examples/date/date-setseconds.js
@@ -7,4 +7,4 @@ console.log(event.getSeconds());
 
 console.log(event);
 // expected output: "Sat Apr 19 1975 23:15:42 GMT+0100 (CET)"
-// (note: your timezone may vary)
+// (Note: your timezone may vary)

--- a/live-examples/js-examples/date/date-setseconds.js
+++ b/live-examples/js-examples/date/date-setseconds.js
@@ -7,4 +7,4 @@ console.log(event.getSeconds());
 
 console.log(event);
 // expected output: "Sat Apr 19 1975 23:15:42 GMT+0100 (CET)"
-// (Note: your timezone may vary)
+// Note: your timezone may vary

--- a/live-examples/js-examples/date/date-settime.js
+++ b/live-examples/js-examples/date/date-settime.js
@@ -10,4 +10,4 @@ futureDate.setTime(futureDate.getTime() + fiveMinutesInMillis);
 
 console.log(futureDate);
 // expected output: "Thu Jul 01 1999 12:05:00 GMT+0200 (CEST)"
-// (note: your timezone may vary)
+// (Note: your timezone may vary)

--- a/live-examples/js-examples/date/date-settime.js
+++ b/live-examples/js-examples/date/date-settime.js
@@ -10,4 +10,4 @@ futureDate.setTime(futureDate.getTime() + fiveMinutesInMillis);
 
 console.log(futureDate);
 // expected output: "Thu Jul 01 1999 12:05:00 GMT+0200 (CEST)"
-// (Note: your timezone may vary)
+// Note: your timezone may vary

--- a/live-examples/js-examples/date/date-todatestring.js
+++ b/live-examples/js-examples/date/date-todatestring.js
@@ -2,7 +2,7 @@ const event = new Date(1993, 6, 28, 14, 39, 7);
 
 console.log(event.toString());
 // expected output: "Wed Jul 28 1993 14:39:07 GMT+0200 (CEST)"
-// (note: your timezone may vary)
+// (Note: your timezone may vary)
 
 console.log(event.toDateString());
 // expected output: "Wed Jul 28 1993"

--- a/live-examples/js-examples/date/date-todatestring.js
+++ b/live-examples/js-examples/date/date-todatestring.js
@@ -2,7 +2,7 @@ const event = new Date(1993, 6, 28, 14, 39, 7);
 
 console.log(event.toString());
 // expected output: "Wed Jul 28 1993 14:39:07 GMT+0200 (CEST)"
-// (Note: your timezone may vary)
+// Note: your timezone may vary
 
 console.log(event.toDateString());
 // expected output: "Wed Jul 28 1993"

--- a/live-examples/js-examples/date/date-toisostring.js
+++ b/live-examples/js-examples/date/date-toisostring.js
@@ -1,7 +1,7 @@
 const event = new Date('05 October 2011 14:48 UTC');
 console.log(event.toString());
 // expected output: "Wed Oct 05 2011 16:48:00 GMT+0200 (CEST)"
-// (Note: your timezone may vary)
+// Note: your timezone may vary
 
 console.log(event.toISOString());
 // expected output: "2011-10-05T14:48:00.000Z"

--- a/live-examples/js-examples/date/date-toisostring.js
+++ b/live-examples/js-examples/date/date-toisostring.js
@@ -1,7 +1,7 @@
 const event = new Date('05 October 2011 14:48 UTC');
 console.log(event.toString());
 // expected output: "Wed Oct 05 2011 16:48:00 GMT+0200 (CEST)"
-// (note: your timezone may vary)
+// (Note: your timezone may vary)
 
 console.log(event.toISOString());
 // expected output: "2011-10-05T14:48:00.000Z"

--- a/live-examples/js-examples/date/date-tostring.js
+++ b/live-examples/js-examples/date/date-tostring.js
@@ -2,4 +2,4 @@ const event = new Date('August 19, 1975 23:15:30');
 
 console.log(event.toString());
 // expected output: "Tue Aug 19 1975 23:15:30 GMT+0200 (CEST)"
-// (Note: your timezone may vary)
+// Note: your timezone may vary

--- a/live-examples/js-examples/date/date-tostring.js
+++ b/live-examples/js-examples/date/date-tostring.js
@@ -2,4 +2,4 @@ const event = new Date('August 19, 1975 23:15:30');
 
 console.log(event.toString());
 // expected output: "Tue Aug 19 1975 23:15:30 GMT+0200 (CEST)"
-// (note: your timezone may vary)
+// (Note: your timezone may vary)

--- a/live-examples/js-examples/date/date-totimestring.js
+++ b/live-examples/js-examples/date/date-totimestring.js
@@ -2,4 +2,4 @@ const event = new Date('August 19, 1975 23:15:30');
 
 console.log(event.toTimeString());
 // expected output: "23:15:30 GMT+0200 (CEST)"
-// (note: your timezone may vary)
+// (Note: your timezone may vary)

--- a/live-examples/js-examples/date/date-totimestring.js
+++ b/live-examples/js-examples/date/date-totimestring.js
@@ -2,4 +2,4 @@ const event = new Date('August 19, 1975 23:15:30');
 
 console.log(event.toTimeString());
 // expected output: "23:15:30 GMT+0200 (CEST)"
-// (Note: your timezone may vary)
+// Note: your timezone may vary

--- a/live-examples/js-examples/expressions/expressions-addition-assignment.js
+++ b/live-examples/js-examples/expressions/expressions-addition-assignment.js
@@ -1,8 +1,8 @@
 let a = 2;
 let b = 'hello';
 
-console.log(a += 3); // addition
+console.log(a += 3); // Addition
 // expected output: 5
 
-console.log(b += ' world'); // concatenation
+console.log(b += ' world'); // Concatenation
 // expected output: "hello world"

--- a/live-examples/js-examples/expressions/expressions-addition.js
+++ b/live-examples/js-examples/expressions/expressions-addition.js
@@ -1,11 +1,11 @@
 console.log(2 + 2);
-// expected result: 4
+// Expected output: 4
 
 console.log(2 + true);
-// expected result: 3
+// Expected output: 3
 
 console.log('hello ' + 'everyone');
-// expected result: "hello everyone"
+// Expected output: "hello everyone"
 
 console.log(2001 + ': A Space Odyssey');
-// expected result: "2001: A Space Odyssey"
+// Expected output: "2001: A Space Odyssey"

--- a/live-examples/js-examples/globalprops/globalprops-decodeuri.js
+++ b/live-examples/js-examples/globalprops/globalprops-decodeuri.js
@@ -6,6 +6,6 @@ console.log(encoded);
 try {
   console.log(decodeURI(encoded));
   // expected output: "https://mozilla.org/?x=шеллы"
-} catch (e) { // catches a malformed URI
+} catch (e) { // Catches a malformed URI
   console.error(e);
 }

--- a/live-examples/js-examples/globalprops/globalprops-encodeuri.js
+++ b/live-examples/js-examples/globalprops/globalprops-encodeuri.js
@@ -6,7 +6,7 @@ console.log(encoded);
 try {
   console.log(decodeURI(encoded));
   // expected output: "https://mozilla.org/?x=шеллы"
-} catch (e) { // catches a malformed URI
+} catch (e) { // Catches a malformed URI
   console.error(e);
 }
 

--- a/live-examples/js-examples/globalprops/globalprops-encodeuricomponent.js
+++ b/live-examples/js-examples/globalprops/globalprops-encodeuricomponent.js
@@ -1,4 +1,4 @@
-// encodes characters such as ?,=,/,&,:
+// Encodes characters such as ?,=,/,&,:
 console.log(`?x=${encodeURIComponent('test?')}`);
 // expected output: "?x=test%3F"
 

--- a/live-examples/js-examples/globalprops/globalprops-infinity.js
+++ b/live-examples/js-examples/globalprops/globalprops-infinity.js
@@ -1,4 +1,4 @@
-const maxNumber = Math.pow(10, 1000); // max positive number
+const maxNumber = Math.pow(10, 1000); // Max positive number
 
 if (maxNumber === Infinity) {
   console.log('Let\'s call it Infinity!');

--- a/live-examples/js-examples/intl/intl-numberformat.js
+++ b/live-examples/js-examples/intl/intl-numberformat.js
@@ -3,10 +3,10 @@ const number = 123456.789;
 console.log(new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(number));
 // expected output: "123.456,79 €"
 
-// the Japanese yen doesn't use a minor unit
+// The Japanese yen doesn't use a minor unit
 console.log(new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(number));
 // expected output: "￥123,457"
 
-// limit to three significant digits
+// Limit to three significant digits
 console.log(new Intl.NumberFormat('en-IN', { maximumSignificantDigits: 3 }).format(number));
 // expected output: "1,23,000"

--- a/live-examples/js-examples/map/map-prototype-delete.js
+++ b/live-examples/js-examples/map/map-prototype-delete.js
@@ -3,7 +3,7 @@ map1.set('bar', 'foo');
 
 console.log(map1.delete('bar'));
 // Expected result: true
-// (True indicates successful removal)
+// True indicates successful removal
 
 console.log(map1.has('bar'));
 // Expected result: false

--- a/live-examples/js-examples/map/map-prototype-delete.js
+++ b/live-examples/js-examples/map/map-prototype-delete.js
@@ -2,8 +2,8 @@ const map1 = new Map();
 map1.set('bar', 'foo');
 
 console.log(map1.delete('bar'));
-// expected result: true
-// (true indicates successful removal)
+// Expected result: true
+// (True indicates successful removal)
 
 console.log(map1.has('bar'));
-// expected result: false
+// Expected result: false

--- a/live-examples/js-examples/number/number-nan.js
+++ b/live-examples/js-examples/number/number-nan.js
@@ -1,7 +1,7 @@
 function clean(x) {
   // eslint-disable-next-line use-isnan
   if (x === Number.NaN) {
-    // can never be true
+    // Can never be true
     return null;
   }
   if (isNaN(x)) {

--- a/live-examples/js-examples/object/object-create.js
+++ b/live-examples/js-examples/object/object-create.js
@@ -8,7 +8,7 @@ const person = {
 const me = Object.create(person);
 
 me.name = 'Matthew'; // "name" is a property set on "me", but not on "person"
-me.isHuman = true; // inherited properties can be overwritten
+me.isHuman = true; // Inherited properties can be overwritten
 
 me.printIntroduction();
 // expected output: "My name is Matthew. Am I human? true"

--- a/live-examples/js-examples/object/object-defineproperty.js
+++ b/live-examples/js-examples/object/object-defineproperty.js
@@ -6,7 +6,7 @@ Object.defineProperty(object1, 'property1', {
 });
 
 object1.property1 = 77;
-// throws an error in strict mode
+// Throws an error in strict mode
 
 console.log(object1.property1);
 // expected output: 42

--- a/live-examples/js-examples/object/object-seal.js
+++ b/live-examples/js-examples/object/object-seal.js
@@ -7,6 +7,6 @@ object1.property1 = 33;
 console.log(object1.property1);
 // expected output: 33
 
-delete object1.property1; // cannot delete when sealed
+delete object1.property1; // Cannot delete when sealed
 console.log(object1.property1);
 // expected output: 33

--- a/live-examples/js-examples/proxyhandler/proxyhandler-setprototypeof.js
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-setprototypeof.js
@@ -11,7 +11,7 @@ const monster1 = {
 };
 
 const proxy1 = new Proxy(monster1, handler1);
-// Object.setPrototypeOf(proxy1, monsterProto); // throws a TypeError
+// Object.setPrototypeOf(proxy1, monsterProto); // Throws a TypeError
 
 console.log(Reflect.setPrototypeOf(proxy1, monsterProto));
 // expected output: false

--- a/live-examples/js-examples/regexp/regexp-prototype-flags.js
+++ b/live-examples/js-examples/regexp/regexp-prototype-flags.js
@@ -1,4 +1,4 @@
-// outputs RegExp flags in alphabetical order
+// Outputs RegExp flags in alphabetical order
 
 console.log(/foo/ig.flags);
 // expected output: "gi"

--- a/live-examples/js-examples/regexp/regexp-prototype-source.js
+++ b/live-examples/js-examples/regexp/regexp-prototype-source.js
@@ -8,4 +8,4 @@ console.log(new RegExp().source);
 
 console.log(new RegExp('\n').source === '\\n');
 // expected output: true (starting with ES5)
-// (Due to escaping)
+// Due to escaping

--- a/live-examples/js-examples/regexp/regexp-prototype-source.js
+++ b/live-examples/js-examples/regexp/regexp-prototype-source.js
@@ -8,4 +8,4 @@ console.log(new RegExp().source);
 
 console.log(new RegExp('\n').source === '\\n');
 // expected output: true (starting with ES5)
-// (due to escaping)
+// (Due to escaping)

--- a/live-examples/js-examples/sharedarraybuffer/sharedarraybuffer-bytelength.js
+++ b/live-examples/js-examples/sharedarraybuffer/sharedarraybuffer-bytelength.js
@@ -1,4 +1,4 @@
-// create a SharedArrayBuffer with a size in bytes
+// Create a SharedArrayBuffer with a size in bytes
 const buffer = new SharedArrayBuffer(8);
 
 console.log(buffer.byteLength);

--- a/live-examples/js-examples/sharedarraybuffer/sharedarraybuffer-constructor.js
+++ b/live-examples/js-examples/sharedarraybuffer/sharedarraybuffer-constructor.js
@@ -1,4 +1,4 @@
-// create a SharedArrayBuffer with a size in bytes
+// Create a SharedArrayBuffer with a size in bytes
 const buffer = new SharedArrayBuffer(8);
 
 console.log(buffer.byteLength);

--- a/live-examples/js-examples/sharedarraybuffer/sharedarraybuffer-slice.js
+++ b/live-examples/js-examples/sharedarraybuffer/sharedarraybuffer-slice.js
@@ -1,7 +1,7 @@
-// create a SharedArrayBuffer with a size in bytes
+// Create a SharedArrayBuffer with a size in bytes
 const buffer = new SharedArrayBuffer(16);
-const int32View = new Int32Array(buffer); // create the view
-// produces Int32Array [0, 0, 0, 0]
+const int32View = new Int32Array(buffer); // Create the view
+// Produces Int32Array [0, 0, 0, 0]
 
 int32View[1] = 42;
 const sliced = new Int32Array(buffer.slice(4, 12));

--- a/live-examples/js-examples/statement/statement-dowhile.js
+++ b/live-examples/js-examples/statement/statement-dowhile.js
@@ -7,4 +7,4 @@ do {
 } while (i < 5);
 
 console.log(result);
-// expected result: "12345"
+// Expected output: "12345"

--- a/live-examples/js-examples/statement/statement-forawaitof.js
+++ b/live-examples/js-examples/statement/statement-forawaitof.js
@@ -8,6 +8,6 @@ async function* foo() {
     console.log(num);
     // expected output: 1
 
-    break; // closes iterator, triggers return
+    break; // Closes iterator, triggers return
   }
 })();

--- a/live-examples/js-examples/string/string-localecompare.js
+++ b/live-examples/js-examples/string/string-localecompare.js
@@ -1,5 +1,5 @@
-const a = 'réservé'; // with accents, lowercase
-const b = 'RESERVE'; // no accents, uppercase
+const a = 'réservé'; // With accents, lowercase
+const b = 'RESERVE'; // No accents, uppercase
 
 console.log(a.localeCompare(b));
 // expected output: 1

--- a/live-examples/js-examples/string/string-replaceall.js
+++ b/live-examples/js-examples/string/string-replaceall.js
@@ -4,7 +4,7 @@ console.log(p.replaceAll('dog', 'monkey'));
 // expected output: "The quick brown fox jumps over the lazy monkey. If the monkey reacted, was it really lazy?"
 
 
-// global flag required when calling replaceAll with regex
+// Global flag required when calling replaceAll with regex
 const regex = /Dog/ig;
 console.log(p.replaceAll(regex, 'ferret'));
 // expected output: "The quick brown fox jumps over the lazy ferret. If the ferret reacted, was it really lazy?"

--- a/live-examples/js-examples/string/string-search.js
+++ b/live-examples/js-examples/string/string-search.js
@@ -1,6 +1,6 @@
 const paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
 
-// any character that is not a word character or whitespace
+// Any character that is not a word character or whitespace
 const regex = /[^\w\s]/g;
 
 console.log(paragraph.search(regex));

--- a/live-examples/js-examples/symbol/symbol-keyfor.js
+++ b/live-examples/js-examples/symbol/symbol-keyfor.js
@@ -1,9 +1,9 @@
-const globalSym = Symbol.for('foo'); // global symbol
+const globalSym = Symbol.for('foo'); // Global symbol
 
 console.log(Symbol.keyFor(globalSym));
 // expected output: "foo"
 
-const localSym = Symbol(); // local symbol
+const localSym = Symbol(); // Local symbol
 
 console.log(Symbol.keyFor(localSym));
 // expected output: undefined

--- a/live-examples/js-examples/typedarray/typedarray-buffer.js
+++ b/live-examples/js-examples/typedarray/typedarray-buffer.js
@@ -1,4 +1,4 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(8);
 const uint16 = new Uint16Array(buffer);
 

--- a/live-examples/js-examples/typedarray/typedarray-bytelength.js
+++ b/live-examples/js-examples/typedarray/typedarray-bytelength.js
@@ -1,4 +1,4 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(8);
 const uint8 = new Uint8Array(buffer, 2);
 

--- a/live-examples/js-examples/typedarray/typedarray-constructor.js
+++ b/live-examples/js-examples/typedarray/typedarray-constructor.js
@@ -1,4 +1,4 @@
-// create a TypedArray with a size in bytes
+// Create a TypedArray with a size in bytes
 const typedArray1 = new Int8Array(8);
 typedArray1[0] = 32;
 

--- a/live-examples/js-examples/typedarray/typedarray-copywithin.js
+++ b/live-examples/js-examples/typedarray/typedarray-copywithin.js
@@ -1,6 +1,6 @@
 const uint8 = new Uint8Array([ 1, 2, 3, 4, 5, 6, 7, 8 ]);
 
-// (insert position, start position, end position)
+// (Insert position, start position, end position)
 uint8.copyWithin(3, 1, 3);
 
 console.log(uint8);

--- a/live-examples/js-examples/typedarray/typedarray-copywithin.js
+++ b/live-examples/js-examples/typedarray/typedarray-copywithin.js
@@ -1,6 +1,6 @@
 const uint8 = new Uint8Array([ 1, 2, 3, 4, 5, 6, 7, 8 ]);
 
-// (Insert position, start position, end position)
+// Insert position, start position, end position
 uint8.copyWithin(3, 1, 3);
 
 console.log(uint8);

--- a/live-examples/js-examples/typedarray/typedarray-fill.js
+++ b/live-examples/js-examples/typedarray/typedarray-fill.js
@@ -1,5 +1,5 @@
 const uint8 = new Uint8Array([0, 0, 0, 0]);
-// (Value, start position, end position);
+// Value, start position, end position
 uint8.fill(4, 1, 3);
 
 console.log(uint8);

--- a/live-examples/js-examples/typedarray/typedarray-fill.js
+++ b/live-examples/js-examples/typedarray/typedarray-fill.js
@@ -1,5 +1,5 @@
 const uint8 = new Uint8Array([0, 0, 0, 0]);
-// (value, start position, end position);
+// (Value, start position, end position);
 uint8.fill(4, 1, 3);
 
 console.log(uint8);

--- a/live-examples/js-examples/typedarray/typedarray-includes.js
+++ b/live-examples/js-examples/typedarray/typedarray-includes.js
@@ -3,6 +3,6 @@ const uint8 = new Uint8Array([10, 20, 30, 40, 50]);
 console.log(uint8.includes(20));
 // expected output: true
 
-// check from position 3
+// Check from position 3
 console.log(uint8.includes(20, 3));
 // expected output: false

--- a/live-examples/js-examples/typedarray/typedarray-indexof.js
+++ b/live-examples/js-examples/typedarray/typedarray-indexof.js
@@ -3,7 +3,7 @@ const uint8 = new Uint8Array([10, 20, 30, 40, 50]);
 console.log(uint8.indexOf(50));
 // expected output: 4
 
-// from position 3
+// From position 3
 console.log(uint8.indexOf(20, 3));
 // expected output: -1
 

--- a/live-examples/js-examples/typedarray/typedarray-length.js
+++ b/live-examples/js-examples/typedarray/typedarray-length.js
@@ -1,4 +1,4 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(8);
 const uint8 = new Uint8Array(buffer, 2);
 

--- a/live-examples/js-examples/typedarray/typedarray-set.js
+++ b/live-examples/js-examples/typedarray/typedarray-set.js
@@ -1,4 +1,4 @@
-// create an ArrayBuffer with a size in bytes
+// Create an ArrayBuffer with a size in bytes
 const buffer = new ArrayBuffer(8);
 const uint8 = new Uint8Array(buffer);
 


### PR DESCRIPTION
This PR changes the first letter of comments to upper case, making them follow the guidelines of examples from the content repository. I have changed all comments except for:
- Comments that start with `// expected output`, which were placed in PR #2385
- Comments that start with a digit
- `// eslint-disable-next-line use-isnan`
- Comments referring to an element in JavaScript code, like `console.log`
- Comments containing the second part of a sentence