### PR TITLE
Fix 2765: prevent gap from making space-evenly look non-even

### DIFF
--- a/live-examples/css-examples/box-alignment/align-content.css
+++ b/live-examples/css-examples/box-alignment/align-content.css
@@ -3,7 +3,7 @@
   display: grid;
   grid-template-columns: 60px 60px;
   grid-auto-rows: 40px;
-  grid-gap: 10px;
+  column-gap: 10px;
   height: 180px;
 }
 

--- a/live-examples/css-examples/box-alignment/justify-content.css
+++ b/live-examples/css-examples/box-alignment/justify-content.css
@@ -4,7 +4,7 @@
   display: grid;
   grid-template-columns: 60px 60px;
   grid-auto-rows: 40px;
-  grid-gap: 10px;
+  row-gap: 10px;
 }
 
 #example-element > div {

--- a/live-examples/css-examples/box-alignment/place-content.css
+++ b/live-examples/css-examples/box-alignment/place-content.css
@@ -3,7 +3,6 @@
   display: grid;
   grid-template-columns: 60px 60px;
   grid-auto-rows: 40px;
-  grid-gap: 10px;
   height: 180px;
   width: 220px;
 }


### PR DESCRIPTION
Fixes https://github.com/mdn/interactive-examples/issues/2765.

This removes `gap` in `place-content`, `align-content`, `justify-content` when it makes `space-evenly` give non-even results.