### PR TITLE
string-indexof.js - comments don't match output

### DIFF
--- a/live-examples/js-examples/string/string-indexof.js
+++ b/live-examples/js-examples/string/string-indexof.js
@@ -4,7 +4,7 @@ const searchTerm = 'dog';
 const indexOfFirst = paragraph.indexOf(searchTerm);
 
 console.log(`The index of the first "${searchTerm}" is ${indexOfFirst}`);
-// Expected output: "The index of the first "dog" is 7"
+// Expected output: "The index of the first "dog" is 15"
 
 console.log(
   `The index of the second "${searchTerm}" is ${paragraph.indexOf(
@@ -12,4 +12,4 @@ console.log(
     indexOfFirst + 1,
   )}`,
 );
-// Expected output: "The index of the second "dog" is 41"
+// Expected output: "The index of the second "dog" is 38"


### PR DESCRIPTION
Fixes https://github.com/mdn/interactive-examples/issues/2654

The example is used in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf so you can easily see that the values don't match the expected output.