### PR TITLE
docs(fix): Add clip keyword value to overflow examples

### DIFF
--- a/live-examples/css-examples/basic-box-model/overflow-block.html
+++ b/live-examples/css-examples/basic-box-model/overflow-block.html
@@ -15,6 +15,13 @@
     </div>
 
     <div class="example-choice">
+        <pre><code class="language-css">overflow-x: clip;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
         <pre><code class="language-css">overflow-block: scroll;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/basic-box-model/overflow-block.html
+++ b/live-examples/css-examples/basic-box-model/overflow-block.html
@@ -15,7 +15,7 @@
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">overflow-x: clip;</code></pre>
+        <pre><code class="language-css">overflow-block: clip;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/basic-box-model/overflow-inline.html
+++ b/live-examples/css-examples/basic-box-model/overflow-inline.html
@@ -15,6 +15,13 @@
     </div>
 
     <div class="example-choice">
+        <pre><code class="language-css">overflow-x: clip;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
         <pre><code class="language-css">overflow-inline: scroll;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/basic-box-model/overflow-inline.html
+++ b/live-examples/css-examples/basic-box-model/overflow-inline.html
@@ -15,7 +15,7 @@
     </div>
 
     <div class="example-choice">
-        <pre><code class="language-css">overflow-x: clip;</code></pre>
+        <pre><code class="language-css">overflow-inline: clip;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>
         </button>

--- a/live-examples/css-examples/basic-box-model/overflow-x.html
+++ b/live-examples/css-examples/basic-box-model/overflow-x.html
@@ -15,6 +15,13 @@
     </div>
 
     <div class="example-choice">
+        <pre><code class="language-css">overflow-x: clip;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
         <pre><code class="language-css">overflow-x: scroll;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/basic-box-model/overflow-y.html
+++ b/live-examples/css-examples/basic-box-model/overflow-y.html
@@ -15,6 +15,13 @@
     </div>
 
     <div class="example-choice">
+        <pre><code class="language-css">overflow-y: clip;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
         <pre><code class="language-css">overflow-y: scroll;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/basic-box-model/overflow.html
+++ b/live-examples/css-examples/basic-box-model/overflow.html
@@ -15,6 +15,13 @@
     </div>
 
     <div class="example-choice">
+        <pre><code class="language-css">overflow: clip;</code></pre>
+        <button type="button" class="copy hidden" aria-hidden="true">
+            <span class="visually-hidden">Copy to Clipboard</span>
+        </button>
+    </div>
+
+    <div class="example-choice">
         <pre><code class="language-css">overflow: scroll;</code></pre>
         <button type="button" class="copy hidden" aria-hidden="true">
             <span class="visually-hidden">Copy to Clipboard</span>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

The syntax on the [`overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#formal_syntax) page states five possible values for the `overflow` shorthand property and so do the syntax on the pages [`overflow-x`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x#formal_syntax) and [`overflow-y`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y#formal_syntax) - `visible`, `hidden`, `clip`, `scroll`, and `auto`.

While all other values are demo'ed in the [interactive example](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y#try_it), `clip` is missing.

### Motivation

All this pull request does is to add the `clip` keyword to the interactive examples for the sake of completeness.

### Related issues and pull requests

Related content update: https://github.com/mdn/content/pull/25749
Related doc issue tracker: https://github.com/mdn/content/issues/25355

