### PR TITLE
fix(css): for font examples use 'rem' instead of 'em'

### DIFF
--- a/live-examples/css-examples/fonts/font-size.html
+++ b/live-examples/css-examples/fonts/font-size.html
@@ -1,6 +1,6 @@
 <section id="example-choice-list" class="example-choice-list" data-property="font-size">
   <div class="example-choice" initial-choice="true">
-    <pre><code class="language-css">font-size: 1.2em;</code></pre>
+    <pre><code class="language-css">font-size: 1.2rem;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>

--- a/live-examples/css-examples/fonts/font.html
+++ b/live-examples/css-examples/fonts/font.html
@@ -1,13 +1,13 @@
 <section id="example-choice-list" class="example-choice-list" data-property="font">
   <div class="example-choice" initial-choice="true">
-    <pre><code class="language-css">font: 1.2em "Fira Sans", sans-serif;</code></pre>
+    <pre><code class="language-css">font: 1.2rem "Fira Sans", sans-serif;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">font: italic 1.2em "Fira Sans", serif;</code></pre>
+    <pre><code class="language-css">font: italic 1.2rem "Fira Sans", serif;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>


### PR DESCRIPTION
- part of fix for https://github.com/mdn/content/issues/14282

There is no change in output because we are not updating font on parent elements in these cases.