### PR TITLE
Update ESLint ECMA version

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
     "env": {
         "browser": true,
-        "es6": true,
+        "es2022": true,
         "node": true
     },
     "extends": "eslint:recommended",
@@ -60,13 +60,6 @@
         "semi": ["error", "always"],
         "space-before-function-paren": ["error", "never"],
         "space-infix-ops": "error"
-    },
-    "globals": {
-        "SharedArrayBuffer": true,
-        "Atomics": true,
-        "BigInt": true,
-        "getShadowRoot": true,
-        "globalThis": true // will be supported in eslint 7.0
     },
     "overrides": [
         {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

I have changed the ECMAScript version against which ESLint is performing an analysis, so we remove the `globals` property and skip updating it whenever we wish to use some of the new features. Unfortunately, there is no `ESNext` value that we can use, so whenever a new ES version comes up and we get the error `NEW_FEATURE is not defined`, we need to update `env` again.

This also makes it easier to merge #2411 and other Typed Array examples, because we don't need to add `BigInt64Array` and other types to `globals`.
