### PR TITLE
fix: place vendor-prefixed props first in declaration order

### DIFF
--- a/live-examples/css-examples/animation/animation-delay.css
+++ b/live-examples/css-examples/animation/animation-delay.css
@@ -25,19 +25,6 @@
   animation-direction: alternate;
 }
 
-@-webkit-keyframes slide {
-  from {
-    background-color: orange;
-    color: black;
-    margin-left: 0;
-  }
-  to {
-    background-color: orange;
-    color: black;
-    margin-left: 80%;
-  }
-}
-
 @keyframes slide {
   from {
     background-color: orange;

--- a/live-examples/css-examples/animation/animation-direction.css
+++ b/live-examples/css-examples/animation/animation-direction.css
@@ -22,19 +22,6 @@
   font-size: 2rem;
 }
 
-@-webkit-keyframes slide {
-  from {
-    background-color: orange;
-    color: black;
-    margin-left: 0;
-  }
-  to {
-    background-color: orange;
-    color: black;
-    margin-left: 80%;
-  }
-}
-
 @keyframes slide {
   from {
     background-color: orange;

--- a/live-examples/css-examples/animation/animation-duration.css
+++ b/live-examples/css-examples/animation/animation-duration.css
@@ -22,19 +22,6 @@
   font-size: 2rem;
 }
 
-@-webkit-keyframes slide {
-  from {
-    background-color: orange;
-    color: black;
-    margin-left: 0;
-  }
-  to {
-    background-color: orange;
-    color: black;
-    margin-left: 80%;
-  }
-}
-
 @keyframes slide {
   from {
     background-color: orange;

--- a/live-examples/css-examples/animation/animation-fill-mode.css
+++ b/live-examples/css-examples/animation/animation-fill-mode.css
@@ -22,19 +22,6 @@
   animation: slide 1s ease-in 1;
 }
 
-@-webkit-keyframes slide {
-  from {
-    background-color: orange;
-    color: black;
-    margin-left: 0;
-  }
-  to {
-    background-color: orange;
-    color: black;
-    margin-left: 80%;
-  }
-}
-
 @keyframes slide {
   from {
     background-color: orange;

--- a/live-examples/css-examples/animation/animation-iteration-count.css
+++ b/live-examples/css-examples/animation/animation-iteration-count.css
@@ -23,19 +23,6 @@
   animation-timing-function: ease-in;
 }
 
-@-webkit-keyframes slide {
-  from {
-    background-color: orange;
-    color: black;
-    margin-left: 0;
-  }
-  to {
-    background-color: orange;
-    color: black;
-    margin-left: 80%;
-  }
-}
-
 @keyframes slide {
   from {
     background-color: orange;

--- a/live-examples/css-examples/animation/animation-name.css
+++ b/live-examples/css-examples/animation/animation-name.css
@@ -13,19 +13,6 @@
   width: 150px;
 }
 
-@-webkit-keyframes slide {
-  from {
-    background-color: orange;
-    color: black;
-    margin-left: 0;
-  }
-  to {
-    background-color: orange;
-    color: black;
-    margin-left: 80%;
-  }
-}
-
 @keyframes slide {
   from {
     background-color: orange;
@@ -36,19 +23,6 @@
     background-color: orange;
     color: black;
     margin-left: 80%;
-  }
-}
-
-@-webkit-keyframes bounce {
-  from {
-    background-color: orange;
-    color: black;
-    margin-bottom: 0;
-  }
-  to {
-    background-color: orange;
-    color: black;
-    margin-bottom: 40%;
   }
 }
 

--- a/live-examples/css-examples/animation/animation-play-state.css
+++ b/live-examples/css-examples/animation/animation-play-state.css
@@ -17,19 +17,6 @@
   animation-direction: alternate;
 }
 
-@-webkit-keyframes slide {
-  from {
-    background-color: orange;
-    color: black;
-    margin-left: 0;
-  }
-  to {
-    background-color: orange;
-    color: black;
-    margin-left: 80%;
-  }
-}
-
 @keyframes slide {
   from {
     background-color: orange;

--- a/live-examples/css-examples/animation/animation-timing-function.css
+++ b/live-examples/css-examples/animation/animation-timing-function.css
@@ -21,19 +21,6 @@
   font-size: 2rem;
 }
 
-@-webkit-keyframes slide {
-  from {
-    background-color: orange;
-    color: black;
-    margin-left: 0;
-  }
-  to {
-    background-color: orange;
-    color: black;
-    margin-left: 80%;
-  }
-}
-
 @keyframes slide {
   from {
     background-color: orange;

--- a/live-examples/css-examples/animation/animation.css
+++ b/live-examples/css-examples/animation/animation.css
@@ -7,15 +7,6 @@
   border-radius: 50%;
 }
 
-@-webkit-keyframes slidein {
-  from {
-    margin-left: -20%;
-  }
-  to {
-    margin-left: 100%;
-  }
-}
-
 @keyframes slidein {
   from {
     margin-left: -20%;

--- a/live-examples/css-examples/backgrounds-and-borders/background-clip.html
+++ b/live-examples/css-examples/backgrounds-and-borders/background-clip.html
@@ -21,8 +21,7 @@
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">-webkit-background-clip: text;
-background-clip: text;
+    <pre><code class="language-css">background-clip: text;
 color: transparent;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/backgrounds-and-borders/background-clip.html
+++ b/live-examples/css-examples/backgrounds-and-borders/background-clip.html
@@ -21,8 +21,8 @@
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">background-clip: text;
--webkit-background-clip: text;
+    <pre><code class="language-css">-webkit-background-clip: text;
+background-clip: text;
 color: transparent;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>

--- a/live-examples/css-examples/fragmentation/box-decoration-break.html
+++ b/live-examples/css-examples/fragmentation/box-decoration-break.html
@@ -1,18 +1,19 @@
 <section
   id="example-choice-list"
   class="example-choice-list"
-  data-property="box-decoration-break -webkit-box-decoration-break">
+  data-property="-webkit-box-decoration-break box-decoration-break">
   <div class="example-choice">
-    <pre><code class="language-css">box-decoration-break: slice;
--webkit-box-decoration-break: slice;</code></pre>
+    <pre><code class="language-css">-webkit-box-decoration-break: slice;
+box-decoration-break: slice;
+    </code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">box-decoration-break: clone;
--webkit-box-decoration-break: clone;</code></pre>
+    <pre><code class="language-css">-webkit-box-decoration-break: clone;
+box-decoration-break: clone;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>

--- a/live-examples/css-examples/pseudo-class/autofill.css
+++ b/live-examples/css-examples/pseudo-class/autofill.css
@@ -3,10 +3,10 @@ label {
   margin-top: 1em;
 }
 
-input:autofill {
+input:-webkit-autofill {
   border: 3px solid darkorange;
 }
 
-input:-webkit-autofill {
+input:autofill {
   border: 3px solid darkorange;
 }

--- a/live-examples/css-examples/pseudo-class/autofill.css
+++ b/live-examples/css-examples/pseudo-class/autofill.css
@@ -3,10 +3,6 @@ label {
   margin-top: 1em;
 }
 
-input:-webkit-autofill {
-  border: 3px solid darkorange;
-}
-
-input:autofill {
+input:is(:-webkit-autofill, :autofill) {
   border: 3px solid darkorange;
 }


### PR DESCRIPTION
### Motivation

We should be placing vendor-prefixed props first in declaration order, followed by the standard props.

__Changes:__
- re-order declarations when vendor-prefixed prop is required

__Removals:__

- `@-webkit-keyframes` when `@keyframes` exists
- `-webkit-background-clip: text` when `background-clip: text` is supported

### Related issues and pull requests

Fixes https://github.com/mdn/interactive-examples/issues/2797
