### PR TITLE
Fix typo of word calculate

### DIFF
--- a/live-examples/wat-examples/numeric/abs.wat
+++ b/live-examples/wat-examples/numeric/abs.wat
@@ -3,7 +3,7 @@
   (func $main
 
     f32.const -10 ;; load a number onto the stack
-    f32.abs ;; caluculate the absolute value
+    f32.abs ;; calculate the absolute value
     call $log ;; log the result
 
   )

--- a/live-examples/wat-examples/numeric/max.wat
+++ b/live-examples/wat-examples/numeric/max.wat
@@ -5,7 +5,7 @@
     f32.const 10
     f32.const 2
 
-    f32.max ;; caluculat the higher number
+    f32.max ;; calculate the higher number
     call $log ;; log the result
   )
   (start $main)

--- a/live-examples/wat-examples/numeric/min.wat
+++ b/live-examples/wat-examples/numeric/min.wat
@@ -5,7 +5,7 @@
     f32.const 10
     f32.const 2
 
-    f32.min ;; caluculat the lower number
+    f32.min ;; calculate the lower number
     call $log ;; log the result
   )
   (start $main)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Fix typo of word calculate on 3 of the WASM numeric examples

### Motivation

I noticed it was wrong, and I wanted to improve the polish of this project.

### Additional details

https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Numeric/Min
https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Numeric/Max
https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Numeric/Absolute

### Related issues and pull requests


