### PR TITLE
feat(css): Add `-webkit-text-stroke-*` CSS examples

### DIFF
--- a/live-examples/css-examples/text-color/meta.json
+++ b/live-examples/css-examples/text-color/meta.json
@@ -1,0 +1,25 @@
+{
+    "pages": {
+        "textStroke": {
+            "cssExampleSrc": "./live-examples/css-examples/text-color/text-stroke.css",
+            "exampleCode": "./live-examples/css-examples/text-color/text-stroke.html",
+            "fileName": "text-stroke.html",
+            "title": "CSS Demo: -webkit-text-stroke",
+            "type": "css"
+        },
+        "textStrokeColor": {
+            "cssExampleSrc": "./live-examples/css-examples/text-color/text-stroke.css",
+            "exampleCode": "./live-examples/css-examples/text-color/text-stroke-color.html",
+            "fileName": "text-stroke-color.html",
+            "title": "CSS Demo: -webkit-text-stroke-color",
+            "type": "css"
+        },
+        "textStrokeWidth": {
+            "cssExampleSrc": "./live-examples/css-examples/text-color/text-stroke.css",
+            "exampleCode": "./live-examples/css-examples/text-color/text-stroke-width.html",
+            "fileName": "text-stroke-width.html",
+            "title": "CSS Demo: -webkit-text-stroke-width",
+            "type": "css"
+        }
+    }
+}

--- a/live-examples/css-examples/text-color/text-stroke-color.html
+++ b/live-examples/css-examples/text-color/text-stroke-color.html
@@ -1,0 +1,29 @@
+<section id="example-choice-list" class="example-choice-list" data-property="-webkit-text-stroke-color">
+	<div class="example-choice">
+		<pre><code class="language-css">-webkit-text-stroke-color: blueviolet;</code></pre>
+		<button type="button" class="copy hidden" aria-hidden="true">
+			<span class="visually-hidden">Copy to Clipboard</span>
+		</button>
+	</div>
+
+	<div class="example-choice">
+		<pre><code class="language-css">-webkit-text-stroke-color: rgb(108 169 199);</code></pre>
+		<button type="button" class="copy hidden" aria-hidden="true">
+			<span class="visually-hidden">Copy to Clipboard</span>
+		</button>
+	</div>
+
+	<div class="example-choice">
+		<pre><code class="language-css">-webkit-text-stroke-color: hsl(343deg 100% 50% / 30%);</code></pre>
+		<button type="button" class="copy hidden" aria-hidden="true">
+			<span class="visually-hidden">Copy to Clipboard</span>
+		</button>
+	</div>
+
+</section>
+
+<div id="output" class="output hidden">
+	<section id="default-example">
+		<p id="example-element" class="stroke-width">Hyperbolic</p>
+	</section>
+</div>

--- a/live-examples/css-examples/text-color/text-stroke-width.html
+++ b/live-examples/css-examples/text-color/text-stroke-width.html
@@ -1,0 +1,29 @@
+<section id="example-choice-list" class="example-choice-list" data-property="-webkit-text-stroke-width">
+	<div class="example-choice">
+		<pre><code class="language-css">-webkit-text-stroke-width: 1px;</code></pre>
+		<button type="button" class="copy hidden" aria-hidden="true">
+			<span class="visually-hidden">Copy to Clipboard</span>
+		</button>
+	</div>
+
+	<div class="example-choice">
+		<pre><code class="language-css">-webkit-text-stroke-width: medium;</code></pre>
+		<button type="button" class="copy hidden" aria-hidden="true">
+			<span class="visually-hidden">Copy to Clipboard</span>
+		</button>
+	</div>
+
+	<div class="example-choice">
+		<pre><code class="language-css">-webkit-text-stroke-width: thick;</code></pre>
+		<button type="button" class="copy hidden" aria-hidden="true">
+			<span class="visually-hidden">Copy to Clipboard</span>
+		</button>
+	</div>
+
+</section>
+
+<div id="output" class="output hidden">
+	<section id="default-example">
+		<p id="example-element" class="stroke-color">Hyperbolic</p>
+	</section>
+</div>

--- a/live-examples/css-examples/text-color/text-stroke.css
+++ b/live-examples/css-examples/text-color/text-stroke.css
@@ -1,0 +1,13 @@
+#example-element {
+    font-size: 3rem;
+    font-weight: bold;
+    color: bisque;
+}
+
+.stroke-width {
+    -webkit-text-stroke-width: 2px;
+}
+
+.stroke-color {
+    -webkit-text-stroke-color: violet;
+}

--- a/live-examples/css-examples/text-color/text-stroke.html
+++ b/live-examples/css-examples/text-color/text-stroke.html
@@ -1,0 +1,29 @@
+<section id="example-choice-list" class="example-choice-list" data-property="-webkit-text-stroke">
+	<div class="example-choice">
+		<pre><code class="language-css">-webkit-text-stroke: tomato 1px;</code></pre>
+		<button type="button" class="copy hidden" aria-hidden="true">
+			<span class="visually-hidden">Copy to Clipboard</span>
+		</button>
+	</div>
+
+	<div class="example-choice">
+		<pre><code class="language-css">-webkit-text-stroke: rgb(118 108 199) medium;</code></pre>
+		<button type="button" class="copy hidden" aria-hidden="true">
+			<span class="visually-hidden">Copy to Clipboard</span>
+		</button>
+	</div>
+
+	<div class="example-choice">
+		<pre><code class="language-css">-webkit-text-stroke: hsl(341deg 100% 50% / 30%) thick;</code></pre>
+		<button type="button" class="copy hidden" aria-hidden="true">
+			<span class="visually-hidden">Copy to Clipboard</span>
+		</button>
+	</div>
+
+</section>
+
+<div id="output" class="output hidden">
+	<section id="default-example">
+		<p id="example-element">Hyperbolic</p>
+	</section>
+</div>


### PR DESCRIPTION
This PR adds examples of [-webkit-text-stroke](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-text-stroke), [-webkit-text-stroke-width](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-text-stroke-width) and [-webkit-text-stroke-color](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-text-stroke-color).

![image](https://user-images.githubusercontent.com/100634371/220976417-fa6a471d-651f-480a-b413-101f7af83005.png)
![image](https://user-images.githubusercontent.com/100634371/220976468-2ac9d747-c75d-4bbc-a324-54854ea43c4b.png)
![image](https://user-images.githubusercontent.com/100634371/220976650-bbc252c5-34fe-43da-8e23-30c37b5d2bcc.png)

I added a directory `text-color`, because [-webkit-text-fill-color](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-text-fill-color) and [-webkit-tap-highlight-color](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-tap-highlight-color) could be added there too.