### PR TITLE
Improve `abbr` example

### DIFF
--- a/live-examples/html-examples/inline-text-semantics/css/abbr.css
+++ b/live-examples/html-examples/inline-text-semantics/css/abbr.css
@@ -1,8 +1,4 @@
-p {
-    font-size: 1.3rem;
-}
-
 abbr {
     font-style: italic;
-    font-weight: 100;
+    color: chocolate;
 }


### PR DESCRIPTION
This PR slightly changes CSS in [abbr](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr) example, to remove the scrollbar and make the text more legible.

**BEFORE:**
![image](https://user-images.githubusercontent.com/100634371/212543386-cc27677d-31d8-412a-b026-85eef31ee3e4.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/100634371/212543411-1ac6a2f3-15f0-4018-bfef-f94ca18c6605.png)
