### PR TITLE
fix(CSS): add :host, :host-context, and ::slotted selector examples

### DIFF
--- a/live-examples/css-examples/pseudo-class/host-context.css
+++ b/live-examples/css-examples/pseudo-class/host-context.css
@@ -1,0 +1,9 @@
+/* Following CSS is being put inside the shadow DOM. */
+
+:host-context(.container) {
+    border: 5px dashed green;
+}
+
+:host-context(h1) {
+    color: red;
+}

--- a/live-examples/css-examples/pseudo-class/host-context.css
+++ b/live-examples/css-examples/pseudo-class/host-context.css
@@ -1,4 +1,4 @@
-/* Following CSS is being put inside the shadow DOM. */
+/* Following CSS is being applied inside the shadow DOM. */
 
 :host-context(.container) {
     border: 5px dashed green;

--- a/live-examples/css-examples/pseudo-class/host-context.html
+++ b/live-examples/css-examples/pseudo-class/host-context.html
@@ -1,0 +1,4 @@
+<!-- elements outside shadow dom -->
+<div class="container">
+  <h1 id="shadow-dom-host"></h1>
+</div>

--- a/live-examples/css-examples/pseudo-class/host.css
+++ b/live-examples/css-examples/pseudo-class/host.css
@@ -1,4 +1,4 @@
-/* This CSS is being put inside the shadow DOM. */
+/* This CSS is being applied inside the shadow DOM. */
 
 :host {
     background-color: aqua;

--- a/live-examples/css-examples/pseudo-class/host.css
+++ b/live-examples/css-examples/pseudo-class/host.css
@@ -1,0 +1,5 @@
+/* This CSS is being put inside the shadow DOM. */
+
+:host {
+    background-color: aqua;
+}

--- a/live-examples/css-examples/pseudo-class/host.html
+++ b/live-examples/css-examples/pseudo-class/host.html
@@ -1,0 +1,1 @@
+<h1 id="shadow-dom-host"></h1>

--- a/live-examples/css-examples/pseudo-class/host.js
+++ b/live-examples/css-examples/pseudo-class/host.js
@@ -1,0 +1,24 @@
+const shadowDom = init();
+
+// add a <span> element in the shadow DOM
+const span = document.createElement('span');
+span.textContent = 'Inside shadow DOM';
+shadowDom.appendChild(span);
+
+// attach shadow DOM to the #shadow-dom-host element
+function init() {
+  const host = document.getElementById('shadow-dom-host');
+  const shadowDom = host.attachShadow({ mode: 'open' });
+
+  const cssTab = document.querySelector('#css-output');
+  const shadowStyle = document.createElement('style');
+  shadowStyle.textContent = cssTab.textContent;
+  shadowDom.appendChild(shadowStyle);
+
+  cssTab.addEventListener('change', () => {
+    shadowStyle.textContent = cssTab.textContent;
+  });
+  return shadowDom;
+}
+
+

--- a/live-examples/css-examples/pseudo-class/host_function.css
+++ b/live-examples/css-examples/pseudo-class/host_function.css
@@ -1,4 +1,4 @@
-/* Following CSS is being put inside the shadow DOM. */
+/* Following CSS is being applied inside the shadow DOM. */
 
 :host(h1) {
     color: red;

--- a/live-examples/css-examples/pseudo-class/host_function.css
+++ b/live-examples/css-examples/pseudo-class/host_function.css
@@ -1,0 +1,9 @@
+/* Following CSS is being put inside the shadow DOM. */
+
+:host(h1) {
+    color: red;
+}
+
+:host(#shadow-dom-host) {
+    border: 2px dashed blue;
+}

--- a/live-examples/css-examples/pseudo-class/host_function.html
+++ b/live-examples/css-examples/pseudo-class/host_function.html
@@ -1,0 +1,4 @@
+<!-- elements outside shadow dom -->
+<div id="container">
+  <h1 id="shadow-dom-host"></h1>
+</div>

--- a/live-examples/css-examples/pseudo-class/meta.json
+++ b/live-examples/css-examples/pseudo-class/meta.json
@@ -135,6 +135,39 @@
             "defaultTab": "css",
             "height": "tabbed-shorter"
         },
+        "host": {
+            "cssExampleSrc": "./live-examples/css-examples/pseudo-class/host.css",
+            "exampleCode": "./live-examples/css-examples/pseudo-class/host.html",
+            "jsExampleSrc": "./live-examples/css-examples/pseudo-class/host.js",
+            "fileName": "pseudo-class-host.html",
+            "title": "CSS Demo: :host",
+            "type": "tabbed",
+            "tabs": "html,css,js",
+            "defaultTab": "css",
+            "height": "tabbed-shorter"
+        },
+        "host-context": {
+            "cssExampleSrc": "./live-examples/css-examples/pseudo-class/host-context.css",
+            "exampleCode": "./live-examples/css-examples/pseudo-class/host-context.html",
+            "jsExampleSrc": "./live-examples/css-examples/pseudo-class/host.js",
+            "fileName": "pseudo-class-host-context.html",
+            "title": "CSS Demo: :host-context()",
+            "type": "tabbed",
+            "tabs": "html,css,js",
+            "defaultTab": "css",
+            "height": "tabbed-shorter"
+        },
+        "host_function": {
+            "cssExampleSrc": "./live-examples/css-examples/pseudo-class/host_function.css",
+            "exampleCode": "./live-examples/css-examples/pseudo-class/host_function.html",
+            "jsExampleSrc": "./live-examples/css-examples/pseudo-class/host.js",
+            "fileName": "pseudo-class-host_function.html",
+            "title": "CSS Demo: :host()",
+            "type": "tabbed",
+            "tabs": "html,css,js",
+            "defaultTab": "css",
+            "height": "tabbed-shorter"
+        },
         "inRange": {
             "cssExampleSrc": "./live-examples/css-examples/pseudo-class/in-range.css",
             "exampleCode": "./live-examples/css-examples/pseudo-class/in-range.html",

--- a/live-examples/css-examples/pseudo-element/meta.json
+++ b/live-examples/css-examples/pseudo-element/meta.json
@@ -80,6 +80,17 @@
             "type": "tabbed",
             "defaultTab": "css",
             "height": "tabbed-shorter"
+        },
+        "slotted": {
+            "exampleCode": "./live-examples/css-examples/pseudo-element/slotted.html",
+            "cssExampleSrc": "./live-examples/css-examples/pseudo-element/slotted.css",
+            "jsExampleSrc": "./live-examples/css-examples/pseudo-element/slotted.js",
+            "fileName": "pseudo-element-slotted.html",
+            "title": "HTML Demo: ::slotted()",
+            "type": "tabbed",
+            "tabs": "html,css,js",
+            "defaultTab": "css",
+            "height": "tabbed-shorter"
         }
     }
 }

--- a/live-examples/css-examples/pseudo-element/slotted.css
+++ b/live-examples/css-examples/pseudo-element/slotted.css
@@ -1,4 +1,4 @@
-/* This CSS is being put inside the shadow DOM. */
+/* This CSS is being applied inside the shadow DOM. */
 
 ::slotted(.content) {
     background-color: aqua;

--- a/live-examples/css-examples/pseudo-element/slotted.css
+++ b/live-examples/css-examples/pseudo-element/slotted.css
@@ -1,0 +1,9 @@
+/* This CSS is being put inside the shadow DOM. */
+
+::slotted(.content) {
+    background-color: aqua;
+}
+
+h2 ::slotted(span) {
+    background: silver;
+}

--- a/live-examples/css-examples/pseudo-element/slotted.html
+++ b/live-examples/css-examples/pseudo-element/slotted.html
@@ -1,0 +1,11 @@
+<template id="card-template">
+  <div>
+    <h2><slot name="caption">title goes here</slot></h2>
+    <slot name="content">content goes here</slot>
+  </div>
+</template>
+
+<my-card>
+  <span slot="caption">Error</span>
+  <p class="content" slot="content">Build failed!</p>
+</my-card>

--- a/live-examples/css-examples/pseudo-element/slotted.js
+++ b/live-examples/css-examples/pseudo-element/slotted.js
@@ -1,0 +1,28 @@
+customElements.define('my-card',
+  class extends HTMLElement {
+    constructor() {
+      super();
+
+      const template = document.getElementById('card-template');
+      const shadow = this.attachShadow({ mode: 'open' });
+      shadow.appendChild(template.content.cloneNode(true));
+
+      const elementStyle = document.createElement('style');
+      elementStyle.textContent = `
+        div {
+          width: 200px;
+          border: 2px dotted red;
+          border-radius: 4px;
+        }`;
+      shadow.appendChild(elementStyle);
+
+      const cssTab = document.querySelector('#css-output');
+      const editorStyle = document.createElement('style');
+      editorStyle.textContent = cssTab.textContent;
+      shadow.appendChild(editorStyle);
+      cssTab.addEventListener('change', () => {
+        editorStyle.textContent = cssTab.textContent;
+      });
+    }
+  }
+);


### PR DESCRIPTION
- Adds examples for https://github.com/mdn/content/issues/27938

To test checkout the branch in local then run
```bash
npm install
npm run build
npm start
```

Open following URLs in browser:
```
http://localhost:9090/pages/tabbed/pseudo-class-host.html
http://localhost:9090/pages/tabbed/pseudo-class-host_function.html
http://localhost:9090/pages/tabbed/pseudo-class-host-context.html
http://localhost:9090/pages/tabbed/pseudo-element-slotted.html
```