### PR TITLE
Fix expected output in example for Logical OR assignment (||=) - expressions-logical-or-assignment.js

### DIFF
--- a/live-examples/js-examples/expressions/expressions-logical-or-assignment.js
+++ b/live-examples/js-examples/expressions/expressions-logical-or-assignment.js
@@ -6,4 +6,4 @@ console.log(a.duration);
 
 a.title ||= 'title is empty.';
 console.log(a.title);
-// Expected output: "title is empty"
+// Expected output: "title is empty."


### PR DESCRIPTION
Missing dot in expected output

### Description

So as not to frustrate the reader, this operator is not a variation of the trim method.
When I first read about this method and this example confused me - “why did the dot disappear?”, but RUN put everything in its place.

### Motivation

Perhaps these seconds of frustration will save thousands of developer hours. ;)

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

Perhaps this will be my most significant contribution to open source in my entire life! (one dot in commit)

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
☺️