### PR TITLE
feat(css): Add example of `overflow-clip-margin`

### DIFF
--- a/live-examples/css-examples/basic-box-model/meta.json
+++ b/live-examples/css-examples/basic-box-model/meta.json
@@ -155,6 +155,13 @@
             "title": "CSS Demo: overflow-block",
             "type": "css"
         },
+        "overflowClipMargin": {
+            "cssExampleSrc": "./live-examples/css-examples/basic-box-model/overflow-clip-margin.css",
+            "exampleCode": "./live-examples/css-examples/basic-box-model/overflow-clip-margin.html",
+            "fileName": "overflow-clip-margin.html",
+            "title": "CSS Demo: overflow-clip-margin",
+            "type": "css"
+        },
         "overflowInline": {
             "cssExampleSrc": "./live-examples/css-examples/basic-box-model/overflow.css",
             "exampleCode": "./live-examples/css-examples/basic-box-model/overflow-inline.html",

--- a/live-examples/css-examples/basic-box-model/overflow-clip-margin.css
+++ b/live-examples/css-examples/basic-box-model/overflow-clip-margin.css
@@ -1,0 +1,8 @@
+#example-element {
+    width: 15em;
+    height: 9em;
+    border: medium dotted;
+    padding: 0.75em;
+    text-align: left;
+    overflow: clip;
+}

--- a/live-examples/css-examples/basic-box-model/overflow-clip-margin.html
+++ b/live-examples/css-examples/basic-box-model/overflow-clip-margin.html
@@ -1,0 +1,37 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="overflow-clip-margin">
+
+    <div class="example-choice">
+        <pre><code class="language-css">overflow-clip-margin: 0px;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice" initial-choice="true">
+        <pre><code class="language-css">overflow-clip-margin: 20px;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">overflow-clip-margin: 2rem;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
+        <pre><code class="language-css">overflow-clip-margin: 4ch;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+</section>
+
+<div id="output" class="output large hidden">
+    <section id="default-example" class="default-example">
+        <p id="example-element">Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather. As much mud in the streets as if the waters had but newly retired from the face of the earth.</p>
+    </section>
+</div>


### PR DESCRIPTION
This PR adds an example of [overflow-clip-margin](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-clip-margin).

![image](https://user-images.githubusercontent.com/100634371/223565918-9e397408-390e-4abc-8048-ace70c724a89.png)
