### PR TITLE
Fix: name attribute value fix for first name and last name

### DIFF
--- a/live-examples/html-examples/form-attributes/attribute-autocomplete.html
+++ b/live-examples/html-examples/form-attributes/attribute-autocomplete.html
@@ -1,8 +1,8 @@
-<label for="firstName">First Name:</label>
-<input name="firstName" type="text" autocomplete="given-name">
+<label for="firstname">First Name:</label>
+<input name="firstname" type="text" autocomplete="given-name">
 
-<label for="lastName">Last Name:</label>
-<input name="lastName" type="text" autocomplete="family-name">
+<label for="lastname">Last Name:</label>
+<input name="lastname" type="text" autocomplete="family-name">
 
 <label for="email">Email:</label>
 <input name="email" type="email" autocomplete="off">


### PR DESCRIPTION
First Name , Last Name 'name' attribute value previously in camel-case order due to this it was not working properly and not suggesting us a first name, same bug also  for last name so i have changed it to lower case and now it working as an expected.

<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

First Name and Last name autocomplete feature not working properly due to the wrong value assigned to the name attribute.





### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

It will fix the autocomplete example and suggest a first name and last name.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fix #2416 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
