### PR TITLE
chore(ci): Switch to weekly cron for idle issues

### DIFF
--- a/.github/workflows/idle.yml
+++ b/.github/workflows/idle.yml
@@ -2,7 +2,7 @@ name: 'Label idle issues'
 
 on:
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 10 * * 1'
 
 jobs:
   mark-as-idle:


### PR DESCRIPTION
I'm not sure if we need this workflow running daily, maybe a weekly schedule is sufficient:

* `0 10 * * 1` -> https://crontab.guru/#0_10_*_*_1