### PR TITLE
chore(column-fill): remove balance-all example

### DIFF
--- a/live-examples/css-examples/multi-column-layout/column-fill.html
+++ b/live-examples/css-examples/multi-column-layout/column-fill.html
@@ -12,12 +12,6 @@
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
-  <div class="example-choice">
-    <pre><code class="language-css">column-fill: balance-all;</code></pre>
-    <button type="button" class="copy hidden" aria-hidden="true">
-      <span class="visually-hidden">Copy to Clipboard</span>
-    </button>
-  </div>
 </section>
 
 <div id="output" class="output large hidden">


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Removes an example for a feature that has not been implemented by any browser.

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

See:
- https://github.com/mdn/content/pull/34561
- https://github.com/mdn/browser-compat-data/pull/23578