### PR TITLE
fix(ci): skip deploy/release on dependabot merges

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.triggering_actor != 'dependabot[bot]'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,12 +7,14 @@ on:
 
 jobs:
   publish-release:
+    if: github.triggering_actor != 'dependabot[bot]'
     uses: mdn/workflows/.github/workflows/publish-release.yml@main
     with:
       npm-publish: ${{ false }}
       target-repo: 'mdn/interactive-examples'
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
   deploy:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/stage-deploy.yml
+++ b/.github/workflows/stage-deploy.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.triggering_actor != 'dependabot[bot]'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Avoids failing `prod-deploy`, `stage-deploy` and `publish-release` workflow runs, if they are triggered by a Dependabot merge (which run without permissions).

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

See:
<img width="1236" alt="image" src="https://user-images.githubusercontent.com/495429/217945517-2562b030-35ca-4c64-a3bc-6c3d0ccd0a08.png">


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
