### PR TITLE
[CSS] Add interactive examples for text-indent values `each-line` and `hanging`

### DIFF
--- a/live-examples/css-examples/text/text-indent.css
+++ b/live-examples/css-examples/text/text-indent.css
@@ -1,9 +1,10 @@
 #output section {
-  font-size: 1em;
+  font-size: 1.25em;
 }
 
 #example-element {
   text-align: left;
   margin-left: 3em;
-  background-color: #808080;
+  background-color: darkslateblue;
+  color: white;
 }

--- a/live-examples/css-examples/text/text-indent.css
+++ b/live-examples/css-examples/text/text-indent.css
@@ -1,10 +1,12 @@
 #output section {
   font-size: 1.25em;
+  background-color: darkslateblue;
+  align-items: start;
 }
 
 #example-element {
   text-align: left;
-  margin-left: 3em;
-  background-color: darkslateblue;
+  margin: 0 0 0 3em;
+  background-color: slateblue;
   color: white;
 }

--- a/live-examples/css-examples/text/text-indent.css
+++ b/live-examples/css-examples/text/text-indent.css
@@ -1,12 +1,12 @@
 #output section {
   font-size: 1.25em;
-  background-color: darkslateblue;
+  background-color: #483d8b;
   align-items: start;
 }
 
 #example-element {
   text-align: left;
   margin: 0 0 0 3em;
-  background-color: slateblue;
+  background-color: #6a5acd;
   color: white;
 }

--- a/live-examples/css-examples/text/text-indent.css
+++ b/live-examples/css-examples/text/text-indent.css
@@ -1,8 +1,9 @@
 #output section {
-  font-size: 1.5em;
+  font-size: 1em;
 }
 
 #example-element {
   text-align: left;
   margin-left: 3em;
+  background-color: #808080;
 }

--- a/live-examples/css-examples/text/text-indent.html
+++ b/live-examples/css-examples/text/text-indent.html
@@ -45,8 +45,11 @@
 <div id="output" class="output hidden">
   <section id="default-example">
     <div id="example-element">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ac dolor fermentum.</p>
-      <p>Curabitur sed eleifend libero. Donec iaculis dignissim egestas.</p>
+      <p>This text is contained within a single paragraph. This paragraph is two sentences long.</p>
+      <p>
+        This text starts a new paragraph. Within this paragraph and after this sentence, there will be a
+        <code>&lt;br&gt;</code> line break element.<br />There it was! How did that affect this paragraph's indentation?
+      </p>
     </div>
   </section>
 </div>

--- a/live-examples/css-examples/text/text-indent.html
+++ b/live-examples/css-examples/text/text-indent.html
@@ -38,12 +38,8 @@
 <div id="output" class="output hidden">
   <section id="default-example">
     <div id="example-element">
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ac dolor fermentum.
-      </p>
-      <p>
-        Curabitur sed eleifend libero. Donec iaculis dignissim egestas.
-      </p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ac dolor fermentum.</p>
+      <p>Curabitur sed eleifend libero. Donec iaculis dignissim egestas.</p>
     </div>
   </section>
 </div>

--- a/live-examples/css-examples/text/text-indent.html
+++ b/live-examples/css-examples/text/text-indent.html
@@ -47,8 +47,8 @@
     <div id="example-element">
       <p>This text is contained within a single paragraph. This paragraph is two sentences long.</p>
       <p>
-        This text starts a new paragraph. Within this paragraph and after this sentence, there will be a
-        <code>&lt;br&gt;</code> line break element.<br />There it was! How did that affect this paragraph's indentation?
+        Within this new paragraph and after this sentence, there is a
+        <code>&lt;br&gt;</code> line break element.<br />There it was! How did that affect the indentation?
       </p>
     </div>
   </section>

--- a/live-examples/css-examples/text/text-indent.html
+++ b/live-examples/css-examples/text/text-indent.html
@@ -33,6 +33,13 @@
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">text-indent: 3em hanging each-line;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
 </section>
 
 <div id="output" class="output hidden">

--- a/live-examples/css-examples/text/text-indent.html
+++ b/live-examples/css-examples/text/text-indent.html
@@ -19,13 +19,30 @@
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">text-indent: 3em each-line;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">text-indent: 3em hanging;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
 </section>
 
 <div id="output" class="output hidden">
   <section id="default-example">
-    <div>
-      <p id="example-element">
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt.
+    <div id="example-element">
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ac dolor fermentum.
+      </p>
+      <p>
+        Curabitur sed eleifend libero. Donec iaculis dignissim egestas.
       </p>
     </div>
   </section>

--- a/live-examples/css-examples/text/text-indent.html
+++ b/live-examples/css-examples/text/text-indent.html
@@ -47,8 +47,8 @@
     <div id="example-element">
       <p>This text is contained within a single paragraph. This paragraph is two sentences long.</p>
       <p>
-        This is a new paragraph. There is a line break element <code>&lt;br&gt;</code>
-        after this sentence.<br />There it is! Notice how it affects the indentation.
+        This is a new paragraph. There is a line break element <code>&lt;br&gt;</code> after this sentence.<br />There
+        it is! Notice how it affects the indentation.
       </p>
     </div>
   </section>

--- a/live-examples/css-examples/text/text-indent.html
+++ b/live-examples/css-examples/text/text-indent.html
@@ -47,8 +47,8 @@
     <div id="example-element">
       <p>This text is contained within a single paragraph. This paragraph is two sentences long.</p>
       <p>
-        Within this new paragraph and after this sentence, there is a
-        <code>&lt;br&gt;</code> line break element.<br />There it was! How did that affect the indentation?
+        This is a new paragraph. There is a line break element <code>&lt;br&gt;</code>
+        after this sentence.<br />There it is! Notice how it affects the indentation.
       </p>
     </div>
   </section>


### PR DESCRIPTION
#### Summary

Updates the `text-indent` interactive example to show usage of `each-line` and `hanging`. Also makes the indentation amount for all examples clearer with the addition of a background color behind the text.

#### Related issues

Parent issue: https://github.com/mdn/content/issues/30337

The three relevant PRs:
1. https://github.com/mdn/browser-compat-data/pull/21309
2. https://github.com/mdn/interactive-examples/pull/2668
3. https://github.com/mdn/content/pull/30433
