### PR TITLE
Do build after `npm install`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "fix:js": "eslint --fix ./live-examples/js-examples",
         "lint:css": "stylelint \"**/*.css\"",
         "lint:js": "eslint ./live-examples/js-examples",
+        "postinstall": "npm run build",
         "start-server": "http-server -p 9090 ./docs",
         "start-watch": "chokidar \"./live-examples/**\" -c \"npm run build:pages\" --initial --silent",
         "start": "npm-run-all --parallel start-watch start-server",


### PR DESCRIPTION
In case people forget to do `npm run build` after checking out the repo and before `npm run start`.

The PR makes repo do build when contributors do `npm install`.