### PR TITLE
Disambiguate `super` from `this` inheritance

### DIFF
--- a/live-examples/js-examples/expressions/expressions-super.js
+++ b/live-examples/js-examples/expressions/expressions-super.js
@@ -14,6 +14,7 @@ class FooBar extends Foo {
     this.index = index;
   }
 
+  // Does not get called
   getNameSeparator() {
     return '/';
   }

--- a/live-examples/js-examples/expressions/expressions-super.js
+++ b/live-examples/js-examples/expressions/expressions-super.js
@@ -14,6 +14,10 @@ class FooBar extends Foo {
     this.index = index;
   }
 
+  getNameSeparator() {
+    return '/';
+  }
+
   getFullName() {
     return this.name + super.getNameSeparator() + this.index;
   }


### PR DESCRIPTION
### Description

If the child class inherits a function, calling it from `super` behaves identically to calling it from `this`. But by overriding the inherited definition, the example can now demonstrate that `super` bypasses the child’s definition.

### Motivation

Understanding `super` is easier when contrasted with `this` than when defined in (comparative) isolation.