### PR TITLE
fix: correct typo for text-transform value

### DIFF
--- a/live-examples/css-examples/text/text-transform.html
+++ b/live-examples/css-examples/text/text-transform.html
@@ -42,7 +42,7 @@
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">text-transform: math-auo;</code></pre>
+    <pre><code class="language-css">text-transform: math-auto;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Simply fixes a typo of the value provided to `text-transform` in an example.

```diff
- math-auo
+ math-auto
```

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

This should make the example on https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform display the correct value. 🤓 
