### PR TITLE
28841 font synthesis position

### DIFF
--- a/live-examples/css-examples/fonts/font-synthesis.css
+++ b/live-examples/css-examples/fonts/font-synthesis.css
@@ -72,3 +72,11 @@
 .small-caps {
   font-variant: small-caps;
 }
+
+.sub {
+  font-variant: sub;
+}
+
+.sup {
+  font-variant: super;
+}

--- a/live-examples/css-examples/fonts/font-synthesis.html
+++ b/live-examples/css-examples/fonts/font-synthesis.html
@@ -1,6 +1,6 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="font-synthesis">
   <div class="example-choice" initial-choice="true">
-    <pre><code class="language-css">font-synthesis: weight style small-caps position;</code></pre>
+    <pre><code class="language-css">font-synthesis: weight style small-caps;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>

--- a/live-examples/css-examples/fonts/font-synthesis.html
+++ b/live-examples/css-examples/fonts/font-synthesis.html
@@ -1,6 +1,6 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="font-synthesis">
   <div class="example-choice" initial-choice="true">
-    <pre><code class="language-css">font-synthesis: weight style small-caps;</code></pre>
+    <pre><code class="language-css">font-synthesis: weight style small-caps position;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
@@ -33,16 +33,27 @@
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">font-synthesis: position;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
 </section>
 
 <div id="output" class="output large hidden">
   <section id="default-example" class="default-example">
     <div id="example-element" class="transition-all">
       <p class="english">
-        This font does not include <span class="bold">bold</span>, <span class="italic">italic</span>, and
-        <span class="small-caps">small-caps</span> variants.
+        This font does not include <span class="bold">bold</span>, <span class="italic">italic</span>,
+        <span class="small-caps">small-caps</span>, and <span class="sub">subscript</span> or
+        <span class="sup">superscript</span> variants.
       </p>
-      <p class="chinese">中文排版通常不运用<span class="bold">粗体</span>或<span class="italic">斜体</span>。</p>
+      <p class="chinese">
+        中文排版通常不运用<span class="bold">粗体</span>或<span class="italic">斜体</span><span class="sub">常不</span
+        ><span class="sup">运用</span>。
+      </p>
     </div>
   </section>
 </div>


### PR DESCRIPTION
### Description

- added `font-synthesis: position` example

### Motivation

Working on the documentation for [[CSS] Add font-synthesis-position property](https://github.com/mdn/content/issues/28841)
### Additional details

[https://drafts.csswg.org/css-fonts-4/#font-synthesis-position](https://drafts.csswg.org/css-fonts-4/#font-synthesis-position)

### Related issues and pull requests

- [Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1849010)
- [Content PR](https://github.com/mdn/content/pull/29108)
- [BCD PR](https://github.com/mdn/browser-compat-data/pull/20688)
- [data PR](https://github.com/mdn/data/pull/691)