### PR TITLE
fix(html): use `<textarea>` in spellcheck example

### DIFF
--- a/live-examples/html-examples/global-attributes/attribute-spellcheck.html
+++ b/live-examples/html-examples/global-attributes/attribute-spellcheck.html
@@ -1,3 +1,3 @@
-<p contenteditable spellcheck="true">This exampull will be checkd fur spellung when you try to edit it.</p>
+<textarea spellcheck="true">This exampull will be checkd fur spellung when you try to edit it.</textarea>
 
-<p contenteditable spellcheck="false">This exampull will nut be checkd fur spellung when you try to edit it.</p>
+<textarea spellcheck="false">This exampull will nut be checkd fur spellung when you try to edit it.</textarea>


### PR DESCRIPTION
- related to https://github.com/mdn/content/pull/30772

`<textarea>` is the most suitable for this demo as spellchecking on it [is supported on more devices than any other element](https://github.com/mdn/content/issues/19285). 