### PR TITLE
feat(css): Add example of `scrollbar-gutter`

### DIFF
--- a/live-examples/css-examples/scrollbars/meta.json
+++ b/live-examples/css-examples/scrollbars/meta.json
@@ -1,18 +1,26 @@
 {
   "pages": {
-      "scrollbarColor": {
-          "cssExampleSrc": "./live-examples/css-examples/scrollbars/scrollbar-common.css",
-          "exampleCode": "./live-examples/css-examples/scrollbars/scrollbar-color.html",
-          "fileName": "scrollbar-color.html",
-          "title": "CSS Demo: scrollbar-color",
-          "type": "css"
-      },
-      "scrollbarWidth": {
-        "cssExampleSrc": "./live-examples/css-examples/scrollbars/scrollbar-common.css",
-        "exampleCode": "./live-examples/css-examples/scrollbars/scrollbar-width.html",
-        "fileName": "scrollbar-width.html",
-        "title": "CSS Demo: scrollbar-width",
-        "type": "css"
-    }
+	"scrollbarColor": {
+	  "cssExampleSrc": "./live-examples/css-examples/scrollbars/scrollbar-common.css",
+	  "exampleCode": "./live-examples/css-examples/scrollbars/scrollbar-color.html",
+	  "fileName": "scrollbar-color.html",
+	  "title": "CSS Demo: scrollbar-color",
+	  "type": "css"
+	},
+	"scrollbarGutter": {
+	  "cssExampleSrc": "./live-examples/css-examples/scrollbars/scrollbar-gutter.css",
+	  "exampleCode": "./live-examples/css-examples/scrollbars/scrollbar-gutter.html",
+	  "jsExampleSrc": "./live-examples/css-examples/scrollbars/scrollbar-gutter.js",
+	  "fileName": "scrollbar-gutter.html",
+	  "title": "CSS Demo: scrollbar-gutter",
+	  "type": "css"
+	},
+	"scrollbarWidth": {
+	  "cssExampleSrc": "./live-examples/css-examples/scrollbars/scrollbar-common.css",
+	  "exampleCode": "./live-examples/css-examples/scrollbars/scrollbar-width.html",
+	  "fileName": "scrollbar-width.html",
+	  "title": "CSS Demo: scrollbar-width",
+	  "type": "css"
+	}
   }
 }

--- a/live-examples/css-examples/scrollbars/scrollbar-gutter.css
+++ b/live-examples/css-examples/scrollbars/scrollbar-gutter.css
@@ -1,0 +1,21 @@
+#default-example {
+    flex-direction: column;
+}
+
+#example-element {
+    width: 15em;
+    margin-bottom: auto;
+    border: medium dotted;
+    padding: 0.2em;
+    text-align: left;
+    overflow: auto;
+    word-break: break-all;
+}
+
+.heightNormal {
+    height: 12em;
+}
+
+.heightShort {
+    height: 8em;
+}

--- a/live-examples/css-examples/scrollbars/scrollbar-gutter.html
+++ b/live-examples/css-examples/scrollbars/scrollbar-gutter.html
@@ -1,0 +1,31 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="scrollbar-gutter">
+
+    <div class="example-choice">
+        <pre><code class="language-css">scrollbar-gutter: auto;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">scrollbar-gutter: stable;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">scrollbar-gutter: stable both-edges;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <button id="control-height" class="control">Change Height</button>
+        <p id="example-element" class="heightNormal">Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather. As much mud in the streets as if the waters had but newly retired from the face of the earth.</p>
+    </section>
+</div>

--- a/live-examples/css-examples/scrollbars/scrollbar-gutter.js
+++ b/live-examples/css-examples/scrollbars/scrollbar-gutter.js
@@ -1,0 +1,17 @@
+'use strict';
+
+window.addEventListener('load', () => {
+    const btnControlHeight = document.getElementById('control-height');
+    const exampleElement = document.getElementById('example-element');
+
+    btnControlHeight.addEventListener('click', () => {
+        const classList = exampleElement.classList;
+        if(classList.contains("heightNormal")) {
+            classList.remove("heightNormal");
+            classList.add("heightShort");
+        } else {
+            classList.remove("heightShort");
+            classList.add("heightNormal");
+        }
+    });
+});


### PR DESCRIPTION
This is an interactive example of [scrollbar-gutter](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter).

![image](https://user-images.githubusercontent.com/100634371/218108421-1e56c74f-e866-4af7-8010-163488203d61.png)
