### PR TITLE
fix(js): ignore formatting empty statement example with code comment

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 CHANGELOG.md
 docs/
 live-examples/html-examples/inline-text-semantics/rtc.html
+live-examples/js-examples/statement/statement-empty.js

--- a/live-examples/js-examples/statement/statement-empty.js
+++ b/live-examples/js-examples/statement/statement-empty.js
@@ -1,7 +1,7 @@
 const array1 = [1, 2, 3];
 
 // Assign all array values to 0
-for (let i = 0; i < array1.length; array1[i++] = 0 /* empty statement */);
+for (let i = 0; i < array1.length; array1[i++] = 0) /* empty statement */ ;
 
 console.log(array1);
 // Expected output: Array [0, 0, 0]


### PR DESCRIPTION
moved the comment to a new position which (i) makes more sense and (ii) is where the identical comment is located in the other code snippet on the same MDN page (see: https://github.com/mdn/content/blob/63a26b042a4d27c1038060c4ea8b605e188a5787/files/en-us/web/javascript/reference/statements/empty/index.md?plain=1#L41C17-L41C17 )

![image](https://github.com/mdn/interactive-examples/assets/148152939/04c4013d-5a12-4071-a25d-ba985cd1d495)

![image](https://github.com/mdn/interactive-examples/assets/148152939/c6764190-ada1-4f86-a81c-88232cee5aa4)


