### PR TITLE
Set `<p>` element's color to `initial` (from CanvasText)

### DIFF
--- a/live-examples/css-examples/pseudo-class/modal.css
+++ b/live-examples/css-examples/pseudo-class/modal.css
@@ -12,5 +12,5 @@ button {
 }
 
 dialog p {
-  color:  #000;
+  color:  black;
 }

--- a/live-examples/css-examples/pseudo-class/modal.css
+++ b/live-examples/css-examples/pseudo-class/modal.css
@@ -11,6 +11,6 @@ button {
   border-radius: 5px;
 }
 
-dialog p {
+p {
   color:  black;
 }

--- a/live-examples/css-examples/pseudo-class/modal.css
+++ b/live-examples/css-examples/pseudo-class/modal.css
@@ -11,6 +11,6 @@ button {
   border-radius: 5px;
 }
 
-dialog p{
-  color: initial;
+dialog p {
+  color:  #000;
 }

--- a/live-examples/css-examples/pseudo-class/modal.css
+++ b/live-examples/css-examples/pseudo-class/modal.css
@@ -5,12 +5,12 @@ button {
   height: 2rem;
 }
 
+dialog p {
+  color:  black;
+}
+
 :modal {
   background-color: beige;
   border: 2px solid burlywood;
   border-radius: 5px;
-}
-
-p {
-  color:  black;
 }

--- a/live-examples/css-examples/pseudo-class/modal.css
+++ b/live-examples/css-examples/pseudo-class/modal.css
@@ -10,3 +10,7 @@ button {
   border: 2px solid burlywood;
   border-radius: 5px;
 }
+
+dialog p{
+  color: initial;
+}

--- a/live-examples/css-examples/pseudo-class/modal.css
+++ b/live-examples/css-examples/pseudo-class/modal.css
@@ -5,7 +5,7 @@ button {
   height: 2rem;
 }
 
-dialog p {
+dialog p{
   color:  black;
 }
 

--- a/live-examples/css-examples/pseudo-class/modal.css
+++ b/live-examples/css-examples/pseudo-class/modal.css
@@ -5,12 +5,12 @@ button {
   height: 2rem;
 }
 
-dialog p{
-  color:  black;
-}
-
 :modal {
   background-color: beige;
   border: 2px solid burlywood;
   border-radius: 5px;
+}
+
+p {
+  color: black;
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Set the `<p>` element's color to `initial` would replace the inherited `CanvasText` color and set to its initial color (black - I guess), making it visible. 

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->
Make paragraph text visible.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->
In case someone considers the changes "not the best practice", [`initial` property is used to reset the color of for an element](https://developer.mozilla.org/en-US/docs/Web/CSS/initial#using_initial_to_reset_color_for_an_element)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #2798 
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
