### PR TITLE
Remove figure/figcaption from blockquote.html

### DIFF
--- a/live-examples/html-examples/text-content/blockquote.html
+++ b/live-examples/html-examples/text-content/blockquote.html
@@ -1,6 +1,4 @@
-<figure>
-    <blockquote cite="https://www.huxley.net/bnw/four.html">
-        <p>Words can be like X-rays, if you use them properly—they’ll go through anything. You read and you’re pierced.</p>
-    </blockquote>
-    <figcaption>—Aldous Huxley, <cite>Brave New World</cite></figcaption>
-</figure>
+<blockquote cite="https://www.huxley.net/bnw/four.html">
+    <p>Words can be like X-rays, if you use them properly—they’ll go through anything. You read and you’re pierced.</p>
+    <footer>—Aldous Huxley, <cite>Brave New World</cite></footer>
+</blockquote>


### PR DESCRIPTION
### Description

Removes the `<figure>` / `<figcaption>` construct that wraps the `<blockquote>` but is not explained in the page nor matches the example later in the page.

### Motivation

In NVDA, the `<figure>` causes an announcement of the figure, which is fine but adds unnecessary noise. The `<figcaption>` causes announcement of the text it contains at the start of the content, prior to announcing the presence of the figure or blockquote Then the contents of the `<figcaption>` are announced again as the user moves the virtual cursor through the DOM.

As a user, it is unclear why I am hearing this information twice (other than the code chosen). As a developer, there is no guidance on what this code will output.

In JAWS, the "has details" announcement is a function of the `<figcaption>`.

### Additional details

See [#28133 Blockquote example does not need figure/figcaption](https://github.com/mdn/interactive-examples/issues/2563)

### Related issues and pull requests

Fixes [#28133](https://github.com/mdn/interactive-examples/issues/2563)

