### PR TITLE
fix(ci): run main workflow with NodeJS 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: 18
           cache: 'yarn'
 
       - name: Install all yarn packages


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the main workflow to run with NodeJS v18.

Fixes https://github.com/mdn/interactive-examples/issues/2428.

### Motivation

In https://github.com/mdn/interactive-examples/pull/2425 we bumped NodeJS from v16 to v18, but accidentally omitted one workflow.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
