### PR TITLE
chore(formatting): Apply default printWidth for JS / CSS

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,12 @@
 {
   "bracketSameLine": true,
   "singleQuote": true,
-  "printWidth": 120
+  "overrides": [
+    {
+      "files": ["**/*.md", "**/*.html"],
+      "options": {
+        "printWidth": 120
+      }
+    }
+  ]
 }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -7,7 +7,10 @@
     "comment-no-empty": true,
     "declaration-block-no-shorthand-property-overrides": true,
     "declaration-block-single-line-max-declarations": 1,
-    "declaration-empty-line-before": ["never", { "ignore": ["after-comment", "after-declaration"] }],
+    "declaration-empty-line-before": [
+      "never",
+      { "ignore": ["after-comment", "after-declaration"] }
+    ],
     "declaration-no-important": true,
     "font-family-name-quotes": "always-where-recommended",
     "font-family-no-duplicate-names": true,
@@ -17,11 +20,17 @@
     "keyframe-declaration-no-important": true,
     "length-zero-no-unit": true,
     "max-nesting-depth": 5,
-    "media-feature-name-no-unknown": [true, { "ignoreMediaFeatureNames": ["min--moz-device-pixel-ratio"] }],
+    "media-feature-name-no-unknown": [
+      true,
+      { "ignoreMediaFeatureNames": ["min--moz-device-pixel-ratio"] }
+    ],
     "no-invalid-double-slash-comments": true,
     "no-unknown-animations": true,
     "property-no-unknown": true,
-    "rule-empty-line-before": ["always", { "ignore": ["after-comment", "inside-block"] }],
+    "rule-empty-line-before": [
+      "always",
+      { "ignore": ["after-comment", "inside-block"] }
+    ],
     "selector-pseudo-class-no-unknown": true,
     "selector-pseudo-element-no-unknown": true,
     "selector-type-case": "lower",

--- a/live-examples/css-examples/color/color-adjust.css
+++ b/live-examples/css-examples/color/color-adjust.css
@@ -2,7 +2,10 @@
   padding: 1rem;
   font-size: 1.5rem;
   background-color: black;
-  background-image: linear-gradient(rgba(0, 0, 180, 0.5), rgba(70, 140, 220, 0.5));
+  background-image: linear-gradient(
+    rgba(0, 0, 180, 0.5),
+    rgba(70, 140, 220, 0.5)
+  );
   color: #333;
   text-align: center;
   display: flex;

--- a/live-examples/css-examples/fonts/font-synthesis.css
+++ b/live-examples/css-examples/fonts/font-synthesis.css
@@ -2,7 +2,8 @@
   font-family: Oxygen;
   font-style: normal;
   font-weight: 400;
-  src: url('https://fonts.gstatic.com/s/oxygen/v14/2sDfZG1Wl4LcnbuKjk0m.woff2') format('woff2');
+  src: url('https://fonts.gstatic.com/s/oxygen/v14/2sDfZG1Wl4LcnbuKjk0m.woff2')
+    format('woff2');
 }
 
 /* [108] */

--- a/live-examples/css-examples/fonts/font-variant-east-asian.css
+++ b/live-examples/css-examples/fonts/font-variant-east-asian.css
@@ -1,5 +1,6 @@
 #output section {
-  font-family: 'YuGothic Medium', YuGothic, 'Yu Gothic Medium', 'Yu Gothic', sans-serif;
+  font-family: 'YuGothic Medium', YuGothic, 'Yu Gothic Medium', 'Yu Gothic',
+    sans-serif;
   margin-top: 10px;
   font-size: 1.5em;
 }

--- a/live-examples/css-examples/fragmentation/break.js
+++ b/live-examples/css-examples/fragmentation/break.js
@@ -1,5 +1,7 @@
 const btn = document.getElementById('print-btn');
-const editorContainer = document.getElementsByClassName('css-editor-container')[0];
+const editorContainer = document.getElementsByClassName(
+  'css-editor-container',
+)[0];
 const exampleHTMLElement = document.getElementById('default-example');
 
 const printableSection = document.createElement('div');

--- a/live-examples/css-examples/motion-path/offset-anchor.css
+++ b/live-examples/css-examples/motion-path/offset-anchor.css
@@ -12,7 +12,14 @@
 }
 
 .wrapper {
-  background-image: linear-gradient(to bottom, transparent, transparent 49%, #000 50%, #000 51%, transparent 52%);
+  background-image: linear-gradient(
+    to bottom,
+    transparent,
+    transparent 49%,
+    #000 50%,
+    #000 51%,
+    transparent 52%
+  );
   border: 1px solid #ccc;
   width: 90%;
 }

--- a/live-examples/css-examples/rhythm/line-height-step.css
+++ b/live-examples/css-examples/rhythm/line-height-step.css
@@ -1,5 +1,11 @@
 .example-container {
-  background-image: repeating-linear-gradient(180deg, #ccc, #ccc 20px, #dbdbdb 20px, #dbdbdb 40px);
+  background-image: repeating-linear-gradient(
+    180deg,
+    #ccc,
+    #ccc 20px,
+    #dbdbdb 20px,
+    #dbdbdb 40px
+  );
   border: 0.75em solid;
   padding: 0.75em;
   text-align: left;

--- a/live-examples/css-examples/shapes/shape-image-threshold.css
+++ b/live-examples/css-examples/shapes/shape-image-threshold.css
@@ -9,5 +9,10 @@
   height: 150px;
   margin: 20px;
   width: 150px;
-  background-image: linear-gradient(50deg, rgb(77, 26, 103), transparent 80%, transparent);
+  background-image: linear-gradient(
+    50deg,
+    rgb(77, 26, 103),
+    transparent 80%,
+    transparent
+  );
 }

--- a/live-examples/html-examples/content-sectioning/css/article.css
+++ b/live-examples/html-examples/content-sectioning/css/article.css
@@ -12,7 +12,8 @@
 }
 
 .day-forecast {
-  background: right/contain content-box border-box no-repeat url('/media/examples/rain.svg') white;
+  background: right/contain content-box border-box no-repeat
+    url('/media/examples/rain.svg') white;
 }
 
 .day-forecast > h2,

--- a/live-examples/html-examples/forms/css/button.css
+++ b/live-examples/html-examples/forms/css/button.css
@@ -8,7 +8,12 @@
   text-shadow: 1px 1px 1px #000;
   border-radius: 10px;
   background-color: rgba(220, 0, 0, 1);
-  background-image: linear-gradient(to top left, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2) 30%, rgba(0, 0, 0, 0));
+  background-image: linear-gradient(
+    to top left,
+    rgba(0, 0, 0, 0.2),
+    rgba(0, 0, 0, 0.2) 30%,
+    rgba(0, 0, 0, 0)
+  );
   box-shadow:
     inset 2px 2px 3px rgba(255, 255, 255, 0.6),
     inset -2px -2px 3px rgba(0, 0, 0, 0.6);

--- a/live-examples/html-examples/global-attributes/js/attribute-is.js
+++ b/live-examples/html-examples/global-attributes/js/attribute-is.js
@@ -15,4 +15,6 @@ class LengthLeftTextarea extends HTMLTextAreaElement {
   }
 }
 
-customElements.define('length-left-textarea', LengthLeftTextarea, { extends: 'textarea' });
+customElements.define('length-left-textarea', LengthLeftTextarea, {
+  extends: 'textarea',
+});

--- a/live-examples/html-examples/input/css/button.css
+++ b/live-examples/html-examples/input/css/button.css
@@ -8,7 +8,12 @@
   text-shadow: 1px 1px 1px #000;
   border-radius: 10px;
   background-color: rgba(220, 0, 0, 1);
-  background-image: linear-gradient(to top left, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2) 30%, rgba(0, 0, 0, 0));
+  background-image: linear-gradient(
+    to top left,
+    rgba(0, 0, 0, 0.2),
+    rgba(0, 0, 0, 0.2) 30%,
+    rgba(0, 0, 0, 0)
+  );
   box-shadow:
     inset 2px 2px 3px rgba(255, 255, 255, 0.6),
     inset -2px -2px 3px rgba(0, 0, 0, 0.6);

--- a/live-examples/js-examples/array/array-at.js
+++ b/live-examples/js-examples/array/array-at.js
@@ -2,10 +2,10 @@ const array1 = [5, 12, 8, 130, 44];
 
 let index = 2;
 
-console.log(`Using an index of ${index} the item returned is ${array1.at(index)}`);
-// Expected output: "Using an index of 2 the item returned is 8"
+console.log(`An index of ${index} returns ${array1.at(index)}`);
+// Expected output: "An index of 2 returns 8"
 
 index = -2;
 
-console.log(`Using an index of ${index} item returned is ${array1.at(index)}`);
-// Expected output: "Using an index of -2 item returned is 130"
+console.log(`An index of ${index} returns ${array1.at(index)}`);
+// Expected output: "An index of -2 returns 130"

--- a/live-examples/js-examples/array/array-filter.js
+++ b/live-examples/js-examples/array/array-filter.js
@@ -1,4 +1,4 @@
-const words = ['spray', 'limit', 'elite', 'exuberant', 'destruction', 'present'];
+const words = ['spray', 'elite', 'exuberant', 'destruction', 'present'];
 
 const result = words.filter((word) => word.length > 6);
 

--- a/live-examples/js-examples/array/array-reduce-right.js
+++ b/live-examples/js-examples/array/array-reduce-right.js
@@ -4,7 +4,9 @@ const array1 = [
   [4, 5],
 ];
 
-const result = array1.reduceRight((accumulator, currentValue) => accumulator.concat(currentValue));
+const result = array1.reduceRight((accumulator, currentValue) =>
+  accumulator.concat(currentValue),
+);
 
 console.log(result);
 // Expected output: Array [4, 5, 2, 3, 0, 1]

--- a/live-examples/js-examples/array/array-reduce.js
+++ b/live-examples/js-examples/array/array-reduce.js
@@ -2,7 +2,10 @@ const array1 = [1, 2, 3, 4];
 
 // 0 + 1 + 2 + 3 + 4
 const initialValue = 0;
-const sumWithInitial = array1.reduce((accumulator, currentValue) => accumulator + currentValue, initialValue);
+const sumWithInitial = array1.reduce(
+  (accumulator, currentValue) => accumulator + currentValue,
+  initialValue,
+);
 
 console.log(sumWithInitial);
 // Expected output: 10

--- a/live-examples/js-examples/bigint/bigint-asintn.js
+++ b/live-examples/js-examples/bigint/bigint-asintn.js
@@ -1,7 +1,9 @@
 const max = 2n ** (64n - 1n) - 1n;
 
 function check64bit(number) {
-  number > max ? console.log("Number doesn't fit in signed 64-bit integer!") : console.log(BigInt.asIntN(64, number));
+  number > max
+    ? console.log("Number doesn't fit in signed 64-bit integer!")
+    : console.log(BigInt.asIntN(64, number));
 }
 
 check64bit(2n ** 64n);

--- a/live-examples/js-examples/bigint/bigint-tolocalestring.js
+++ b/live-examples/js-examples/bigint/bigint-tolocalestring.js
@@ -5,5 +5,7 @@ console.log(bigint.toLocaleString('de-DE'));
 // Expected output: "123.456.789.123.456.789"
 
 // Request a currency format
-console.log(bigint.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' }));
+console.log(
+  bigint.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' }),
+);
 // Expected output: "123.456.789.123.456.789,00 €"

--- a/live-examples/js-examples/classes/classes-extends.js
+++ b/live-examples/js-examples/classes/classes-extends.js
@@ -1,6 +1,19 @@
 class DateFormatter extends Date {
   getFormattedDate() {
-    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const months = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
     return `${this.getDate()}-${months[this.getMonth()]}-${this.getFullYear()}`;
   }
 }

--- a/live-examples/js-examples/date/date-tolocaledatestring.js
+++ b/live-examples/js-examples/date/date-tolocaledatestring.js
@@ -1,5 +1,10 @@
 const event = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
-const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+const options = {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+};
 
 console.log(event.toLocaleDateString('de-DE', options));
 // Expected output (varies according to local timezone): Donnerstag, 20. Dezember 2012

--- a/live-examples/js-examples/finalizationregistry/finalizationregistry.js
+++ b/live-examples/js-examples/finalizationregistry/finalizationregistry.js
@@ -9,7 +9,7 @@ const array1 = ['foo'];
 registry.register(array1, 'foo');
 // array1 is not referenced in any callback, so it can be garbage collected
 
-console.log("Triggering garbage collection, don't do this in production code!");
+console.log("Triggering garbage collection. Don't do this in production code!");
 
 (function allocateMemory() {
   Array.from({ length: 50000 }, () => () => {});

--- a/live-examples/js-examples/finalizationregistry/finalizationregistry.js
+++ b/live-examples/js-examples/finalizationregistry/finalizationregistry.js
@@ -9,7 +9,7 @@ const array1 = ['foo'];
 registry.register(array1, 'foo');
 // array1 is not referenced in any callback, so it can be garbage collected
 
-console.log('Triggering garbage collection, which you should never do in production code');
+console.log("Triggering garbage collection, don't do this in production code!");
 
 (function allocateMemory() {
   Array.from({ length: 50000 }, () => () => {});

--- a/live-examples/js-examples/intl/intl-collator.js
+++ b/live-examples/js-examples/intl/intl-collator.js
@@ -4,5 +4,9 @@ console.log(['Z', 'a', 'z', 'ä'].sort(new Intl.Collator('de').compare));
 console.log(['Z', 'a', 'z', 'ä'].sort(new Intl.Collator('sv').compare));
 // Expected output: Array ["a", "z", "Z", "ä"]
 
-console.log(['Z', 'a', 'z', 'ä'].sort(new Intl.Collator('de', { caseFirst: 'upper' }).compare));
+console.log(
+  ['Z', 'a', 'z', 'ä'].sort(
+    new Intl.Collator('de', { caseFirst: 'upper' }).compare,
+  ),
+);
 // Expected output: Array ["a", "ä", "Z", "z"]

--- a/live-examples/js-examples/intl/intl-datetimeformat-prototype-format.js
+++ b/live-examples/js-examples/intl/intl-datetimeformat-prototype-format.js
@@ -1,4 +1,9 @@
-const options1 = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+const options1 = {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+};
 const date1 = new Date(2012, 5);
 
 const dateTimeFormat1 = new Intl.DateTimeFormat('sr-RS', options1);

--- a/live-examples/js-examples/intl/intl-datetimeformat-prototype-formatrange.js
+++ b/live-examples/js-examples/intl/intl-datetimeformat-prototype-formatrange.js
@@ -1,4 +1,9 @@
-const options1 = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+const options1 = {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+};
 const options2 = { year: '2-digit', month: 'numeric', day: 'numeric' };
 
 const startDate = new Date(Date.UTC(2007, 0, 10, 10, 0, 0));

--- a/live-examples/js-examples/intl/intl-datetimeformat-prototype-formattoparts.js
+++ b/live-examples/js-examples/intl/intl-datetimeformat-prototype-formattoparts.js
@@ -1,5 +1,10 @@
 const date = new Date(2012, 5);
-const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+const options = {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+};
 const dateTimeFormat = new Intl.DateTimeFormat('en-US', options);
 
 const parts = dateTimeFormat.formatToParts(date);

--- a/live-examples/js-examples/intl/intl-datetimeformat.js
+++ b/live-examples/js-examples/intl/intl-datetimeformat.js
@@ -11,6 +11,10 @@ console.log(new Intl.DateTimeFormat(['ban', 'id']).format(date));
 
 // Specify date and time format using "style" options (i.e. full, long, medium, short)
 console.log(
-  new Intl.DateTimeFormat('en-GB', { dateStyle: 'full', timeStyle: 'long', timeZone: 'Australia/Sydney' }).format(date),
+  new Intl.DateTimeFormat('en-GB', {
+    dateStyle: 'full',
+    timeStyle: 'long',
+    timeZone: 'Australia/Sydney',
+  }).format(date),
 );
 // Expected output: "Sunday, 20 December 2020 at 14:23:16 GMT+11"

--- a/live-examples/js-examples/intl/intl-displaynames.js
+++ b/live-examples/js-examples/intl/intl-displaynames.js
@@ -1,5 +1,7 @@
 const regionNamesInEnglish = new Intl.DisplayNames(['en'], { type: 'region' });
-const regionNamesInTraditionalChinese = new Intl.DisplayNames(['zh-Hant'], { type: 'region' });
+const regionNamesInTraditionalChinese = new Intl.DisplayNames(['zh-Hant'], {
+  type: 'region',
+});
 
 console.log(regionNamesInEnglish.of('US'));
 // Expected output: "United States"

--- a/live-examples/js-examples/intl/intl-listformat-prototype-formattoparts.js
+++ b/live-examples/js-examples/intl/intl-listformat-prototype-formattoparts.js
@@ -1,6 +1,12 @@
 const vehicles = ['Motorcycle', 'Bus', 'Car'];
-const formatterEn = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' });
-const formatterFr = new Intl.ListFormat('fr', { style: 'long', type: 'conjunction' });
+const formatterEn = new Intl.ListFormat('en', {
+  style: 'long',
+  type: 'conjunction',
+});
+const formatterFr = new Intl.ListFormat('fr', {
+  style: 'long',
+  type: 'conjunction',
+});
 
 const partValuesEn = formatterEn.formatToParts(vehicles).map((p) => p.value);
 const partValuesFr = formatterFr.formatToParts(vehicles).map((p) => p.value);

--- a/live-examples/js-examples/intl/intl-listformat.js
+++ b/live-examples/js-examples/intl/intl-listformat.js
@@ -1,10 +1,16 @@
 const vehicles = ['Motorcycle', 'Bus', 'Car'];
 
-const formatter = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' });
+const formatter = new Intl.ListFormat('en', {
+  style: 'long',
+  type: 'conjunction',
+});
 console.log(formatter.format(vehicles));
 // Expected output: "Motorcycle, Bus, and Car"
 
-const formatter2 = new Intl.ListFormat('de', { style: 'short', type: 'disjunction' });
+const formatter2 = new Intl.ListFormat('de', {
+  style: 'short',
+  type: 'disjunction',
+});
 console.log(formatter2.format(vehicles));
 // Expected output: "Motorcycle, Bus oder Car"
 

--- a/live-examples/js-examples/intl/intl-locale-prototype-tostring.js
+++ b/live-examples/js-examples/intl/intl-locale-prototype-tostring.js
@@ -1,5 +1,11 @@
-const french = new Intl.Locale('fr-Latn-FR', { calendar: 'gregory', hourCycle: 'h12' });
-const korean = new Intl.Locale('ko-Kore-KR', { numeric: true, caseFirst: 'upper' });
+const french = new Intl.Locale('fr-Latn-FR', {
+  calendar: 'gregory',
+  hourCycle: 'h12',
+});
+const korean = new Intl.Locale('ko-Kore-KR', {
+  numeric: true,
+  caseFirst: 'upper',
+});
 
 console.log(french.toString());
 // Expected output: "fr-Latn-FR-u-ca-gregory-hc-h12"

--- a/live-examples/js-examples/intl/intl-numberformat.js
+++ b/live-examples/js-examples/intl/intl-numberformat.js
@@ -1,12 +1,24 @@
 const number = 123456.789;
 
-console.log(new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(number));
+console.log(
+  new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(
+    number,
+  ),
+);
 // Expected output: "123.456,79 €"
 
 // The Japanese yen doesn't use a minor unit
-console.log(new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(number));
+console.log(
+  new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(
+    number,
+  ),
+);
 // Expected output: "￥123,457"
 
 // Limit to three significant digits
-console.log(new Intl.NumberFormat('en-IN', { maximumSignificantDigits: 3 }).format(number));
+console.log(
+  new Intl.NumberFormat('en-IN', { maximumSignificantDigits: 3 }).format(
+    number,
+  ),
+);
 // Expected output: "1,23,000"

--- a/live-examples/js-examples/intl/intl-segmenter-prototype-segment.js
+++ b/live-examples/js-examples/intl/intl-segmenter-prototype-segment.js
@@ -1,6 +1,8 @@
 const string1 = 'Que ma joie demeure';
 
-const segmenterFrGrapheme = new Intl.Segmenter('fr', { granularity: 'grapheme' });
+const segmenterFrGrapheme = new Intl.Segmenter('fr', {
+  granularity: 'grapheme',
+});
 const graphemeSegments = segmenterFrGrapheme.segment(string1);
 
 console.log(Array.from(graphemeSegments)[0]);

--- a/live-examples/js-examples/json/json-stringify.js
+++ b/live-examples/js-examples/json/json-stringify.js
@@ -1,7 +1,9 @@
 console.log(JSON.stringify({ x: 5, y: 6 }));
 // Expected output: '{"x":5,"y":6}'
 
-console.log(JSON.stringify([new Number(3), new String('false'), new Boolean(false)]));
+console.log(
+  JSON.stringify([new Number(3), new String('false'), new Boolean(false)]),
+);
 // Expected output: '[3,"false",false]'
 
 console.log(JSON.stringify({ x: [10, undefined, function () {}, Symbol('')] }));

--- a/live-examples/js-examples/map/map-groupby.js
+++ b/live-examples/js-examples/map/map-groupby.js
@@ -8,6 +8,8 @@ const inventory = [
 
 const restock = { restock: true };
 const sufficient = { restock: false };
-const result = Map.groupBy(inventory, ({ quantity }) => (quantity < 6 ? restock : sufficient));
+const result = Map.groupBy(inventory, ({ quantity }) =>
+  quantity < 6 ? restock : sufficient,
+);
 console.log(result.get(restock));
 // [{ name: "bananas", type: "fruit", quantity: 5 }]

--- a/live-examples/js-examples/promise/promise-allsettled.js
+++ b/live-examples/js-examples/promise/promise-allsettled.js
@@ -1,8 +1,12 @@
 const promise1 = Promise.resolve(3);
-const promise2 = new Promise((resolve, reject) => setTimeout(reject, 100, 'foo'));
+const promise2 = new Promise((resolve, reject) =>
+  setTimeout(reject, 100, 'foo'),
+);
 const promises = [promise1, promise2];
 
-Promise.allSettled(promises).then((results) => results.forEach((result) => console.log(result.status)));
+Promise.allSettled(promises).then((results) =>
+  results.forEach((result) => console.log(result.status)),
+);
 
 // Expected output:
 // "fulfilled"

--- a/live-examples/js-examples/reflect/reflect-apply.js
+++ b/live-examples/js-examples/reflect/reflect-apply.js
@@ -1,10 +1,14 @@
 console.log(Reflect.apply(Math.floor, undefined, [1.75]));
 // Expected output: 1
 
-console.log(Reflect.apply(String.fromCharCode, undefined, [104, 101, 108, 108, 111]));
+console.log(
+  Reflect.apply(String.fromCharCode, undefined, [104, 101, 108, 108, 111]),
+);
 // Expected output: "hello"
 
-console.log(Reflect.apply(RegExp.prototype.exec, /ab/, ['confabulation']).index);
+console.log(
+  Reflect.apply(RegExp.prototype.exec, /ab/, ['confabulation']).index,
+);
 // Expected output: 4
 
 console.log(Reflect.apply(''.charAt, 'ponies', [3]));

--- a/live-examples/js-examples/statement/statement-async-for-in.js
+++ b/live-examples/js-examples/statement/statement-async-for-in.js
@@ -1,5 +1,6 @@
 async function getFromList() {
-  const url = 'https://www.random.org/decimal-fractions/?num=1&dec=10&col=1&format=plain&rnd=new';
+  const url =
+    'https://www.random.org/decimal-fractions/?num=1&dec=10&col=1&format=plain&rnd=new';
 
   const arrayOfFetches = [doFetch(url), doFetch(url), doFetch(url)];
 

--- a/live-examples/js-examples/string/string-at.js
+++ b/live-examples/js-examples/string/string-at.js
@@ -2,10 +2,10 @@ const sentence = 'The quick brown fox jumps over the lazy dog.';
 
 let index = 5;
 
-console.log(`Using an index of ${index} the character returned is ${sentence.at(index)}`);
-// Expected output: "Using an index of 5 the character returned is u"
+console.log(`An index of ${index} returns the character ${sentence.at(index)}`);
+// Expected output: "An index of 5 returns the character u"
 
 index = -4;
 
-console.log(`Using an index of ${index} the character returned is ${sentence.at(index)}`);
-// Expected output: "Using an index of -4 the character returned is d"
+console.log(`An index of ${index} returns the character ${sentence.at(index)}`);
+// Expected output: "An index of -4 returns the character d"

--- a/live-examples/js-examples/string/string-charcodeat.js
+++ b/live-examples/js-examples/string/string-charcodeat.js
@@ -2,5 +2,9 @@ const sentence = 'The quick brown fox jumps over the lazy dog.';
 
 const index = 4;
 
-console.log(`The character code ${sentence.charCodeAt(index)} is equal to ${sentence.charAt(index)}`);
-// Expected output: "The character code 113 is equal to q"
+console.log(
+  `Character code ${sentence.charCodeAt(index)} is equal to ${sentence.charAt(
+    index,
+  )}`,
+);
+// Expected output: "Character code 113 is equal to q"

--- a/live-examples/js-examples/string/string-includes.js
+++ b/live-examples/js-examples/string/string-includes.js
@@ -2,5 +2,9 @@ const sentence = 'The quick brown fox jumps over the lazy dog.';
 
 const word = 'fox';
 
-console.log(`The word "${word}" ${sentence.includes(word) ? 'is' : 'is not'} in the sentence`);
+console.log(
+  `The word "${word}" ${
+    sentence.includes(word) ? 'is' : 'is not'
+  } in the sentence`,
+);
 // Expected output: "The word "fox" is in the sentence"

--- a/live-examples/js-examples/string/string-indexof.js
+++ b/live-examples/js-examples/string/string-indexof.js
@@ -1,10 +1,18 @@
-const paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
+const paragraph =
+  'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
 
 const searchTerm = 'dog';
 const indexOfFirst = paragraph.indexOf(searchTerm);
 
-console.log(`The index of the first "${searchTerm}" from the beginning is ${indexOfFirst}`);
+console.log(
+  `The index of the first "${searchTerm}" from the beginning is ${indexOfFirst}`,
+);
 // Expected output: "The index of the first "dog" from the beginning is 40"
 
-console.log(`The index of the 2nd "${searchTerm}" is ${paragraph.indexOf(searchTerm, indexOfFirst + 1)}`);
+console.log(
+  `The index of the 2nd "${searchTerm}" is ${paragraph.indexOf(
+    searchTerm,
+    indexOfFirst + 1,
+  )}`,
+);
 // Expected output: "The index of the 2nd "dog" is 52"

--- a/live-examples/js-examples/string/string-lastindexof.js
+++ b/live-examples/js-examples/string/string-lastindexof.js
@@ -1,6 +1,11 @@
-const paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
+const paragraph =
+  'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
 
 const searchTerm = 'dog';
 
-console.log(`The index of the first "${searchTerm}" from the end is ${paragraph.lastIndexOf(searchTerm)}`);
+console.log(
+  `The index of the first "${searchTerm}" from the end is ${paragraph.lastIndexOf(
+    searchTerm,
+  )}`,
+);
 // Expected output: "The index of the first "dog" from the end is 52"

--- a/live-examples/js-examples/string/string-replace.js
+++ b/live-examples/js-examples/string/string-replace.js
@@ -1,4 +1,5 @@
-const p = 'The quick brown fox jumps over the lazy dog. If the dog reacted, was it really lazy?';
+const p =
+  'The quick brown fox jumps over the lazy dog. If the dog reacted, was it really lazy?';
 
 console.log(p.replace('dog', 'monkey'));
 // Expected output: "The quick brown fox jumps over the lazy monkey. If the dog reacted, was it really lazy?"

--- a/live-examples/js-examples/string/string-replaceall.js
+++ b/live-examples/js-examples/string/string-replaceall.js
@@ -1,4 +1,5 @@
-const p = 'The quick brown fox jumps over the lazy dog. If the dog reacted, was it really lazy?';
+const p =
+  'The quick brown fox jumps over the lazy dog. If the dog reacted, was it really lazy?';
 
 console.log(p.replaceAll('dog', 'monkey'));
 // Expected output: "The quick brown fox jumps over the lazy monkey. If the monkey reacted, was it really lazy?"

--- a/live-examples/js-examples/string/string-search.js
+++ b/live-examples/js-examples/string/string-search.js
@@ -1,4 +1,5 @@
-const paragraph = 'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
+const paragraph =
+  'The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?';
 
 // Any character that is not a word character or whitespace
 const regex = /[^\w\s]/g;

--- a/live-examples/js-examples/symbol/symbol-split.js
+++ b/live-examples/js-examples/symbol/symbol-split.js
@@ -4,7 +4,9 @@ class Split1 {
   }
   [Symbol.split](string) {
     const index = string.indexOf(this.value);
-    return `${this.value}${string.substr(0, index)}/${string.substr(index + this.value.length)}`;
+    return `${this.value}${string.substr(0, index)}/${string.substr(
+      index + this.value.length,
+    )}`;
   }
 }
 

--- a/live-examples/js-examples/typedarray/typedarray-at.js
+++ b/live-examples/js-examples/typedarray/typedarray-at.js
@@ -2,10 +2,10 @@ const int8 = new Int8Array([0, 10, -10, 20, -30, 40, -50]);
 
 let index = 1;
 
-console.log(`Using an index of ${index} the item returned is ${int8.at(index)}`);
-// Expected output: "Using an index of 1 the item returned is 10"
+console.log(`An index of ${index} returns the item ${int8.at(index)}`);
+// Expected output: "An index of 1 returns the item 10"
 
 index = -2;
 
-console.log(`Using an index of ${index} the item returned is ${int8.at(index)}`);
-// Expected output: "Using an index of -2 the item returned is 40"
+console.log(`An index of ${index} returns the item ${int8.at(index)}`);
+// Expected output: "An index of -2 returns the item 40"

--- a/live-examples/js-examples/typedarray/typedarray-reduceright.js
+++ b/live-examples/js-examples/typedarray/typedarray-reduceright.js
@@ -1,6 +1,8 @@
 const uint8 = new Uint8Array([10, 20, 30]);
 
-const result = uint8.reduceRight((accumulator, currentValue) => `${accumulator}, ${currentValue}`);
+const result = uint8.reduceRight(
+  (accumulator, currentValue) => `${accumulator}, ${currentValue}`,
+);
 
 console.log(result);
 // Expected output: "30, 20, 10"

--- a/live-examples/js-examples/typedarray/typedarray-tolocalestring.js
+++ b/live-examples/js-examples/typedarray/typedarray-tolocalestring.js
@@ -6,5 +6,7 @@ console.log(uint8.toLocaleString());
 console.log(uint8.toLocaleString('en-GB'));
 // Expected output: "500,8,123,12"
 
-console.log(uint8.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' }));
+console.log(
+  uint8.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' }),
+);
 // Expected output: "500,00 €,8.123,00 €,12,00 €"

--- a/live-examples/js-examples/weakref/weakref.js
+++ b/live-examples/js-examples/weakref/weakref.js
@@ -3,7 +3,7 @@ const ref = new WeakRef(['foo', 'bar']);
 console.log(ref.deref()[0]);
 // Expected output: "foo"
 
-console.log('Triggering garbage collection, which you should never do in production code');
+console.log("Triggering garbage collection. Don't do this in production code!");
 console.log('This process is unpredictable and may take few minutes');
 
 function checkIfCollected() {

--- a/live-examples/wat-examples/numeric/and.js
+++ b/live-examples/wat-examples/numeric/and.js
@@ -1,11 +1,13 @@
 const url = '{%wasm-url%}';
-await WebAssembly.instantiateStreaming(fetch(url), { console }).then((result) => {
-  const and = result.instance.exports.and;
+await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
+  (result) => {
+    const and = result.instance.exports.and;
 
-  const res = and(0b10000010, 0b01101111);
-  console.log(numToBin(res));
-  // Expected output: "00000010"
-});
+    const res = and(0b10000010, 0b01101111);
+    console.log(numToBin(res));
+    // Expected output: "00000010"
+  },
+);
 
 function numToBin(num) {
   return (num >>> 0).toString(2).padStart(8, '0');

--- a/live-examples/wat-examples/numeric/clz.js
+++ b/live-examples/wat-examples/numeric/clz.js
@@ -1,7 +1,11 @@
 const url = '{%wasm-url%}';
-await WebAssembly.instantiateStreaming(fetch(url), { console }).then((result) => {
-  const leading0 = result.instance.exports.leading0;
+await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
+  (result) => {
+    const leading0 = result.instance.exports.leading0;
 
-  console.log(`Leading zeros: ${leading0(0b00000000_10000000_00000000_00000000)}`);
-  // Expected output: "Leading zeros: 8"
-});
+    console.log(
+      `Leading zeros: ${leading0(0b00000000_10000000_00000000_00000000)}`,
+    );
+    // Expected output: "Leading zeros: 8"
+  },
+);

--- a/live-examples/wat-examples/numeric/ctz.js
+++ b/live-examples/wat-examples/numeric/ctz.js
@@ -1,7 +1,11 @@
 const url = '{%wasm-url%}';
-await WebAssembly.instantiateStreaming(fetch(url), { console }).then((result) => {
-  const trailing0 = result.instance.exports.trailing0;
+await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
+  (result) => {
+    const trailing0 = result.instance.exports.trailing0;
 
-  console.log(`Trailing zeros: ${trailing0(0b00000000_10000000_00000000_00000000)}`);
-  // Expected output: "Trailing zeros: 23"
-});
+    console.log(
+      `Trailing zeros: ${trailing0(0b00000000_10000000_00000000_00000000)}`,
+    );
+    // Expected output: "Trailing zeros: 23"
+  },
+);

--- a/live-examples/wat-examples/numeric/or.js
+++ b/live-examples/wat-examples/numeric/or.js
@@ -1,11 +1,13 @@
 const url = '{%wasm-url%}';
-await WebAssembly.instantiateStreaming(fetch(url), { console }).then((result) => {
-  const or = result.instance.exports.or;
+await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
+  (result) => {
+    const or = result.instance.exports.or;
 
-  const res = or(0b10000010, 0b01101111);
-  console.log(numToBin(res));
-  // Expected output: "11101111"
-});
+    const res = or(0b10000010, 0b01101111);
+    console.log(numToBin(res));
+    // Expected output: "11101111"
+  },
+);
 
 function numToBin(num) {
   return (num >>> 0).toString(2).padStart(8, '0');

--- a/live-examples/wat-examples/numeric/popcnt.js
+++ b/live-examples/wat-examples/numeric/popcnt.js
@@ -1,7 +1,9 @@
 const url = '{%wasm-url%}';
-await WebAssembly.instantiateStreaming(fetch(url), { console }).then((result) => {
-  const count1s = result.instance.exports.count1s;
+await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
+  (result) => {
+    const count1s = result.instance.exports.count1s;
 
-  console.log(count1s(0b10000010));
-  // Expected output: 2
-});
+    console.log(count1s(0b10000010));
+    // Expected output: 2
+  },
+);

--- a/live-examples/wat-examples/numeric/rotl.js
+++ b/live-examples/wat-examples/numeric/rotl.js
@@ -1,11 +1,13 @@
 const url = '{%wasm-url%}';
-await WebAssembly.instantiateStreaming(fetch(url), { console }).then((result) => {
-  const rotate_left = result.instance.exports.rotate_left;
+await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
+  (result) => {
+    const rotate_left = result.instance.exports.rotate_left;
 
-  const res = rotate_left(0b11100000_00000000_00000000_00000000, 1);
-  console.log(numToBin(res));
-  // Expected output: "11000000_00000000_00000000_00000001"
-});
+    const res = rotate_left(0b11100000_00000000_00000000_00000000, 1);
+    console.log(numToBin(res));
+    // Expected output: "11000000_00000000_00000000_00000001"
+  },
+);
 
 function numToBin(num) {
   return (num >>> 0)

--- a/live-examples/wat-examples/numeric/rotr.js
+++ b/live-examples/wat-examples/numeric/rotr.js
@@ -1,11 +1,13 @@
 const url = '{%wasm-url%}';
-await WebAssembly.instantiateStreaming(fetch(url), { console }).then((result) => {
-  const rotate_right = result.instance.exports.rotate_right;
+await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
+  (result) => {
+    const rotate_right = result.instance.exports.rotate_right;
 
-  const res = rotate_right(0b00000000_00000000_00000000_00000111, 1);
-  console.log(numToBin(res));
-  // Expected output: "10000000_00000000_00000000_00000011"
-});
+    const res = rotate_right(0b00000000_00000000_00000000_00000111, 1);
+    console.log(numToBin(res));
+    // Expected output: "10000000_00000000_00000000_00000011"
+  },
+);
 
 function numToBin(num) {
   return (num >>> 0)

--- a/live-examples/wat-examples/numeric/shl.js
+++ b/live-examples/wat-examples/numeric/shl.js
@@ -1,11 +1,13 @@
 const url = '{%wasm-url%}';
-await WebAssembly.instantiateStreaming(fetch(url), { console }).then((result) => {
-  const shift_left = result.instance.exports.shift_left;
+await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
+  (result) => {
+    const shift_left = result.instance.exports.shift_left;
 
-  const res = shift_left(0b11100000_00000000_00000000_00000000, 1);
-  console.log(numToBin(res));
-  // Expected output: "11000000_00000000_00000000_00000000"
-});
+    const res = shift_left(0b11100000_00000000_00000000_00000000, 1);
+    console.log(numToBin(res));
+    // Expected output: "11000000_00000000_00000000_00000000"
+  },
+);
 
 function numToBin(num) {
   return (num >>> 0)

--- a/live-examples/wat-examples/numeric/shr.js
+++ b/live-examples/wat-examples/numeric/shr.js
@@ -1,11 +1,13 @@
 const url = '{%wasm-url%}';
-await WebAssembly.instantiateStreaming(fetch(url), { console }).then((result) => {
-  const shift_right = result.instance.exports.shift_right;
+await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
+  (result) => {
+    const shift_right = result.instance.exports.shift_right;
 
-  const res = shift_right(0b00000000_00000000_00000000_00000111, 1);
-  console.log(numToBin(res));
-  // Expected output: "00000000_00000000_00000000_00000011"
-});
+    const res = shift_right(0b00000000_00000000_00000000_00000111, 1);
+    console.log(numToBin(res));
+    // Expected output: "00000000_00000000_00000000_00000011"
+  },
+);
 
 function numToBin(num) {
   return (num >>> 0)

--- a/live-examples/wat-examples/numeric/xor.js
+++ b/live-examples/wat-examples/numeric/xor.js
@@ -1,11 +1,13 @@
 const url = '{%wasm-url%}';
-await WebAssembly.instantiateStreaming(fetch(url), { console }).then((result) => {
-  const xor = result.instance.exports.xor;
+await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
+  (result) => {
+    const xor = result.instance.exports.xor;
 
-  const res = xor(0b10000010, 0b01101111);
-  console.log(numToBin(res));
-  // Expected output: "11101101"
-});
+    const res = xor(0b10000010, 0b01101111);
+    console.log(numToBin(res));
+    // Expected output: "11101101"
+  },
+);
 
 function numToBin(num) {
   return (num >>> 0).toString(2).padStart(8, '0');

--- a/live-examples/wat-examples/statements/block.js
+++ b/live-examples/wat-examples/statements/block.js
@@ -1,11 +1,13 @@
 const url = '{%wasm-url%}';
-await WebAssembly.instantiateStreaming(fetch(url), { console }).then((result) => {
-  const log_if_not_100 = result.instance.exports.log_if_not_100;
+await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
+  (result) => {
+    const log_if_not_100 = result.instance.exports.log_if_not_100;
 
-  log_if_not_100(99);
-  // Expected output: 99
-  log_if_not_100(100);
-  // Should not log anything
-  log_if_not_100(101);
-  // Expected output: 101
-});
+    log_if_not_100(99);
+    // Expected output: 99
+    log_if_not_100(100);
+    // Should not log anything
+    log_if_not_100(101);
+    // Expected output: 101
+  },
+);

--- a/live-examples/webapi-examples/url/url-prototype-password.js
+++ b/live-examples/webapi-examples/url/url-prototype-password.js
@@ -1,3 +1,3 @@
-const url = new URL('https://admin:test@en.wikipedia.org:443/wiki/Mozilla#Software');
+const url = new URL('https://admin:test@example.com:443/wiki/Mozilla#Software');
 console.log(url.password);
 // expected output: "test"

--- a/live-examples/webapi-examples/url/url-prototype-search.js
+++ b/live-examples/webapi-examples/url/url-prototype-search.js
@@ -1,3 +1,3 @@
-const url = new URL('https://en.wikipedia.org/w/index.php?title=Mozilla&action=edit');
+const url = new URL('https://example.com/index.php?title=Mozilla&action=edit');
 console.log(url.search);
 // expected output: "?title=Mozilla&action=edit"

--- a/live-examples/webapi-examples/url/url-prototype-searchparams.js
+++ b/live-examples/webapi-examples/url/url-prototype-searchparams.js
@@ -1,4 +1,4 @@
-const url = new URL('https://en.wikipedia.org/w/index.php?title=Mozilla&action=edit');
+const url = new URL('https://example.com/index.php?title=Mozilla&action=edit');
 const params = url.searchParams;
 
 params.forEach((value, key) => console.log(`${key} - ${value}`));

--- a/live-examples/webapi-examples/url/url-prototype-username.js
+++ b/live-examples/webapi-examples/url/url-prototype-username.js
@@ -1,3 +1,3 @@
-const url = new URL('https://admin:test@en.wikipedia.org:443/wiki/Mozilla#Software');
+const url = new URL('https://admin:test@example.com:443/wiki/Mozilla#Software');
 console.log(url.username);
 // expected output: "admin"


### PR DESCRIPTION
### Description

* Remove 120 char `printWidth` configuration in `.prettierrc.json`
  * excluding HTML & markdown files for now. Checking removal of these in a follow-up.
* In parallel: use `example.com` for domains where possible instead of real domains

### Motivation

JS and CSS examples should follow the same formatting as in `mdn/content`

### Additional details

__Types of changes and summary:__

For the following files, here's my personal opinion of whether the changes are acceptable or not:

<details>

- live-examples/css-examples/color/color-adjust.css -> not used in content
- live-examples/css-examples/fonts/font-synthesis.css -> non-visible change
- live-examples/css-examples/fonts/font-variant-east-asian.css -> non-visible change
- live-examples/css-examples/fragmentation/break.js -> non-visible change
- live-examples/css-examples/motion-path/offset-anchor.css -> non-visible change
- live-examples/css-examples/rhythm/line-height-step.css -> non-visible change
- live-examples/css-examples/shapes/shape-image-threshold.css -> non-visible change
- live-examples/html-examples/content-sectioning/css/article.css -> non-visible change
- live-examples/html-examples/forms/css/button.css -> non-visible change
- live-examples/html-examples/global-attributes/js/attribute-is.js -> not used in content
- live-examples/html-examples/input/css/button.css -> non-visible change
- live-examples/js-examples/array/array-at.js -> modified to fit line wrap
- live-examples/js-examples/array/array-filter.js -> modified to fit line wrap
- live-examples/js-examples/array/array-reduce-right.js -> adds line breaks, neutral change
- live-examples/js-examples/array/array-reduce.js -> adds line breaks, neutral change
- live-examples/js-examples/bigint/bigint-asintn.js -> adds line breaks, notable improvement
- live-examples/js-examples/bigint/bigint-tolocalestring.js -> adds line breaks, neutral change
- live-examples/js-examples/classes/classes-extends.js -> adds line breaks, neutral change
- live-examples/js-examples/date/date-tolocaledatestring.js -> adds line breaks, improvement
- live-examples/js-examples/finalizationregistry/finalizationregistry.js -> modified to fit line wrap
- live-examples/js-examples/intl/intl-collator.js -> adds line breaks, neutral change
- live-examples/js-examples/intl/intl-datetimeformat-prototype-format.js -> adds line breaks, improvement
- live-examples/js-examples/intl/intl-datetimeformat-prototype-formatrange.js -> adds line breaks, improvement
- live-examples/js-examples/intl/intl-datetimeformat-prototype-formattoparts.js -> adds line breaks, improvement
- live-examples/js-examples/intl/intl-datetimeformat.js -> adds line breaks, improvement
- live-examples/js-examples/intl/intl-displaynames.js -> adds line breaks, neutral change
- live-examples/js-examples/intl/intl-listformat-prototype-formattoparts.js -> adds line breaks, improvement
- live-examples/js-examples/intl/intl-listformat.js -> adds line breaks, improvement
- live-examples/js-examples/intl/intl-locale-prototype-tostring.js -> adds line breaks, improvement
- live-examples/js-examples/intl/intl-numberformat.js -> adds line breaks, improvement
- live-examples/js-examples/intl/intl-segmenter-prototype-segment.js -> adds line breaks, improvement
- live-examples/js-examples/json/json-stringify.js -> adds line breaks, improvement
- live-examples/js-examples/map/map-groupby.js -> adds line breaks, improvement
- live-examples/js-examples/promise/promise-allsettled.js -> adds line breaks, improvement
- live-examples/js-examples/reflect/reflect-apply.js -> adds line breaks, improvement
- live-examples/js-examples/statement/statement-async-for-in.js -> not used in content
- live-examples/js-examples/string/string-at.js -> modified to fit line wrap
- live-examples/js-examples/string/string-charcodeat.js -> modified, still wraps but is acceptable
- live-examples/js-examples/string/string-includes.js -> adds line breaks, neutral change
- live-examples/js-examples/string/string-indexof.js -> adds line breaks, neutral change
- live-examples/js-examples/string/string-lastindexof.js -> adds line breaks, neutral change
- live-examples/js-examples/string/string-replace.js -> adds line breaks, neutral change
- live-examples/js-examples/string/string-replaceall.js -> adds line breaks, neutral change
- live-examples/js-examples/string/string-search.js -> adds line breaks, neutral change
- live-examples/js-examples/symbol/symbol-split.js -> adds line breaks, neutral change
- live-examples/js-examples/typedarray/typedarray-at.js -> modified to fit line wrap
- live-examples/js-examples/typedarray/typedarray-reduceright.js -> adds line breaks, improvement
- live-examples/js-examples/typedarray/typedarray-tolocalestring.js -> adds line breaks, improvement
- live-examples/js-examples/weakref/weakref.js -> modified to fit line wrap
- live-examples/wat-examples/numeric/and.js -> adds indentation fix, wrapping / readability improvement
- live-examples/wat-examples/numeric/clz.js -> adds indentation fix, wrapping / readability improvement
- live-examples/wat-examples/numeric/ctz.js -> adds indentation fix, wrapping / readability improvement
- live-examples/wat-examples/numeric/or.js -> adds indentation fix, wrapping / readability improvement
- live-examples/wat-examples/numeric/popcnt.js -> adds indentation fix, wrapping / readability improvement
- live-examples/wat-examples/numeric/rotl.js -> adds indentation fix, wrapping / readability improvement
- live-examples/wat-examples/numeric/rotr.js -> adds indentation fix, wrapping / readability improvement
- live-examples/wat-examples/numeric/shl.js -> adds indentation fix, wrapping / readability improvement
- live-examples/wat-examples/numeric/shr.js -> adds indentation fix, wrapping / readability improvement
- live-examples/wat-examples/numeric/xor.js -> adds indentation fix, wrapping / readability improvement
- live-examples/wat-examples/statements/block.js -> adds indentation fix, wrapping / readability improvement
- live-examples/webapi-examples/url/url-prototype-password.js -> not used in content, using example.com domain
- live-examples/webapi-examples/url/url-prototype-search.js -> not used in content, using example.com domain
- live-examples/webapi-examples/url/url-prototype-searchparams.js -> not used in content, using example.com domain
- live-examples/webapi-examples/url/url-prototype-username.js -> not used in content, using example.com domain
</details>



### Related issues and pull requests

- [x] https://github.com/mdn/interactive-examples/pull/2633
