### PR TITLE
fix: Improve contrast of SVG element

### DIFF
--- a/live-examples/css-examples/svg/pointer-events.html
+++ b/live-examples/css-examples/svg/pointer-events.html
@@ -38,7 +38,7 @@
       <p>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
           <a xlink:href="#">
-            <circle cx="50" cy="50" r="40" stroke="#ffb500" stroke-width="5" fill="#264653" />
+            <circle cx="50" cy="50" r="40" stroke="#ffb500" stroke-width="5" fill="#3E6E84" />
             <text x="50" y="55" text-anchor="middle" fill="white">SVG</text>
           </a>
         </svg>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Improve contrast of the SVG element's fill to the SVG element's border and page background for issue #2054 
### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->
The SVG element's fill didn't comply with the WCAG contrast criteria. By improving the contrast it now complies with the WCAG AA criteria for Graphical Objects and User Interface Components.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
