### PR TITLE
Fix double allocation in typedarray-of.js

### DIFF
--- a/live-examples/js-examples/typedarray/typedarray-of.js
+++ b/live-examples/js-examples/typedarray/typedarray-of.js
@@ -1,5 +1,4 @@
-let int16array = new Int16Array();
-int16array = Int16Array.of('10', '20', '30', '40', '50');
+const int16array = Int16Array.of('10', '20', '30', '40', '50');
 
 console.log(int16array);
 // Expected output: Int16Array [10, 20, 30, 40, 50]


### PR DESCRIPTION
### Description

The current example for [TypedArray.of()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/of) allocates an empty array first, before invoking the static `of()` method. My fix removes that unnecessary and misleading initial allocation.

### Motivation

A novice user might look at the current example code and infer that they need to create a new typed array first before they can use the `of()` method. That is not the case. Also, simpler is better. 

### Additional details

I replaced

    let int16array = new Int16Array();
    int16array = Int16Array.of('10', '20', '30', '40', '50');

with

    const int16array = Int16Array.of('10', '20', '30', '40', '50');

to avoid the unnecessary allocation of the empty array.

### Related issues and pull requests

n/a