### PR TITLE
bdi سما rather than تیز سمی

### DIFF
--- a/live-examples/html-examples/inline-text-semantics/bdi.html
+++ b/live-examples/html-examples/inline-text-semantics/bdi.html
@@ -3,7 +3,7 @@
 <ul>
    <li><bdi class="name">Evil Steven</bdi>: 1st place</li>
    <li><bdi class="name">François fatale</bdi>: 2nd place</li>
-   <li><span class="name">تیز سمی</span>: 3rd place</li>
+   <li><span class="name">سما</span>: 3rd place</li>
    <li><bdi class="name">الرجل القوي إيان</bdi>: 4th place</li>
-   <li><span class="name" dir="auto">تیز سمی</span>: 5th place</li>
+   <li><span class="name" dir="auto">سما</span>: 5th place</li>
 </ul>


### PR DESCRIPTION
Fixes https://github.com/mdn/interactive-examples/issues/2438

The issue is that تیز سمی in Egyptian Arabic apparently means "Sama's ass", and the suggestion was to replace it with سما.

I was unable to verify the problem - searching on the word in English, and google translate seem to indicate it means "strong poison". However it is quite possible this is idiomatic, or Google is getting it wrong.

I have changed the instances to the suggested values because Google translate says that this term means "Heaven".