### PR TITLE
fix(js): Fix invalid output in `RelativeTimeFormat` example

### DIFF
--- a/live-examples/js-examples/intl/intl-relativetimeformat-prototype-format.js
+++ b/live-examples/js-examples/intl/intl-relativetimeformat-prototype-format.js
@@ -1,4 +1,4 @@
-const rtf1 = new Intl.RelativeTimeFormat('en', { style: 'narrow' });
+const rtf1 = new Intl.RelativeTimeFormat('en', { style: 'short' });
 
 console.log(rtf1.format(3, 'quarter'));
 // Expected output: "in 3 qtrs."

--- a/live-examples/js-examples/intl/intl-relativetimeformat.js
+++ b/live-examples/js-examples/intl/intl-relativetimeformat.js
@@ -1,4 +1,4 @@
-const rtf1 = new Intl.RelativeTimeFormat('en', { style: 'narrow' });
+const rtf1 = new Intl.RelativeTimeFormat('en', { style: 'short' });
 
 console.log(rtf1.format(3, 'quarter'));
 // Expected output: "in 3 qtrs."


### PR DESCRIPTION
Fixes #2501 