### PR TITLE
Remove slashes from void elements

### DIFF
--- a/live-examples/html-examples/table-content/col.html
+++ b/live-examples/html-examples/table-content/col.html
@@ -3,9 +3,9 @@
     Superheros and sidekicks
   </caption>
   <colgroup>
-    <col />
-    <col span="2" class="batman" />
-    <col span="2" class="flash" />
+    <col>
+    <col span="2" class="batman">
+    <col span="2" class="flash">
   </colgroup>
   <tr>
     <td></td>


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/syntax.html#start-tags

<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Removed slashes from void `<co.>` elements on the col element page example

### Motivation

The [spec](https://html.spec.whatwg.org/multipage/syntax.html#start-tags) discourages use of slash:

>

### Additional details

> On [void elements](https://html.spec.whatwg.org/multipage/syntax.html#void-elements), [a slash] does not mark the start tag as self-closing but instead is unnecessary and has no effect of any kind. For such void elements, **it should be used only with caution** — especially since, if directly preceded by an [unquoted attribute value](https://html.spec.whatwg.org/multipage/syntax.html#unquoted), it becomes part of the attribute value rather than being discarded by the parser.

(emphasis mine)