### PR TITLE
fix(css): improve contrast of margin-block

### DIFF
--- a/live-examples/css-examples/logical-properties/margin-block.css
+++ b/live-examples/css-examples/logical-properties/margin-block.css
@@ -12,6 +12,7 @@
   display: inline-block;
   border: solid #ce7777 10px;
   background-color: #2b3a55;
+  color: #ffffff;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
### Description
Make the text inside the rows at [margin-block-start](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-block-start) and [margin-block-end](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-block-end) examples white.

### Motivation
To prevent the text from becoming black color at light mode causing contrast issues

### Related issues and pull requests
#2054

