### PR TITLE
fix docs/Web/CSS/@layer try-it box .warning class is being overrided

### DIFF
--- a/live-examples/css-examples/cascading-and-inheritance/at-rule-layer.css
+++ b/live-examples/css-examples/cascading-and-inheritance/at-rule-layer.css
@@ -1,7 +1,7 @@
 @layer module, state;
 
 @layer state {
-    .warning {
+    .zombiewarning {
         background-color: brown;
     }
     p {
@@ -10,7 +10,7 @@
 }
 
 @layer module {
-    .warning {
+    .zombiewarning {
         text-align: left;
         background-color: yellow;
         color: white;

--- a/live-examples/css-examples/cascading-and-inheritance/at-rule-layer.html
+++ b/live-examples/css-examples/cascading-and-inheritance/at-rule-layer.html
@@ -1,3 +1,3 @@
-<p class="warning">
+<p class="zombiewarning">
     Beware of the zombies
 </p>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description
fix https://github.com/mdn/content/issues/26502

It appears the try-it box in https://developer.mozilla.org/en-US/docs/Web/CSS/@layer has its built-in .warning class, which overrides the .warning class in the try-it box example. I have to rename the CSS class to .zombiewarning to make it work.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

as above

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
https://github.com/mdn/content/issues/26502

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
