### PR TITLE
fix incorrect method parameter '...arguments' with actual parameters (target, prop, receiver)

### DIFF
--- a/live-examples/js-examples/proxyhandler/proxyhandler-get.js
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-get.js
@@ -8,7 +8,7 @@ const handler1 = {
     if (prop === 'secret') {
       return `${target.secret.substring(0, 4)} ... shhhh!`;
     }
-    return Reflect.get(...arguments);
+    return Reflect.get(target, prop, receiver);
   },
 };
 


### PR DESCRIPTION
### Description

The [Proxy documentation page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) currently contains an example which is most likely outdated. The parameter `..arguments` no longer exists. At least, when I used TypeScript it complained that the arguments did not exist. On the other hand, the example itself in the browser still works.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/32790
