### PR TITLE
fix: improve color contrast in menu element example for accessibility

### DIFF
--- a/live-examples/html-examples/interactive-elements/css/menu.css
+++ b/live-examples/html-examples/interactive-elements/css/menu.css
@@ -1,5 +1,5 @@
 .news {
-  background-color: bisque;
+  background-color: black;
   padding: 1em;
   border: solid thin black;
 }

--- a/live-examples/html-examples/interactive-elements/css/menu.css
+++ b/live-examples/html-examples/interactive-elements/css/menu.css
@@ -1,7 +1,11 @@
 .news {
-  background-color: black;
+  background-color: bisque;
   padding: 1em;
   border: solid thin black;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: black;
+  }
 }
 
 menu {
@@ -10,4 +14,9 @@ menu {
   padding: 0;
   margin-bottom: 0;
   gap: 1em;
+}
+
+button {
+  color: black;
+  background: white;
 }


### PR DESCRIPTION
### Description

I changed the background color of the `menu` element example from bisque to black to fix the inaccessible color contrast issue, improving readability and meeting WCAG 2.1 contrast ratio standards.

### Motivation

The previous background color did not meet the minimum contrast ratio requirement, making the text difficult to read for users with visual impairments (and even hard for normal users). This change improves accessibility across browsers.

### Additional details

- [MDN menu element example](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu#try_it)  
- The issue is reproducible on macOS Monterey using Safari 17.5, Chrome 128.0.6613.138, and Firefox 130.0.

### Related issues and pull requests

Fixes #2839 
