### PR TITLE
Fix text-underline-offset example in Safari

### DIFF
--- a/live-examples/css-examples/text-decoration/text-underline-offset.css
+++ b/live-examples/css-examples/text-decoration/text-underline-offset.css
@@ -1,4 +1,5 @@
 p {
   font: 1.5em sans-serif;
-  text-decoration: underline #ff0000;
+  text-decoration-line: underline;
+  text-decoration-color: #ff0000;
 }


### PR DESCRIPTION
### Description

Replace `text-decoration` shorthand with `text-decoration-line` and `text-decoration-color` in `text-underline-offset.css`

```diff
-  text-decoration: underline #ff0000;
+  text-decoration-line: underline;
+  text-decoration-color: #ff0000;
```

### Motivation

[`text-underline-offset` example](https://developer.mozilla.org/en-US/docs/Web/CSS/text-underline-offset) currently appears broken in Safari because of it not supporting `text-decoration` shorthand without `-webkit-` prefix

### Additional details

Alternative could be to add `-webkit-` prefixed version of `text-decoration` property

```diff
+  -webkit-text-decoration: underline #ff0000;
text-decoration: underline #ff0000;
```

However a solution that doesn’t require a vendor prefix seems preferable.