### PR TITLE
fix: Replace marker example

### DIFF
--- a/live-examples/css-examples/pseudo-element/marker.css
+++ b/live-examples/css-examples/pseudo-element/marker.css
@@ -1,0 +1,4 @@
+li::marker {
+  content: '✝ ';
+  font-size: 1.2em;
+}

--- a/live-examples/css-examples/pseudo-element/marker.html
+++ b/live-examples/css-examples/pseudo-element/marker.html
@@ -1,0 +1,10 @@
+<p>Group known as Mercury Seven:</p>
+<ul>
+  <li>Malcolm Scott Carpenter</li>
+  <li>Leroy Gordon (Gordo) Cooper Jr.</li>
+  <li>John Herschel Glenn Jr.</li>
+  <li>Virgil Ivan (Gus) Grissom</li>
+  <li>Walter Marty (Wally) Schirra Jr.</li>
+  <li>Alan Bartlett Shepard Jr.</li>
+  <li>Donald Kent (Deke) Slayton</li>
+</ul>

--- a/live-examples/css-examples/pseudo-element/meta.json
+++ b/live-examples/css-examples/pseudo-element/meta.json
@@ -9,17 +9,6 @@
       "defaultTab": "css",
       "height": "tabbed-standard"
     },
-    "backdrop": {
-      "exampleCode": "./live-examples/css-examples/pseudo-element/backdrop.html",
-      "cssExampleSrc": "./live-examples/css-examples/pseudo-element/backdrop.css",
-      "jsExampleSrc": "./live-examples/css-examples/pseudo-element/backdrop.js",
-      "fileName": "pseudo-element-backdrop.html",
-      "title": "HTML Demo: ::backdrop",
-      "type": "tabbed",
-      "defaultTab": "css",
-      "tabs": "html,css,js",
-      "height": "tabbed-shorter"
-    },
     "before": {
       "exampleCode": "./live-examples/css-examples/pseudo-element/before.html",
       "cssExampleSrc": "./live-examples/css-examples/pseudo-element/before.css",
@@ -28,15 +17,6 @@
       "type": "tabbed",
       "defaultTab": "css",
       "height": "tabbed-standard"
-    },
-    "cue": {
-      "exampleCode": "./live-examples/css-examples/pseudo-element/cue.html",
-      "cssExampleSrc": "./live-examples/css-examples/pseudo-element/cue.css",
-      "fileName": "pseudo-element-cue.html",
-      "title": "HTML Demo: ::cue",
-      "type": "tabbed",
-      "defaultTab": "css",
-      "height": "tabbed-shorter"
     },
     "fileSelectorButton": {
       "exampleCode": "./live-examples/css-examples/pseudo-element/file-selector-button.html",
@@ -65,6 +45,15 @@
       "defaultTab": "css",
       "height": "tabbed-shorter"
     },
+    "marker": {
+      "exampleCode": "./live-examples/css-examples/pseudo-element/marker.html",
+      "cssExampleSrc": "./live-examples/css-examples/pseudo-element/marker.css",
+      "fileName": "pseudo-element-marker.html",
+      "title": "HTML Demo: ::marker",
+      "type": "tabbed",
+      "defaultTab": "css",
+      "height": "tabbed-shorter"
+    },
     "placeholder": {
       "exampleCode": "./live-examples/css-examples/pseudo-element/placeholder.html",
       "cssExampleSrc": "./live-examples/css-examples/pseudo-element/placeholder.css",
@@ -80,17 +69,6 @@
       "fileName": "pseudo-element-selection.html",
       "title": "HTML Demo: ::selection",
       "type": "tabbed",
-      "defaultTab": "css",
-      "height": "tabbed-shorter"
-    },
-    "slotted": {
-      "exampleCode": "./live-examples/css-examples/pseudo-element/slotted.html",
-      "cssExampleSrc": "./live-examples/css-examples/pseudo-element/slotted.css",
-      "jsExampleSrc": "./live-examples/css-examples/pseudo-element/slotted.js",
-      "fileName": "pseudo-element-slotted.html",
-      "title": "HTML Demo: ::slotted()",
-      "type": "tabbed",
-      "tabs": "html,css,js",
       "defaultTab": "css",
       "height": "tabbed-shorter"
     }

--- a/live-examples/css-examples/pseudo-element/meta.json
+++ b/live-examples/css-examples/pseudo-element/meta.json
@@ -9,6 +9,17 @@
       "defaultTab": "css",
       "height": "tabbed-standard"
     },
+    "backdrop": {
+      "exampleCode": "./live-examples/css-examples/pseudo-element/backdrop.html",
+      "cssExampleSrc": "./live-examples/css-examples/pseudo-element/backdrop.css",
+      "jsExampleSrc": "./live-examples/css-examples/pseudo-element/backdrop.js",
+      "fileName": "pseudo-element-backdrop.html",
+      "title": "HTML Demo: ::backdrop",
+      "type": "tabbed",
+      "defaultTab": "css",
+      "tabs": "html,css,js",
+      "height": "tabbed-shorter"
+    },
     "before": {
       "exampleCode": "./live-examples/css-examples/pseudo-element/before.html",
       "cssExampleSrc": "./live-examples/css-examples/pseudo-element/before.css",
@@ -17,6 +28,15 @@
       "type": "tabbed",
       "defaultTab": "css",
       "height": "tabbed-standard"
+    },
+    "cue": {
+      "exampleCode": "./live-examples/css-examples/pseudo-element/cue.html",
+      "cssExampleSrc": "./live-examples/css-examples/pseudo-element/cue.css",
+      "fileName": "pseudo-element-cue.html",
+      "title": "HTML Demo: ::cue",
+      "type": "tabbed",
+      "defaultTab": "css",
+      "height": "tabbed-shorter"
     },
     "fileSelectorButton": {
       "exampleCode": "./live-examples/css-examples/pseudo-element/file-selector-button.html",
@@ -69,6 +89,17 @@
       "fileName": "pseudo-element-selection.html",
       "title": "HTML Demo: ::selection",
       "type": "tabbed",
+      "defaultTab": "css",
+      "height": "tabbed-shorter"
+    },
+    "slotted": {
+      "exampleCode": "./live-examples/css-examples/pseudo-element/slotted.html",
+      "cssExampleSrc": "./live-examples/css-examples/pseudo-element/slotted.css",
+      "jsExampleSrc": "./live-examples/css-examples/pseudo-element/slotted.js",
+      "fileName": "pseudo-element-slotted.html",
+      "title": "HTML Demo: ::slotted()",
+      "type": "tabbed",
+      "tabs": "html,css,js",
       "defaultTab": "css",
       "height": "tabbed-shorter"
     }


### PR DESCRIPTION
Replacing the `::marker` example.

See https://github.com/mdn/interactive-examples/pull/2175

CC @NiedziolkaMichal 