### PR TITLE
Update attribute-autocomplete.html

### DIFF
--- a/live-examples/html-examples/form-attributes/attribute-autocomplete.html
+++ b/live-examples/html-examples/form-attributes/attribute-autocomplete.html
@@ -1,8 +1,8 @@
 <label for="firstName">First Name:</label>
-<input name="firstName" type="text" autocomplete="given-name">
+<input name="firstName" id="firstName" type="text" autocomplete="given-name">
 
 <label for="lastName">Last Name:</label>
-<input name="lastName" type="text" autocomplete="family-name">
+<input name="lastName" id="lastName" type="text" autocomplete="family-name">
 
 <label for="email">Email:</label>
-<input name="email" type="email" autocomplete="off">
+<input name="email" id="email" type="email" autocomplete="off">


### PR DESCRIPTION
Updated attribute-autocomplete.html to include id's corresponding to the respective labels' for attributes. Resolving issue #27126.

### Description

Added id's within `<input>` that correspond to the `<label>`'s for attribute. 

### Motivation

Previous source code did not allow the user to focus the inputs by clicking on the corresponding label, which is the whole point of the interactive demo. 

### Additional details

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label

To explicitly associate a <label> element with an <input> element, you first need to add the id attribute to the <input> element. Next, you add the for attribute to the <label> element, where the value of for is the same as the id in the <input> element.

### Related issues and pull requests

Fixes issue #27126. 