### PR TITLE
respect example domains in RFC 6761

### DIFF
--- a/live-examples/css-examples/pseudo-element/after.html
+++ b/live-examples/css-examples/pseudo-element/after.html
@@ -1,9 +1,11 @@
+<h2>Example Domain</h2>
 <p>
-  The sailfish is named for its sail-like dorsal fin and is widely considered the fastest fish in the ocean.
-  <a href="https://en.wikipedia.org/wiki/Sailfish">You can read more about it here</a>.
+  This domain is for use in illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.
+  <a href="https://www.iana.org/domains/example">More information...</a>
 </p>
 
+<h2>Example Domain</h2>
 <p>
-  The red lionfish is a predatory scorpionfish that lives on coral reefs of the Indo-Pacific Ocean and more recently in
-  the western Atlantic. <a href="" class="dead-link">You can read more about it here</a>.
+  This domain is for use in illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.
+  <a href="" class="dead-link">More information...</a>
 </p>

--- a/live-examples/html-examples/inline-text-semantics/q.html
+++ b/live-examples/html-examples/inline-text-semantics/q.html
@@ -1,6 +1,6 @@
 <p>
-  When Dave asks HAL to open the pod bay door, HAL answers:
-  <q cite="https://www.imdb.com/title/tt0062622/quotes/?item=qt0396921&ref_=ext_shr_lnk">
-    I'm sorry, Dave. I'm afraid I can't do that.
+  Example Domain is aimed for
+  <q cite="https://example.com/">
+    use in illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.
   </q>
 </p>

--- a/live-examples/webapi-examples/url/url.js
+++ b/live-examples/webapi-examples/url/url.js
@@ -1,12 +1,12 @@
-const url = new URL('https://en.wikipedia.org/wiki/Mozilla#Software');
+const url = new URL('https://example.com/path/to/file#Software');
 console.log(url.protocol);
 // expected output: "https:"
 
 console.log(url.hostname);
-// expected output: "en.wikipedia.org"
+// expected output: "example.com"
 
 console.log(url.pathname);
-// expected output: "/wiki/Mozilla"
+// expected output: "/path/to/file"
 
 console.log(url.hash);
 // expected output: "#Software"


### PR DESCRIPTION
### Description

Replace some real domains in documentation with example domains.

### Motivation

Respect "example domain" defined in [RFC 6761](https://datatracker.ietf.org/doc/html/rfc6761).

### Additional details

https://github.com/orgs/mdn/discussions/450

### Related issues and pull requests

#2650 
