### PR TITLE
Fix for https://github.com/mdn/content/issues/26432

### DIFF
--- a/live-examples/css-examples/cascading-and-inheritance/at-rule-layer.css
+++ b/live-examples/css-examples/cascading-and-inheritance/at-rule-layer.css
@@ -1,7 +1,7 @@
 @layer module, state;
 
 @layer state {
-    .warning {
+    .alert {
         background-color: brown;
     }
     p {
@@ -10,7 +10,7 @@
 }
 
 @layer module {
-    .warning {
+    .alert {
         text-align: left;
         background-color: yellow;
         color: white;

--- a/live-examples/css-examples/cascading-and-inheritance/at-rule-layer.html
+++ b/live-examples/css-examples/cascading-and-inheritance/at-rule-layer.html
@@ -1,3 +1,3 @@
-<p class="warning">
+<p class="alert">
     Beware of the zombies
 </p>


### PR DESCRIPTION
### Description

Due to the use of the css class "warning", which is also defined in the global css of the mdn page, the layer example shows the wrong output. To fix this problem I renamed the class from warning to alert.

### Motivation

I made this change, because the provided @layer example does not show the correct output.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/@layer

### Related issues and pull requests

Fixes: https://github.com/mdn/interactive-examples/issues/2510
