### PR TITLE
fix(css): Remove invalid CSS comment

### DIFF
--- a/live-examples/css-examples/lists/list-style-type.html
+++ b/live-examples/css-examples/lists/list-style-type.html
@@ -21,7 +21,7 @@
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">list-style-type: "\1F44D"; // thumbs up sign</code></pre>
+        <pre><code class="language-css">list-style-type: "\1F44D";</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
                 <span class="visually-hidden">Copy to Clipboard</span>
         </button>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Removes `// thumbs up sign` from `list-style-type`, because it makes the CSS invalid.

Before:
![image](https://user-images.githubusercontent.com/100634371/222798964-e87da9f8-439e-4685-97d5-aec11eb809d0.png)

After:
![image](https://user-images.githubusercontent.com/100634371/222798999-24923451-b780-443b-8bf6-70f9b321fb7d.png)

