### PR TITLE
fix(css): Change `font-family` only when it's needed

### DIFF
--- a/live-examples/css-examples/fonts/font-optical-sizing.css
+++ b/live-examples/css-examples/fonts/font-optical-sizing.css
@@ -1,5 +1,3 @@
-@import 'fonts.css';
-
 @font-face {
     src: url('/media/fonts/AmstelvarAlpha-VF.ttf');
     font-family: Amstelvar;

--- a/live-examples/css-examples/fonts/font-size.css
+++ b/live-examples/css-examples/fonts/font-size.css
@@ -1,5 +1,0 @@
-@import 'fonts.css';
-
-#output section {
-    font-family: 'Fira Sans', sans-serif;
-}

--- a/live-examples/css-examples/fonts/font-variation-settings.css
+++ b/live-examples/css-examples/fonts/font-variation-settings.css
@@ -1,5 +1,3 @@
-@import 'fonts.css';
-
 @font-face {
     src: url('/media/fonts/AmstelvarAlpha-VF.ttf');
     font-family: Amstelvar;

--- a/live-examples/css-examples/fonts/font.css
+++ b/live-examples/css-examples/fonts/font.css
@@ -1,4 +1,16 @@
-@import 'fonts-base.css';
+@font-face {
+    font-family: 'Fira Sans';
+    src: local('FiraSans-Regular'), url('/media/fonts/FiraSans-Regular.woff2') format('woff2');
+    font-weight: normal;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'Fira Sans';
+    src: local('FiraSans-Italic'), url('../../../media/fonts/FiraSans-Italic.woff2') format('woff2');
+    font-weight: normal;
+    font-style: italic;
+}
 
 #output section {
     margin-top: 10px;

--- a/live-examples/css-examples/fonts/font.css
+++ b/live-examples/css-examples/fonts/font.css
@@ -7,7 +7,7 @@
 
 @font-face {
     font-family: 'Fira Sans';
-    src: local('FiraSans-Italic'), url('../../../media/fonts/FiraSans-Italic.woff2') format('woff2');
+    src: local('FiraSans-Italic'), url('/media/fonts/FiraSans-Italic.woff2') format('woff2');
     font-weight: normal;
     font-style: italic;
 }

--- a/live-examples/css-examples/fonts/font.html
+++ b/live-examples/css-examples/fonts/font.html
@@ -6,7 +6,7 @@
 </button>
 </div>
 
-<div class="example-choice" initial-choice="true">
+<div class="example-choice">
 <pre><code class="language-css">font: italic 1.2em "Fira Sans", serif;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/fonts/meta.json
+++ b/live-examples/css-examples/fonts/meta.json
@@ -43,7 +43,6 @@
             "type": "css"
         },
         "fontSize": {
-            "cssExampleSrc": "./live-examples/css-examples/fonts/font-size.css",
             "exampleCode": "./live-examples/css-examples/fonts/font-size.html",
             "fileName": "font-size.html",
             "title": "CSS Demo: font-size",

--- a/live-examples/css-examples/fonts/text-align.css
+++ b/live-examples/css-examples/fonts/text-align.css
@@ -1,7 +1,4 @@
-@import 'fonts.css';
-
 #output section {
-    font-family: 'Fira Sans', sans-serif;
     font-size: 1.5em;
 }
 

--- a/live-examples/css-examples/text/meta.json
+++ b/live-examples/css-examples/text/meta.json
@@ -57,14 +57,14 @@
             "type": "css"
         },
         "textAlign": {
-            "cssExampleSrc": "./live-examples/css-examples/fonts/fonts-base.css",
+            "cssExampleSrc": "./live-examples/css-examples/fonts/text-align.css",
             "exampleCode": "./live-examples/css-examples/text/text-align.html",
             "fileName": "text-align.html",
             "title": "CSS Demo: text-align",
             "type": "css"
         },
         "textAlignLast": {
-            "cssExampleSrc": "./live-examples/css-examples/fonts/fonts-base.css",
+            "cssExampleSrc": "./live-examples/css-examples/fonts/text-align.css",
             "exampleCode": "./live-examples/css-examples/text/text-align-last.html",
             "fileName": "text-align-last.html",
             "title": "CSS Demo: text-align-last",

--- a/live-examples/css-examples/text/text-indent.css
+++ b/live-examples/css-examples/text/text-indent.css
@@ -1,7 +1,4 @@
-@import '../fonts/fonts.css';
-
 #output section {
-    font-family: 'Fira Sans', sans-serif;
     font-size: 1.5em;
 }
 

--- a/live-examples/html-examples/content-sectioning/css/article.css
+++ b/live-examples/html-examples/content-sectioning/css/article.css
@@ -2,7 +2,6 @@
     margin: 0;
     padding: 0.3rem;
     background-color: #eee;
-    font: 1rem 'Fira Sans', sans-serif;
 }
 
 .forecast > h1,

--- a/live-examples/html-examples/content-sectioning/css/aside.css
+++ b/live-examples/html-examples/content-sectioning/css/aside.css
@@ -11,7 +11,3 @@ aside {
 aside > p {
     margin: 0.5rem;
 }
-
-p {
-    font-family: 'Fira Sans', sans-serif;
-}

--- a/live-examples/html-examples/forms/css/datalist.css
+++ b/live-examples/html-examples/forms/css/datalist.css
@@ -1,3 +1,4 @@
 label {
-    font-family: 'Fira Sans', sans-serif;
+    display: block;
+    margin-bottom: 10px;
 }

--- a/live-examples/html-examples/forms/css/optgroup.css
+++ b/live-examples/html-examples/forms/css/optgroup.css
@@ -1,3 +1,4 @@
 label {
-    font-family: 'Fira Sans', sans-serif;
+    display: block;
+    margin-bottom: 10px;
 }

--- a/live-examples/html-examples/inline-text-semantics/css/u.css
+++ b/live-examples/html-examples/inline-text-semantics/css/u.css
@@ -1,5 +1,5 @@
 p {
-    font: 1rem 'Fira Sans', sans-serif;
+    margin: 0;
 }
 
 u {

--- a/live-examples/html-examples/input/css/password.css
+++ b/live-examples/html-examples/input/css/password.css
@@ -1,6 +1,5 @@
 label {
     display: block;
-    font: 0.9rem 'Fira Sans', sans-serif;
 }
 
 input[type='submit'],


### PR DESCRIPTION
I have noticed that `@import` doesn't work in CSS examples(for a long time, not because of BOB version 3). It is sometimes used to get `@font-face` and change the default font of the example. I think it is better to change the default font, only when it matters to understand the presented feature, or in some cases when the example looks much better.

In this PR I have:
- Removed modification of `font-family` when it didn't bring any benefit, so the style of the examples is more consistent.
- In the few HTML examples where CSS tab would be empty, I have added some minor style addition.
- Replaced `@import` in CSS examples with `@font-face` that they were meant to import.
- I have also noticed that `fonts/meta.json` is in CRLF, so it was changed to `LF`, together with the removal of `font-size.css` which is no longer needed.
- In `font.html`, the `initial-choice` attribute was set twice.

I have kept `fonts.css` which is currently not used by anything because I plan to use it when `@import` is fixed.