### PR TITLE
CSS live examples: color contrast improvements

### DIFF
--- a/live-examples/css-examples/container/content-visibility.css
+++ b/live-examples/css-examples/container/content-visibility.css
@@ -11,6 +11,7 @@
 .child {
   border: 3px solid rgb(64, 28, 163);
   background-color: wheat;
+  color: black;
   width: 80%;
   height: 80%;
   display: flex;

--- a/live-examples/css-examples/filter-effects/filter.css
+++ b/live-examples/css-examples/filter-effects/filter.css
@@ -1,0 +1,13 @@
+.example-container {
+  background-color: #fff;
+  width: 260px;
+  height: 260px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#example-element {
+  flex: 1;
+  padding: 30px;
+}

--- a/live-examples/css-examples/filter-effects/filter.html
+++ b/live-examples/css-examples/filter-effects/filter.html
@@ -44,6 +44,8 @@
 
 <div id="output" class="output large hidden">
   <section id="default-example">
-    <img id="example-element" src="../../media/examples/firefox-logo.svg" width="200" />
+    <div class="example-container">
+      <img id="example-element" src="../../media/examples/firefox-logo.svg" width="200" />
+    </div>
   </section>
 </div>

--- a/live-examples/css-examples/filter-effects/meta.json
+++ b/live-examples/css-examples/filter-effects/meta.json
@@ -32,6 +32,7 @@
       "type": "css"
     },
     "filter": {
+      "cssExampleSrc": "./live-examples/css-examples/filter-effects/filter.css",
       "exampleCode": "./live-examples/css-examples/filter-effects/filter.html",
       "fileName": "filter.html",
       "title": "CSS Demo: filter",

--- a/live-examples/css-examples/logical-properties/inset-block-end.css
+++ b/live-examples/css-examples/logical-properties/inset-block-end.css
@@ -9,6 +9,7 @@
 
 #abspos {
   background-color: yellow;
+  color: black;
   border: 3px solid red;
   position: absolute;
   inset-block-end: 20px;

--- a/live-examples/css-examples/logical-properties/inset-block-start.css
+++ b/live-examples/css-examples/logical-properties/inset-block-start.css
@@ -9,6 +9,7 @@
 
 #abspos {
   background-color: yellow;
+  color: black;
   border: 3px solid red;
   position: absolute;
   inset-block-start: 50px;

--- a/live-examples/css-examples/logical-properties/inset-inline-end.css
+++ b/live-examples/css-examples/logical-properties/inset-inline-end.css
@@ -9,6 +9,7 @@
 
 #abspos {
   background-color: yellow;
+  color: black;
   border: 3px solid red;
   position: absolute;
   inset-inline-end: 50px;

--- a/live-examples/css-examples/logical-properties/inset-inline-start.css
+++ b/live-examples/css-examples/logical-properties/inset-inline-start.css
@@ -9,6 +9,7 @@
 
 #abspos {
   background-color: yellow;
+  color: black;
   border: 3px solid red;
   position: absolute;
   inset-inline-start: 50px;


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

For the demonstration elements with `background-color:` set and text content, also set explicit foreground color.

### Motivation

Prevents contrast issues (unreadable text inside the element), with the dark skin.

### Additional details

I noticed at https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block-start#try_it that, with the dark site palette enabled, the yellow absolutely-positioned element appeared to contain no text — because it was rendered in white over yellow, due to the element's background-color being set while leaving the default text color.

I'd be pretty surprised if this is the only instance of color clashes due to incomplete styles, across the examples — it'd probably make sense to tackle them all at once, or at least as many as possible. So, feel free to consider this a WIP / starting-point PR. I'm willing to scan (ar at least grep) through the rest of the demo CSS files to look for more styles that need to be fixed in a similar manner, if it'd be a useful project to undertake.