### PR TITLE
button.html - remove css class favourites

### DIFF
--- a/live-examples/html-examples/input/button.html
+++ b/live-examples/html-examples/input/button.html
@@ -1,1 +1,1 @@
-<input class="favorite styled" type="button" value="Add to favorites" />
+<input class="styled" type="button" value="Add to favorites" />


### PR DESCRIPTION
The example is used in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#try_it. Note that the class "favorite" is not actually referenced by any CSS - so it is confusing and pointless.

Fixes https://github.com/mdn/interactive-examples/issues/2706