### PR TITLE
Removed comma in try it example on Web/JavaScript/Reference/Global_Objects/Map/groupBy 

### DIFF
--- a/live-examples/js-examples/map/map-groupby.js
+++ b/live-examples/js-examples/map/map-groupby.js
@@ -9,7 +9,7 @@ const inventory = [
 const restock = { restock: true };
 const sufficient = { restock: false };
 const result = Map.groupBy(inventory, ({ quantity }) =>
-  quantity < 6 ? restock : sufficient,
+  quantity < 6 ? restock : sufficient
 );
 console.log(result.get(restock));
 // [{ name: "bananas", type: "fruit", quantity: 5 }]


### PR DESCRIPTION
Removed comma in the [Try it](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy#try_it) example callbackFn.

Updated the [Using Map.groupBy()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy#using_map.groupby) example in this [PR](https://github.com/mdn/content/pull/30726).

