### PR TITLE
fix link in audio.html

### DIFF
--- a/live-examples/html-examples/image-and-multimedia/audio.html
+++ b/live-examples/html-examples/image-and-multimedia/audio.html
@@ -1,6 +1,5 @@
 <figure>
   <figcaption>Listen to the T-Rex:</figcaption>
-  <audio controls src="/media/cc0-audio/t-rex-roar.mp3">
-    <a href="/media/cc0-audio/t-rex-roar.mp3"> Download audio </a>
-  </audio>
+  <audio controls src="/media/cc0-audio/t-rex-roar.mp3"></audio>
+  <a href="/media/cc0-audio/t-rex-roar.mp3"> Download audio </a>
 </figure>


### PR DESCRIPTION
### Description

Moved the download link outside the &lt;audio&gt; element.

### Motivation

The &lt;a&gt; tag was functioning incorrectly within the &lt;audio&gt; element. After the changes, the link works correctly

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

No additional details are required for this modification.

Before:  
![image](https://github.com/mdn/interactive-examples/assets/97907825/202a4121-c634-4e0b-b80a-05f3aaed3001)  
After:  
![image](https://github.com/mdn/interactive-examples/assets/97907825/42b23e6a-eb95-44de-bcdc-cda5ece4d6f8)
