### PR TITLE
31103 rect xywh

### DIFF
--- a/live-examples/css-examples/masking/clip-path.html
+++ b/live-examples/css-examples/masking/clip-path.html
@@ -26,6 +26,20 @@
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">clip-path: rect(5px 5px 210px 220px round 20%);</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">clip-path: xywh(0 20% 100% 67% round 5%);</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
 </section>
 
 <div id="output" class="output large hidden">

--- a/live-examples/css-examples/masking/clip-path.html
+++ b/live-examples/css-examples/masking/clip-path.html
@@ -28,14 +28,14 @@
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">clip-path: rect(5px 5px 210px 220px round 20%);</code></pre>
+    <pre><code class="language-css">clip-path: rect(5px 5px 160px 145px round 20%);</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">clip-path: xywh(0 20% 100% 67% round 5%);</code></pre>
+    <pre><code class="language-css">clip-path: xywh(0 5px 100% 75% round 15% 0);</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>


### PR DESCRIPTION
### Description

Added examples of `rect()` & `xywh()` to the `clip-path` CSS example

### Motivation

Working on [Issue 31103](https://github.com/mdn/content/issues/31103)

### Related issues and pull requests

- [BCD PR](https://github.com/mdn/browser-compat-data/pull/21877)
- [Content PR](https://github.com/mdn/content/pull/31663)
- [Content Firefox release PR](https://github.com/mdn/content/pull/31661)
