### PR TITLE
Add return_call example for WASM

### DIFF
--- a/live-examples/wat-examples/statements/call.wat
+++ b/live-examples/wat-examples/statements/call.wat
@@ -1,10 +1,12 @@
 (module
+  ;; Import the `greet` function from the environment
   (import "env" "greet" (func $greet))
 
   (func
-    ;; call the greet function
+    ;; Call the imported `greet` function
     call $greet
   )
 
-  (start 1) ;; run the first function automatically
+  ;; Automatically run the first function when the module starts
+  (start 1)
 )

--- a/live-examples/wat-examples/statements/meta.json
+++ b/live-examples/wat-examples/statements/meta.json
@@ -63,6 +63,13 @@
       "title": "Wat Demo: return",
       "type": "wat"
     },
+    "return_call": {
+      "watExampleCode": "./live-examples/wat-examples/statements/return_call.wat",
+      "jsExampleCode": "./live-examples/wat-examples/statements/return_call.js",
+      "fileName": "return_call.html",
+      "title": "Wat Demo: return_call",
+      "type": "wat"
+    },
     "select": {
       "watExampleCode": "./live-examples/wat-examples/statements/select.wat",
       "jsExampleCode": "./live-examples/wat-examples/statements/select.js",

--- a/live-examples/wat-examples/statements/return_call.js
+++ b/live-examples/wat-examples/statements/return_call.js
@@ -1,0 +1,11 @@
+const url = '{%wasm-url%}';
+await WebAssembly.instantiateStreaming(fetch(url), {
+  env: {
+    fac: function (x) {
+      if (x === 0) {
+        return 1;
+      }
+      return x * this.fac(x - 1);
+    },
+  },
+});

--- a/live-examples/wat-examples/statements/return_call.js
+++ b/live-examples/wat-examples/statements/return_call.js
@@ -3,3 +3,4 @@ const { instance } = await WebAssembly.instantiateStreaming(fetch(url));
 const result = instance.exports.fac(5n);
 
 console.log(result);
+// Expected output: 120n

--- a/live-examples/wat-examples/statements/return_call.js
+++ b/live-examples/wat-examples/statements/return_call.js
@@ -1,4 +1,5 @@
 const url = '{%wasm-url%}';
 const { instance } = await WebAssembly.instantiateStreaming(fetch(url));
 const result = instance.exports.fac(5n);
+
 console.log(result);

--- a/live-examples/wat-examples/statements/return_call.js
+++ b/live-examples/wat-examples/statements/return_call.js
@@ -1,11 +1,4 @@
 const url = '{%wasm-url%}';
-await WebAssembly.instantiateStreaming(fetch(url), {
-  env: {
-    fac: function (x) {
-      if (x === 0) {
-        return 1;
-      }
-      return x * this.fac(x - 1);
-    },
-  },
-});
+const { instance } = await WebAssembly.instantiateStreaming(fetch(url));
+const result = instance.exports.fac(5n);
+console.log(result);

--- a/live-examples/wat-examples/statements/return_call.wat
+++ b/live-examples/wat-examples/statements/return_call.wat
@@ -1,12 +1,17 @@
 (module
+  ;; Calculate the factorial of a number
   (func $fac (export "fac") (param $x i64) (result i64)
+    ;; Call the `fac-aux` function with $x and 1 parameters
     (return_call $fac-aux (local.get $x) (i64.const 1))
   )
 
+  ;; Perform the factorial calculation
   (func $fac-aux (param $x i64) (param $r i64) (result i64)
+    ;; If $x is zero, return the accumulated result $r
     (if (result i64) (i64.eqz (local.get $x))
       (then (return (local.get $r)))
       (else
+        ;; Otherwise, recursively call `fac-aux` with $x-1 and $x*$r
         (return_call $fac-aux
           (i64.sub (local.get $x) (i64.const 1))
           (i64.mul (local.get $x) (local.get $r))

--- a/live-examples/wat-examples/statements/return_call.wat
+++ b/live-examples/wat-examples/statements/return_call.wat
@@ -4,7 +4,7 @@
   )
 
   (func $fac-aux (param $x i64) (param $r i64) (result i64)
-    (if (i64.eqz (local.get $x))
+    (if (result i64) (i64.eqz (local.get $x))
       (then (return (local.get $r)))
       (else
         (return_call $fac-aux

--- a/live-examples/wat-examples/statements/return_call.wat
+++ b/live-examples/wat-examples/statements/return_call.wat
@@ -1,0 +1,17 @@
+(module
+  (func $fac (export "fac") (param $x i64) (result i64)
+    (return_call $fac-aux (local.get $x) (i64.const 1))
+  )
+
+  (func $fac-aux (param $x i64) (param $r i64) (result i64)
+    (if (i64.eqz (local.get $x))
+      (then (return (local.get $r)))
+      (else
+        (return_call $fac-aux
+          (i64.sub (local.get $x) (i64.const 1))
+          (i64.mul (local.get $x) (local.get $r))
+        )
+      )
+    )
+  )
+)


### PR DESCRIPTION
### Description

Adds example for `return_call`, tail call version of the `call`. I took it [from the explainer](https://github.com/WebAssembly/tail-call/blob/main/proposals/tail-call/Overview.md#examples).

But there’s a catch: the playground shows an error when I try to run the code. There might be two reasons for that:

- I don’t fully understand what I’m doing (first time looking at WASM)
- Playground doesn’t support `return_call`, see the error below

### Motivation

To support enabled tail calls in Firefox 121.

### Additional details

```
> Error: parseWat failed:
3:6: error: opcode not allowed: return_call
    (return_call $fac-aux (local.get $x) (i32.const 1))
     ^^^^^^^^^^^
10:10: error: opcode not allowed: return_call
        (return_call $fac-aux
         ^^^^^^^^^^^
```

### Related issues and pull requests

- https://github.com/mdn/content/issues/30333
- https://github.com/mdn/content/pull/36288