### PR TITLE
fix(css): Improve `appearance` example

### DIFF
--- a/live-examples/css-examples/basic-user-interface/appearance.css
+++ b/live-examples/css-examples/basic-user-interface/appearance.css
@@ -1,0 +1,8 @@
+.background {
+    display: flex;
+    place-content: center;
+    place-items: center;
+    width: 150px;
+    height: 150px;
+    background-color: white;
+}

--- a/live-examples/css-examples/basic-user-interface/appearance.html
+++ b/live-examples/css-examples/basic-user-interface/appearance.html
@@ -1,15 +1,13 @@
 <section id="example-choice-list" class="example-choice-list" data-property="appearance">
   <div class="example-choice">
-    <pre><code class="language-css">
-        appearance: none;</code></pre>
+    <pre><code class="language-css">appearance: none;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">
-        appearance: auto;</code></pre>
+    <pre><code class="language-css">appearance: auto;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
@@ -18,6 +16,8 @@
 
 <div id="output" class="output hidden large">
   <section id="default-example">
-    <button id="example-element">button</button>
+    <div class="background">
+      <button id="example-element">button</button>
+    </div>
   </section>
 </div>

--- a/live-examples/css-examples/basic-user-interface/meta.json
+++ b/live-examples/css-examples/basic-user-interface/meta.json
@@ -8,6 +8,7 @@
             "type": "css"
         },
         "appearance": {
+            "cssExampleSrc": "./live-examples/css-examples/basic-user-interface/appearance.css",
             "exampleCode": "./live-examples/css-examples/basic-user-interface/appearance.html",
             "fileName": "appearance.html",
             "title": "CSS Demo: appearance",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description
Those are 2 minor changes to the [appearance](https://developer.mozilla.org/en-US/docs/Web/CSS/appearance) example:
- whitespace is removed choice buttons
- white background is now surrounding the presented button, so the effect is more visible in dark theme

Before:
![image](https://user-images.githubusercontent.com/100634371/221292390-66cc3578-ed8c-4414-bd68-278be7aa5537.png)

After:
![image](https://user-images.githubusercontent.com/100634371/221292716-8be7ce52-4eeb-4680-8310-64d91ce2722b.png)

