### PR TITLE
Add lang attribute that should be present

### DIFF
--- a/live-examples/html-examples/inline-text-semantics/i.html
+++ b/live-examples/html-examples/inline-text-semantics/i.html
@@ -1,5 +1,5 @@
 <p>I looked at it and thought <i>This can't be real!</i></p>
 
-<p><i class="latin">Musa</i> is one of two or three genera in the family <i class="latin">Musaceae</i>; it includes bananas and plantains.</p>
+<p><i lang="la">Musa</i> is one of two or three genera in the family <i lang="la">Musaceae</i>; it includes bananas and plantains.</p>
 
 <p>The term <i>bandwidth</i> describes the measure of how much information can pass through a data connection in a given amount of time.</p>


### PR DESCRIPTION
The [usage notes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i#usage_notes) section of the `<i>` page in the MDN HTML Reference states that this element can be used to mark up—

> Idiomatic terms from another language (such as "et cetera"); these should include the lang attribute to identify the language

There are two terms in Latin in this example, but they have `class="latin"` (which is unused in the CSS) instead of the `lang="la"` that should be present.

This change replaces that `class` attribute with the `lang` attribute that should be present.

### Description

Make add `lang` to relevant tags to example better conform to what is suggested in the documentation.

### Motivation

Apply best practices to example.
