### PR TITLE
chore(wat): Add `Expected output` to WAT examples

### DIFF
--- a/live-examples/wat-examples/log_bool_false.js
+++ b/live-examples/wat-examples/log_bool_false.js
@@ -2,6 +2,7 @@ var url = "{%wasm-url%}";
 
 function log_bool(value) {
   console.log(Boolean(value));
+  // Expected output: false
 }
 
 await WebAssembly.instantiateStreaming(fetch(url), {

--- a/live-examples/wat-examples/log_bool_true.js
+++ b/live-examples/wat-examples/log_bool_true.js
@@ -1,0 +1,10 @@
+var url = "{%wasm-url%}";
+
+function log_bool(value) {
+  console.log(Boolean(value));
+  // Expected output: true
+}
+
+await WebAssembly.instantiateStreaming(fetch(url), {
+  env: {log_bool}
+});

--- a/live-examples/wat-examples/memory/load.js
+++ b/live-examples/wat-examples/memory/load.js
@@ -5,9 +5,10 @@ await WebAssembly.instantiateStreaming(fetch(url)).then(
     const memory = result.instance.exports.memory;
 
     var dataView = new DataView(memory.buffer);
-    // store 30 at the beginning of memory
+    // Store 30 at the beginning of memory
     dataView.setUint32(0, 30, true);
 
     console.log(load_first_item_in_mem(100));
+    // Expected output: 30
   }
 );

--- a/live-examples/wat-examples/memory/store.js
+++ b/live-examples/wat-examples/memory/store.js
@@ -10,5 +10,6 @@ await WebAssembly.instantiateStreaming(fetch(url)).then(
     var first_number_in_mem = dataView.getUint32(0, true);
 
     console.log(first_number_in_mem);
+    // Expected output: 100
   }
 );

--- a/live-examples/wat-examples/numeric/and.js
+++ b/live-examples/wat-examples/numeric/and.js
@@ -5,6 +5,7 @@ await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
 
     let res = and(0b10000010, 0b01101111)
     console.log(numToBin(res));
+    // Expected output: "00000010"
   }
 );
 

--- a/live-examples/wat-examples/numeric/clz.js
+++ b/live-examples/wat-examples/numeric/clz.js
@@ -4,5 +4,6 @@ await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
     const leading0 = result.instance.exports.leading0;
 
     console.log("Leading zeros: " + leading0(0b00000000_10000000_00000000_00000000));
+    // Expected output: "Leading zeros: 8"
   }
 );

--- a/live-examples/wat-examples/numeric/ctz.js
+++ b/live-examples/wat-examples/numeric/ctz.js
@@ -3,6 +3,7 @@ await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
   (result) => {
     const trailing0 = result.instance.exports.trailing0;
 
-    console.log("Ttrailing zeros: " + trailing0(0b00000000_10000000_00000000_00000000));
+    console.log("Trailing zeros: " + trailing0(0b00000000_10000000_00000000_00000000));
+    // Expected output: "Trailing zeros: 23"
   }
 );

--- a/live-examples/wat-examples/numeric/meta.json
+++ b/live-examples/wat-examples/numeric/meta.json
@@ -9,42 +9,42 @@
         },
         "eq": {
             "watExampleCode": "./live-examples/wat-examples/numeric/eq.wat",
-            "jsExampleCode": "./live-examples/wat-examples/log_bool.js",
+            "jsExampleCode": "./live-examples/wat-examples/log_bool_false.js",
             "fileName": "eq.html",
             "title": "Wat Demo: eq",
             "type": "wat"
         },
         "ne": {
             "watExampleCode": "./live-examples/wat-examples/numeric/ne.wat",
-            "jsExampleCode": "./live-examples/wat-examples/log_bool.js",
+            "jsExampleCode": "./live-examples/wat-examples/log_bool_true.js",
             "fileName": "ne.html",
             "title": "Wat Demo: ne",
             "type": "wat"
         },
         "gt": {
             "watExampleCode": "./live-examples/wat-examples/numeric/gt.wat",
-            "jsExampleCode": "./live-examples/wat-examples/log_bool.js",
+            "jsExampleCode": "./live-examples/wat-examples/log_bool_true.js",
             "fileName": "gt.html",
             "title": "Wat Demo: gt",
             "type": "wat"
         },
         "lt": {
             "watExampleCode": "./live-examples/wat-examples/numeric/lt.wat",
-            "jsExampleCode": "./live-examples/wat-examples/log_bool.js",
+            "jsExampleCode": "./live-examples/wat-examples/log_bool_false.js",
             "fileName": "lt.html",
             "title": "Wat Demo: lt",
             "type": "wat"
         },
         "ge": {
             "watExampleCode": "./live-examples/wat-examples/numeric/ge.wat",
-            "jsExampleCode": "./live-examples/wat-examples/log_bool.js",
+            "jsExampleCode": "./live-examples/wat-examples/log_bool_true.js",
             "fileName": "ge.html",
             "title": "Wat Demo: ge",
             "type": "wat"
         },
         "le": {
             "watExampleCode": "./live-examples/wat-examples/numeric/le.wat",
-            "jsExampleCode": "./live-examples/wat-examples/log_bool.js",
+            "jsExampleCode": "./live-examples/wat-examples/log_bool_false.js",
             "fileName": "le.html",
             "title": "Wat Demo: le",
             "type": "wat"

--- a/live-examples/wat-examples/numeric/or.js
+++ b/live-examples/wat-examples/numeric/or.js
@@ -5,6 +5,7 @@ await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
 
     let res = or(0b10000010, 0b01101111)
     console.log(numToBin(res));
+    // Expected output: "11101111"
   }
 );
 

--- a/live-examples/wat-examples/numeric/popcnt.js
+++ b/live-examples/wat-examples/numeric/popcnt.js
@@ -4,5 +4,6 @@ await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
     const count1s = result.instance.exports.count1s;
 
     console.log(count1s(0b10000010));
+    // Expected output: 2
   }
 );

--- a/live-examples/wat-examples/numeric/rotl.js
+++ b/live-examples/wat-examples/numeric/rotl.js
@@ -5,6 +5,7 @@ await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
 
     let res = rotate_left(0b11100000_00000000_00000000_00000000, 1);
     console.log(numToBin(res));
+    // Expected output: "11000000_00000000_00000000_00000001"
   }
 );
 

--- a/live-examples/wat-examples/numeric/rotr.js
+++ b/live-examples/wat-examples/numeric/rotr.js
@@ -5,6 +5,7 @@ await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
 
     let res = rotate_right(0b00000000_00000000_00000000_00000111, 1);
     console.log(numToBin(res));
+    // Expected output: "10000000_00000000_00000000_00000011"
   }
 );
 

--- a/live-examples/wat-examples/numeric/shl.js
+++ b/live-examples/wat-examples/numeric/shl.js
@@ -5,6 +5,7 @@ await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
 
     let res = shift_left(0b11100000_00000000_00000000_00000000, 1);
     console.log(numToBin(res));
+    // Expected output: "11000000_00000000_00000000_00000000"
   }
 );
 

--- a/live-examples/wat-examples/numeric/shr.js
+++ b/live-examples/wat-examples/numeric/shr.js
@@ -5,6 +5,7 @@ await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
 
     let res = shift_right(0b00000000_00000000_00000000_00000111, 1);
     console.log(numToBin(res));
+    // Expected output: "00000000_00000000_00000000_00000011"
   }
 );
 

--- a/live-examples/wat-examples/numeric/xor.js
+++ b/live-examples/wat-examples/numeric/xor.js
@@ -5,6 +5,7 @@ await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
 
     let res = xor(0b10000010, 0b01101111)
     console.log(numToBin(res));
+    // Expected output: "11101101"
   }
 );
 

--- a/live-examples/wat-examples/statements/block.js
+++ b/live-examples/wat-examples/statements/block.js
@@ -3,8 +3,11 @@ await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
   (result) => {
     const log_if_not_100 = result.instance.exports.log_if_not_100;
 
-    log_if_not_100(99); // should log 99
-    log_if_not_100(100); // should not log anything
-    log_if_not_100(101); // should log 101
+    log_if_not_100(99);
+    // Expected output: 99
+    log_if_not_100(100);
+    // Should not log anything
+    log_if_not_100(101);
+    // Expected output: 101
   }
 );

--- a/live-examples/wat-examples/statements/call.js
+++ b/live-examples/wat-examples/statements/call.js
@@ -5,6 +5,7 @@ await WebAssembly.instantiateStreaming(
     env: {
       greet: function() {
         console.log("Hello");
+        // Expected output: "Hello"
       }
     }
   }

--- a/live-examples/wat-examples/statements/return.js
+++ b/live-examples/wat-examples/statements/return.js
@@ -4,4 +4,5 @@ await WebAssembly.instantiateStreaming(
 ).then(result => {
   const { get_90 } = result.instance.exports;
   console.log(get_90());
+  // Expected output: 90
 });

--- a/live-examples/wat-examples/statements/select.js
+++ b/live-examples/wat-examples/statements/select.js
@@ -5,9 +5,12 @@ await WebAssembly.instantiateStreaming(
   const { select_simple, select_externref } = result.instance.exports;
 
   console.log(select_simple());
+  // Expected output: 20
 
-  // if the second parameter is zero, returns the first paramater (which may be an arbitrary JS value)
+  // If the second parameter is zero, returns the first paramater (which may be an arbitrary JS value)
   const map = new Map();
-  console.log(select_externref(map, 0)); // logs Map {}
-  console.log(select_externref(map, -1)); // logs null
+  console.log(select_externref(map, 0));
+  // Expected output: [object Map]
+  console.log(select_externref(map, -1));
+  // Expected output: null
 });

--- a/live-examples/wat-examples/statements/unreachable.js
+++ b/live-examples/wat-examples/statements/unreachable.js
@@ -3,4 +3,5 @@ await WebAssembly.instantiateStreaming(
   fetch(url)
 ).then(result => {
   result.instance.exports.throw();
+  // Expected output: RuntimeError: unreachable
 });


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

This PR adds `Expected output` comments to JS files which produce a console log. I didn't add any comments to WAT files, in which comment `log the result` is usually written.
I have also changed some JS comments to upper case and fixed a typo.
