### PR TITLE
fix CSS/@layer try-it: make text-align effect visible

### DIFF
--- a/live-examples/css-examples/cascading-and-inheritance/at-rule-layer.css
+++ b/live-examples/css-examples/cascading-and-inheritance/at-rule-layer.css
@@ -1,21 +1,17 @@
 @layer module, state;
 
-#html-output {
-  width: unset;
-}
-
 @layer state {
     .alert {
         background-color: brown;
     }
     p {
-        text-align: right;
+        border: medium solid limegreen;
     }
 }
 
 @layer module {
     .alert {
-        text-align: left;
+        border: medium solid violet;
         background-color: yellow;
         color: white;
     }

--- a/live-examples/css-examples/cascading-and-inheritance/at-rule-layer.css
+++ b/live-examples/css-examples/cascading-and-inheritance/at-rule-layer.css
@@ -1,5 +1,9 @@
 @layer module, state;
 
+#html-output {
+  width: unset;
+}
+
 @layer state {
     .alert {
         background-color: brown;


### PR DESCRIPTION
### Description

built in #html-output: fit-content limits the text box width, this PR unset it to make text-align of try-it example visible

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
