### PR TITLE
Fix comment about variable scope

### DIFF
--- a/live-examples/wat-examples/statements/loop.wat
+++ b/live-examples/wat-examples/statements/loop.wat
@@ -3,7 +3,7 @@
   (import "console" "log" (func $log (param i32)))
 
   (func
-    ;; create a global variable and initialize it to 0
+    ;; create a local variable and initialize it to 0
     (local $i i32)
 
     (loop $my_loop


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description
The variable below the comment is a `local` variable and not a `global` variable. This patch fixes the comment.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
It is confusing that the comment says one thing but the code says a different thing.
<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

Syntax for Global variables is documented on https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Variables/Global

Syntax for Local variables is documented on https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Variables/Local
<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
