### PR TITLE
Fixes Japanese example sentence

### DIFF
--- a/live-examples/css-examples/text/word-break.html
+++ b/live-examples/css-examples/text/word-break.html
@@ -29,7 +29,7 @@
     <div id="example-element" class="transition-all">
       Honorificabilitudinitatibus califragilisticexpialidocious
       Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu
-      次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉
+      グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉
     </div>
   </section>
 </div>


### PR DESCRIPTION
### Description

The current Japanese text "次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉" means "**Next word really big word** in United Kingdom of Great Britain and Northern Ireland". The correct word is long, not big. And the character "で" is wrong, correct character is "は".

Correct Japanese text is "グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉" that means "The United Kingdom of Great Britain and Northern Ireland is a really long word".

### Motivation

### Additional details

- refs. https://github.com/mdn/content/blob/main/files/en-us/web/css/word-break/index.md?plain=1#L63

### Related issues and pull requests