### PR TITLE
correct MIME type 

### DIFF
--- a/live-examples/html-examples/embedded-content/embed.html
+++ b/live-examples/html-examples/embedded-content/embed.html
@@ -1,1 +1,1 @@
-<embed type="video/webm" src="/media/cc0-videos/flower.mp4" width="250" height="200" />
+<embed type="video/mp4" src="/media/cc0-videos/flower.mp4" width="250" height="200" />


### PR DESCRIPTION
### Description

Changed `type="video/webm"` to  `type="video/mp4"` for `src="/media/cc0-videos/flower.mp4"`

### Related issues and pull requests

Fixes #2860

