### PR TITLE
chore(deps-dev): switch from mdn-bob to @mdn/bob

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "devDependencies": {
         "@babel/core": "^7.20.12",
         "@babel/eslint-parser": "^7.19.1",
+        "@mdn/bob": "^2.2.0",
         "chokidar-cli": "^3.0.0",
         "eslint": "^8.33.0",
         "http-server": "^14.1.1",
-        "mdn-bob": "^2.2.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.8.4",
         "prettier-eslint": "^15.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,6 +282,21 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@mdn/bob@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@mdn/bob/-/bob-2.2.0.tgz#8c34e1789567b5e0911b31f4881dff119ce46059"
+  integrity sha512-owatrwlwqrcRuip0roTBEIx3MTg+/tAcUn71VoOLKoN1HcY9bcEa8kYDDDR4YQQdKzUKNPxs6e5FtnqJHdbDMg==
+  dependencies:
+    browserify "17.0.0"
+    clean-css "5.3.0"
+    codemirror "5.65.3"
+    cosmiconfig "7.0.1"
+    fs-extra "10.1.0"
+    glob "8.0.1"
+    node-dir "0.1.17"
+    uglify-es "3.3.9"
+    wabt "^1.0.23"
+
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
   resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz#dbf733a965ca47b1973177dc0bb6c889edcfb129"
@@ -2250,21 +2265,6 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
-
-mdn-bob@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/mdn-bob/-/mdn-bob-2.2.0.tgz#471acd2c8bec6432ea81a1bceac0428b21e20d38"
-  integrity sha512-oAkq8GGGgciLB8jpvHgN1LC4As6sY1wsjdmzX13sK22XC+6qvGGLTiFusAl5MVqs93W4NBTxqpYm+tBwu9Hbaw==
-  dependencies:
-    browserify "17.0.0"
-    clean-css "5.3.0"
-    codemirror "5.65.3"
-    cosmiconfig "7.0.1"
-    fs-extra "10.1.0"
-    glob "8.0.1"
-    node-dir "0.1.17"
-    uglify-es "3.3.9"
-    wabt "^1.0.23"
 
 memorystream@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
### Description

Replaces `mdn-bob` with the exact same version of `@mdn/bob`.

Fixes https://github.com/mdn/interactive-examples/issues/2423.

### Motivation

We finally "moved" bob into the `@mdn` namespace, and will publish further releases as `@mdn/bob` only.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

See: https://github.com/mdn/bob/pull/1073
