### PR TITLE
Add example of `text-wrap`

### DIFF
--- a/live-examples/css-examples/text/meta.json
+++ b/live-examples/css-examples/text/meta.json
@@ -98,6 +98,13 @@
       "title": "CSS Demo: text-transform",
       "type": "css"
     },
+    "textWrap": {
+      "cssExampleSrc": "./live-examples/css-examples/text/text-wrap.css",
+      "exampleCode": "./live-examples/css-examples/text/text-wrap.html",
+      "fileName": "text-wrap.html",
+      "title": "CSS Demo: text-wrap",
+      "type": "css"
+    },
     "userSelect": {
       "cssExampleSrc": "./live-examples/css-examples/text/user-select.css",
       "exampleCode": "./live-examples/css-examples/text/user-select.html",

--- a/live-examples/css-examples/text/text-wrap.css
+++ b/live-examples/css-examples/text/text-wrap.css
@@ -1,0 +1,4 @@
+#example-element {
+  border: 1px solid #c5c5c5;
+  width: 250px;
+}

--- a/live-examples/css-examples/text/text-wrap.css
+++ b/live-examples/css-examples/text/text-wrap.css
@@ -1,3 +1,10 @@
+.whole-content-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
 #example-element {
   border: 1px solid #c5c5c5;
   width: 250px;

--- a/live-examples/css-examples/text/text-wrap.html
+++ b/live-examples/css-examples/text/text-wrap.html
@@ -37,8 +37,13 @@
 
 <div id="output" class="output large hidden">
   <section id="default-example" class="default-example">
-    <div id="example-element" class="transition-all">
-      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatem aut cum eum id quos est.</p>
+    <div class="whole-content-wrapper">
+      <p>Click here to edit the text:</p>
+      <div id="example-element" class="transition-all">
+        <p contenteditable>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatem aut cum eum id quos est.
+        </p>
+      </div>
     </div>
   </section>
 </div>

--- a/live-examples/css-examples/text/text-wrap.html
+++ b/live-examples/css-examples/text/text-wrap.html
@@ -1,0 +1,44 @@
+<section id="example-choice-list" class="example-choice-list large" data-property="text-wrap">
+  <div class="example-choice" initial-choice="true">
+    <pre><code class="language-css">text-wrap: wrap;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">text-wrap: nowrap;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">text-wrap: balance;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">text-wrap: pretty;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">text-wrap: stable;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+</section>
+
+<div id="output" class="output large hidden">
+  <section id="default-example" class="default-example">
+    <div id="example-element" class="transition-all">
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatem aut cum eum id quos est.</p>
+    </div>
+  </section>
+</div>

--- a/live-examples/css-examples/text/text-wrap.html
+++ b/live-examples/css-examples/text/text-wrap.html
@@ -38,7 +38,7 @@
 <div id="output" class="output large hidden">
   <section id="default-example" class="default-example">
     <div class="whole-content-wrapper">
-      <p>Click here to edit the text:</p>
+      <p>Edit the text in the box:</p>
       <div id="example-element" class="transition-all">
         <p contenteditable>
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatem aut cum eum id quos est.


### PR DESCRIPTION
### Description

This PR adds an example of [text-wrap](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap).

### Motivation

There is not an existing example.

### Additional details

![Image](https://github.com/mdn/interactive-examples/assets/123000937/598909ff-7341-446f-acce-09e9ba430116)


### Related issues and pull requests
