### PR TITLE
fix: Fix JS for CSS transform-origin example (#2875)

### DIFF
--- a/live-examples/css-examples/transforms/transform-origin.html
+++ b/live-examples/css-examples/transforms/transform-origin.html
@@ -1,27 +1,28 @@
 <section id="example-choice-list" class="example-choice-list large" data-property="transform-origin">
-  <div class="example-choice">
-    <pre><code class="language-css" data-animation="rotate">transform-origin: center;</code></pre>
+  <div class="example-choice" data-animation="rotate">
+    <pre><code class="language-css">transform-origin: center;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
-  <div class="example-choice">
-    <pre><code class="language-css" data-animation="rotate">transform-origin: top left;</code></pre>
+  <div class="example-choice" data-animation="rotate">
+    <pre><code class="language-css">transform-origin: top left;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
-  <div class="example-choice">
-    <pre><code class="language-css" data-animation="rotate">transform-origin: 50px 50px;</code></pre>
+  <div class="example-choice" data-animation="rotate">
+    <pre><code class="language-css">transform-origin: 50px 50px;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
-  <div class="example-choice">
-    <pre><code class="language-css" data-animation="rotate3d">transform-origin: bottom right 60px;</code></pre>
+  <div class="example-choice" data-animation="rotate3d">
+    <pre><code class="language-css">/* 3D rotation with z-axis origin */
+transform-origin: bottom right 60px;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>

--- a/live-examples/css-examples/transforms/transform-origin.js
+++ b/live-examples/css-examples/transforms/transform-origin.js
@@ -2,7 +2,7 @@
 
 window.addEventListener('load', () => {
   function update() {
-    const selected = document.querySelector('.selected code');
+    const selected = document.querySelector('.selected');
 
     /* Restart the animation
            https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Animations/Tips */


### PR DESCRIPTION
### Description

From linked issue:

> The examples in the interactive example at https://developer.mozilla.org/en-US/docs/Web/CSS/transform-origin are supposed to rotate, but they don't any more.

### Motivation

Fix examples.

### Additional details

Also added clarifying comment to 4th example, which uses a different transform.

### Related issues and pull requests

Fixes #2875.