### PR TITLE
Remove unnecessary CSS property

### DIFF
--- a/live-examples/html-examples/global-attributes/css/attribute-accesskey.css
+++ b/live-examples/html-examples/global-attributes/css/attribute-accesskey.css
@@ -1,4 +1,3 @@
 b {
-  font-weight: bold;
   text-decoration: underline;
 }


### PR DESCRIPTION
### Description

Removes useless style property

### Motivation

In addition to #2842

For some reason I've included `font-weight: bold` for the `<b>` element

It was unintentional