### PR TITLE
build: 10x faster rebuild of pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
     "main": "index.js",
     "scripts": {
         "build": "mdn-bob",
+        "build:pages": "mdn-bob --skip-webpack",
         "fix:css": "npm run lint:css -- --fix",
         "fix:js": "eslint --fix ./live-examples/js-examples",
         "lint:css": "stylelint \"**/*.css\"",
         "lint:js": "eslint ./live-examples/js-examples",
         "start-server": "http-server -p 9090 ./docs",
-        "start-watch": "chokidar '**/{*.js,*.css,*.html,*.json}' -i 'package.json' -i 'docs/**' -i 'node_modules/**' -i 'js/editor-*.js' -c 'npm run build' --initial --silent",
+        "start-watch": "chokidar '**/{*.js,*.css,*.html,*.json}' -i 'package.json' -i 'docs/**' -i 'node_modules/**' -i 'js/editor-*.js' -c 'npm run build:pages' --initial --silent",
         "start": "npm-run-all --parallel start-watch start-server",
         "test": "npm run lint:js"
     },


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

This PR adds `build:pages` script, which builds only pages of the project, without running webpack. This makes `start-watch` script very responsive, as `build:pages` can refresh all examples in around 2 seconds.

