### PR TITLE
feat(css): add auto examples for text-emphasis-position

### DIFF
--- a/live-examples/css-examples/text-decoration/text-emphasis-position.html
+++ b/live-examples/css-examples/text-decoration/text-emphasis-position.html
@@ -1,5 +1,12 @@
 <section id="example-choice-list" class="example-choice-list" data-property="text-emphasis-position">
   <div class="example-choice" initial-choice="true">
+    <pre><code class="language-css">text-emphasis-position: auto;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
     <pre><code class="language-css">text-emphasis-position: over right;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
@@ -8,6 +15,14 @@
 
   <div class="example-choice">
     <pre><code class="language-css">text-emphasis-position: under right;</code></pre>
+    <button type="button" class="copy hidden" aria-hidden="true">
+      <span class="visually-hidden">Copy to Clipboard</span>
+    </button>
+  </div>
+
+  <div class="example-choice">
+    <pre><code class="language-css">text-emphasis-position: auto;
+writing-mode: vertical-rl;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>


### PR DESCRIPTION
### Description

Added examples for `auto` value for `text-emphasis-position` for horizontal and vertical text

### Motivation

- Working on [#36125](https://github.com/mdn/content/issues/36125)

### Additional details

- [RESOLVED: add `auto` value for `text-emphasis-position`](https://github.com/w3c/csswg-drafts/issues/1198#issuecomment-2358986319)

### Related issues and pull requests

- [Data PR](https://github.com/mdn/data/pull/772)
- [BCD PR](https://github.com/mdn/browser-compat-data/pull/24670)
