### PR TITLE
ci(deps): bump aws-actions/configure-aws-credentials from v1 to v1-node16

### DIFF
--- a/.github/workflows/stage-deploy.yml
+++ b/.github/workflows/stage-deploy.yml
@@ -32,7 +32,7 @@ jobs:
         run: yarn build
 
       - name: Configure AWS credentials for stage
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.STAGE_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.STAGE_AWS_ACCESS_KEY_SECRET }}


### PR DESCRIPTION
### Description

Migrates the `aws-actions/configure-aws-credentials` to use Node.js 16.

### Motivation

Avoids this warning: `Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: aws-actions/configure-aws-credentials@v1.`

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

See: https://github.com/mdn/interactive-examples/pull/2388#pullrequestreview-1287547473
