### PR TITLE
Remove `lang` from scientific names

### DIFF
--- a/live-examples/html-examples/inline-text-semantics/i.html
+++ b/live-examples/html-examples/inline-text-semantics/i.html
@@ -1,5 +1,5 @@
 <p>I looked at it and thought <i>This can't be real!</i></p>
 
-<p><i lang="la">Musa</i> is one of two or three genera in the family <i lang="la">Musaceae</i>; it includes bananas and plantains.</p>
+<p><i>Musa</i> is one of two or three genera in the family <i>Musaceae</i>; it includes bananas and plantains.</p>
 
 <p>The term <i>bandwidth</i> describes the measure of how much information can pass through a data connection in a given amount of time.</p>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description
Removes `lang="la"` attribute from words `Musa` and `Musaceae`, as those are scientific names and shouldn't be marked as Latin.

Fixes #2440

<!-- ✍️ Summarize your changes in one or two sentences -->
