### PR TITLE
Fix: expected output comments for indexOf example

### DIFF
--- a/live-examples/js-examples/string/string-indexof.js
+++ b/live-examples/js-examples/string/string-indexof.js
@@ -4,7 +4,7 @@ const searchTerm = 'dog';
 const indexOfFirst = paragraph.indexOf(searchTerm);
 
 console.log(`The index of the first "${searchTerm}" is ${indexOfFirst}`);
-// Expected output: "The index of the first "dog" is 7"
+// Expected output: "The index of the first "dog" is 15"
 
 console.log(
   `The index of the second "${searchTerm}" is ${paragraph.indexOf(
@@ -12,4 +12,4 @@ console.log(
     indexOfFirst + 1,
   )}`,
 );
-// Expected output: "The index of the second "dog" is 41"
+// Expected output: "The index of the second "dog" is 38"


### PR DESCRIPTION
### Description
The comments stated that the first occurrence of the search term "dog" should be at index 7, and the second occurrence at index 41. However, the correct values should be 15 for the first occurrence and 38 for the second occurrence.

<!-- ✍️ Summarize your changes in one or two sentences -->


### Related issues and pull requests

incorrect expected output comments in the indexOf example [Fixes mdn/interactive-examples#2654](https://github.com/mdn/interactive-examples/issues/2654)
