### PR TITLE
chore(prettier): Ignore implicit closing bracket in rtc element

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 docs/
+live-examples/html-examples/inline-text-semantics/rtc.html

--- a/live-examples/html-examples/inline-text-semantics/rtc.html
+++ b/live-examples/html-examples/inline-text-semantics/rtc.html
@@ -1,4 +1,3 @@
-<!-- prettier-ignore -->
 <ruby xml:lang="zh-Hant" style="ruby-position: under;">
     <rbc>
         <rb>馬</rb><rp>(</rp><rt>mǎ</rt><rp>)</rp>
@@ -8,4 +7,5 @@
     </rbc>
     <rtc xml:lang="en" style="ruby-position: over;">
         <rp>(</rp><rt>Malaysia</rt><rp>)</rp>
+    </rtc>
 </ruby>

--- a/live-examples/html-examples/inline-text-semantics/rtc.html
+++ b/live-examples/html-examples/inline-text-semantics/rtc.html
@@ -1,3 +1,4 @@
+<!-- prettier-ignore -->
 <ruby xml:lang="zh-Hant" style="ruby-position: under;">
     <rbc>
         <rb>馬</rb><rp>(</rp><rt>mǎ</rt><rp>)</rp>
@@ -7,5 +8,4 @@
     </rbc>
     <rtc xml:lang="en" style="ruby-position: over;">
         <rp>(</rp><rt>Malaysia</rt><rp>)</rp>
-    </rtc>
 </ruby>


### PR DESCRIPTION
Slightly ugly workaround to get tests to pass in https://github.com/mdn/interactive-examples/pull/2576

This is the only case of a magic comment necessary, I think we can allow one exception for this.