### PR TITLE
fix(css): Hide `box-shadow` declaration in `box-decoration-break`

### DIFF
--- a/live-examples/css-examples/fragmentation/box-decoration-break.css
+++ b/live-examples/css-examples/fragmentation/box-decoration-break.css
@@ -4,6 +4,7 @@
 
 #example-element {
     background: linear-gradient(to bottom right, #fffd55, #387d22);
+    box-shadow: 8px 8px 10px 0 #ff1492, -5px -5px 5px 0 #00f, 5px 5px 15px 0 #ff0;
     padding: 0 1em;
     border-radius: 16px;
     border-style: solid;

--- a/live-examples/css-examples/fragmentation/box-decoration-break.html
+++ b/live-examples/css-examples/fragmentation/box-decoration-break.html
@@ -1,8 +1,7 @@
 <section id="example-choice-list" class="example-choice-list" data-property="box-decoration-break -webkit-box-decoration-break">
 <div class="example-choice">
 <pre><code class="language-css">box-decoration-break: slice;
--webkit-box-decoration-break: slice;
-box-shadow: 8px 8px 10px 0 #ff1493, -5px -5px 5px 0 #00f, 5px 5px 15px 0 #ff0;</code></pre>
+-webkit-box-decoration-break: slice;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>
@@ -10,8 +9,7 @@ box-shadow: 8px 8px 10px 0 #ff1493, -5px -5px 5px 0 #00f, 5px 5px 15px 0 #ff0;</
 
 <div class="example-choice">
 <pre><code class="language-css">box-decoration-break: clone;
--webkit-box-decoration-break: clone;
-box-shadow: 8px 8px 10px 0 #ff1492, -5px -5px 5px 0 #00f, 5px 5px 15px 0 #ff0;</code></pre>
+-webkit-box-decoration-break: clone;</code></pre>
 <button type="button" class="copy hidden" aria-hidden="true">
     <span class="visually-hidden">Copy to Clipboard</span>
 </button>


### PR DESCRIPTION
This PR moves `box-shadow` declaration to a hidden CSS, instead of letting it be present in the choice box.

Before:
![image](https://user-images.githubusercontent.com/100634371/225159617-2a971628-bb1a-46f8-baee-f3ac9765b895.png)

After:
![image](https://user-images.githubusercontent.com/100634371/225159633-eceaa59a-ebd6-4920-a8a1-cb5c38e82285.png)