### PR TITLE
Demonstrate wrapping with asIntN/asUintN Bigint static methods

### DIFF
--- a/live-examples/js-examples/bigint/bigint-asintn.js
+++ b/live-examples/js-examples/bigint/bigint-asintn.js
@@ -1,12 +1,12 @@
-const max = 2n ** (64n - 1n) - 1n;
+const I64_CEIL = 2n ** 63n;
 
-function check64bit(number) {
-  number > max
-    ? console.log("Number doesn't fit in signed 64-bit integer!")
-    : console.log(BigInt.asIntN(64, number));
-}
-
-check64bit(2n ** 64n);
-// Expected output: "Number doesn't fit in signed 64-bit integer!"
-check64bit(2n ** 32n);
-// Expected output: 4294967296n
+console.log(BigInt.asIntN(64, I64_CEIL - 1n));
+// 9223372036854775807n (2n ** 64n - 1n, the maximum non-wrapping value)
+console.log(BigInt.asIntN(64, I64_CEIL));
+// -9223372036854775808n (wraps to min value)
+console.log(BigInt.asIntN(64, I64_CEIL + 1n));
+// -9223372036854775807n (min value + 1n)
+console.log(BigInt.asIntN(64, I64_CEIL * 2n));
+// 0n (wrapped around to zero)
+console.log(BigInt.asIntN(64, -I64_CEIL * -42n));
+// 0n (also wraps on negative multiples)

--- a/live-examples/js-examples/bigint/bigint-asuintn.js
+++ b/live-examples/js-examples/bigint/bigint-asuintn.js
@@ -1,13 +1,12 @@
-const max = 2n ** 64n - 1n;
+const U64_CEIL = 2n ** 64n;
 
-function check64bit(number) {
-  number > max
-    ? console.log("Number doesn't fit in unsigned 64-bit integer!")
-    : console.log(BigInt.asUintN(64, number));
-}
-
-check64bit(2n ** 64n);
-// Expected output: "Number doesn't fit in unsigned 64-bit integer!"
-
-check64bit(2n ** 32n);
-// Expected output: 4294967296n
+console.log(BigInt.asUintN(64, U64_CEIL - 1n));
+// 18446744073709551615n (2n ** 64n - 1n, the maximum non-wrapping value)
+console.log(BigInt.asUintN(64, U64_CEIL));
+// 0n (wraps to zero)
+console.log(BigInt.asUintN(64, U64_CEIL + 1n));
+// 1n
+console.log(BigInt.asUintN(64, U64_CEIL * 2n));
+// 0n (wraps on multiples)
+console.log(BigInt.asUintN(64, U64_CEIL * -42n));
+// 0n (also wraps on negative multiples)


### PR DESCRIPTION
### Description

Demonstrate wrapping with asIntN/asUintN Bigint static methods

### Motivation

Current examples fail to demonstrate the main use case for `asIntN` and `asUintN`, namely wrapping. The `number > max` check in the function means the number will never wrap, so there's no point in calling `asIntN`/`asUintN`. Also, the check is buggy, given that it only checks the max and not the min (`-1n` doesn't fit in a u64, and `-9223372036854775809n` doesn't fit in an i64, yet neither would trigger the "Number doesn't fit" path).

### Additional details

N/A

### Related issues and pull requests

N/A