### PR TITLE
WAT memory examples - fix await

### DIFF
--- a/live-examples/wat-examples/memory/load.js
+++ b/live-examples/wat-examples/memory/load.js
@@ -1,12 +1,11 @@
 const url = '{%wasm-url%}';
-await WebAssembly.instantiateStreaming(fetch(url)).then((result) => {
-  const load_first_item_in_mem = result.instance.exports.load_first_item_in_mem;
-  const memory = result.instance.exports.memory;
+const result = await WebAssembly.instantiateStreaming(fetch(url));
+const load_first_item_in_mem = result.instance.exports.load_first_item_in_mem;
+const memory = result.instance.exports.memory;
 
-  const dataView = new DataView(memory.buffer);
-  // Store 30 at the beginning of memory
-  dataView.setUint32(0, 30, true);
+const dataView = new DataView(memory.buffer);
+// Store 30 at the beginning of memory
+dataView.setUint32(0, 30, true);
 
-  console.log(load_first_item_in_mem(100));
-  // Expected output: 30
-});
+console.log(load_first_item_in_mem(100));
+// Expected output: 30

--- a/live-examples/wat-examples/memory/store.js
+++ b/live-examples/wat-examples/memory/store.js
@@ -1,13 +1,13 @@
 const url = '{%wasm-url%}';
-await WebAssembly.instantiateStreaming(fetch(url)).then((result) => {
-  const store_in_mem = result.instance.exports.store_in_mem;
-  const memory = result.instance.exports.memory;
+const result = await WebAssembly.instantiateStreaming(fetch(url));
 
-  store_in_mem(100);
+const store_in_mem = result.instance.exports.store_in_mem;
+const memory = result.instance.exports.memory;
 
-  const dataView = new DataView(memory.buffer);
-  const first_number_in_mem = dataView.getUint32(0, true);
+store_in_mem(100);
 
-  console.log(first_number_in_mem);
-  // Expected output: 100
-});
+const dataView = new DataView(memory.buffer);
+const first_number_in_mem = dataView.getUint32(0, true);
+
+console.log(first_number_in_mem);
+// Expected output: 100


### PR DESCRIPTION
This fixes two WASM examples for working for memory.

Specifically these are JavaScript files that use `await` to wait on a returned promise, but then chain off the result using `then` - there is no point doing both, so this removes the "then" and makes it await properly.

There are probably similar examples, but these are the ones I'm looking at for https://github.com/mdn/content/issues/32777