### PR TITLE
style example - add second css selector, bolden keyword in example

### DIFF
--- a/live-examples/html-examples/document-metadata/style.html
+++ b/live-examples/html-examples/document-metadata/style.html
@@ -2,6 +2,9 @@
   p {
     color: #26b72b;
   }
+  code {
+    font-weight: bold;
+  }
 </style>
 
 <p>This text will be green. Inline styles take precedence over CSS included externally.</p>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

This PR adds a second CSS selector to the style example, which boldens the style keyword in the example HTML styling.

### Motivation

This serves two purposes: on the HTML code side of the example/demo, it gives an example of using multiple CSS selectors for different elements in a style element.
On the output side, it adds a little touch to bolden the keyword `style` in the description text (which is already expressed as a code element).
![image](https://github.com/mdn/interactive-examples/assets/5124946/5e51d074-0ead-450d-a14b-0122368b5eae)

[NO_TRAIN]::