### PR TITLE
fix(ci): check dependabot PR user instead of actor

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -5,7 +5,7 @@ on: [pull_request_target]
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - uses: ahmadnassri/action-dependabot-auto-merge@v2


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Modify the automerge to check on dependabot user instead of actor to prevent force pushes from forks

### Motivation

Make sure automerging only works for dependabot

### Additional details

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1914746

### Related issues and pull requests

(MP-1479)