### PR TITLE
Add resizable ArrayBuffer examples

### DIFF
--- a/live-examples/js-examples/arraybuffer/arraybuffer-maxbytelength.js
+++ b/live-examples/js-examples/arraybuffer/arraybuffer-maxbytelength.js
@@ -1,0 +1,8 @@
+// Create an ArrayBuffer with a size and max length in bytes
+const buffer = new ArrayBuffer(8, { maxByteLength: 16 } );
+
+console.log(buffer.byteLength);
+// Expected output: 8
+
+console.log(buffer.maxByteLength);
+// Expected output: 16

--- a/live-examples/js-examples/arraybuffer/arraybuffer-maxbytelength.js
+++ b/live-examples/js-examples/arraybuffer/arraybuffer-maxbytelength.js
@@ -1,4 +1,3 @@
-// Create an ArrayBuffer with a size and max length in bytes
 const buffer = new ArrayBuffer(8, { maxByteLength: 16 } );
 
 console.log(buffer.byteLength);

--- a/live-examples/js-examples/arraybuffer/arraybuffer-resizable.js
+++ b/live-examples/js-examples/arraybuffer/arraybuffer-resizable.js
@@ -1,4 +1,3 @@
-// Create two ArrayBuffers, one with a max byte length, and one without
 const buffer1 = new ArrayBuffer(8, { maxByteLength: 16 } );
 const buffer2 = new ArrayBuffer(8);
 

--- a/live-examples/js-examples/arraybuffer/arraybuffer-resizable.js
+++ b/live-examples/js-examples/arraybuffer/arraybuffer-resizable.js
@@ -1,0 +1,9 @@
+// Create two ArrayBuffers, one with a max byte length, and one without
+const buffer1 = new ArrayBuffer(8, { maxByteLength: 16 } );
+const buffer2 = new ArrayBuffer(8);
+
+console.log(buffer1.resizable);
+// Expected output: true
+
+console.log(buffer2.resizable);
+// Expected output: false

--- a/live-examples/js-examples/arraybuffer/arraybuffer-resize.js
+++ b/live-examples/js-examples/arraybuffer/arraybuffer-resize.js
@@ -1,0 +1,10 @@
+// Create an ArrayBuffer with a size and max length in bytes
+const buffer = new ArrayBuffer(8, { maxByteLength: 16 } );
+
+console.log(buffer.byteLength);
+// Expected output: 8
+
+buffer.resize(12);
+
+console.log(buffer.byteLength);
+// Expected output: 12

--- a/live-examples/js-examples/arraybuffer/arraybuffer-resize.js
+++ b/live-examples/js-examples/arraybuffer/arraybuffer-resize.js
@@ -1,4 +1,3 @@
-// Create an ArrayBuffer with a size and max length in bytes
 const buffer = new ArrayBuffer(8, { maxByteLength: 16 } );
 
 console.log(buffer.byteLength);

--- a/live-examples/js-examples/arraybuffer/meta.json
+++ b/live-examples/js-examples/arraybuffer/meta.json
@@ -18,6 +18,24 @@
             "title": "JavaScript Demo: ArrayBuffer.isView()",
             "type": "js"
         },
+        "arraybufferMaxByteLength": {
+            "exampleCode": "./live-examples/js-examples/arraybuffer/arraybuffer-maxbytelength.js",
+            "fileName": "arraybuffer-maxbytelength.html",
+            "title": "JavaScript Demo: ArrayBuffer.maxByteLength",
+            "type": "js"
+        },
+        "arraybufferResizable": {
+            "exampleCode": "./live-examples/js-examples/arraybuffer/arraybuffer-resizable.js",
+            "fileName": "arraybuffer-resizable.html",
+            "title": "JavaScript Demo: ArrayBuffer.resizable",
+            "type": "js"
+        },
+        "arraybufferResize": {
+            "exampleCode": "./live-examples/js-examples/arraybuffer/arraybuffer-resize.js",
+            "fileName": "arraybuffer-resize.html",
+            "title": "JavaScript Demo: ArrayBuffer.resize()",
+            "type": "js"
+        },
         "arraybufferSlice": {
             "exampleCode": "./live-examples/js-examples/arraybuffer/arraybuffer-slice.js",
             "fileName": "arraybuffer-slice.html",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

This PR adds interactive examples for the new features related to the [Resizable ArrayBuffer and growable SharedArrayBuffer](https://tc39.es/proposal-resizablearraybuffer/) Stage 3 draft, which was implemented in Chrome 111+.

Note that this just includes the new features related to [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/ArrayBuffer), not [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer). I didn't add examples for those, as SAB is only available in cross-origin isolated browsing contexts. In the SAB pages that currently do have interactive examples (for example [`SharedArrayBuffer.slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice)), the examples don't run successfully because of this, and I am concerned that it makes the pages look broken.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes mdn/interactive-examples#123" -->
<!-- 👉 Highlight related pull requests using "Relates to mdn/interactive-examples#123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** mdn/interactive-examples#123" -->
