### PR TITLE
Made JS Expected output comments consistent with actual output

### DIFF
--- a/live-examples/js-examples/bigint/bigint-tolocalestring.js
+++ b/live-examples/js-examples/bigint/bigint-tolocalestring.js
@@ -8,4 +8,4 @@ console.log(bigint.toLocaleString('de-DE'));
 console.log(
   bigint.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' }),
 );
-// Expected output: "123.456.789.123.456.789,00 €"
+// Expected output: "123.456.789.123.456.789,00 €"

--- a/live-examples/js-examples/classes/classes-static.js
+++ b/live-examples/js-examples/classes/classes-static.js
@@ -7,6 +7,7 @@ class ClassWithStaticMethod {
     console.log('Class static initialization block called');
   }
 }
+// Expected output: "Class static initialization block called"
 
 console.log(ClassWithStaticMethod.staticProperty);
 // Expected output: "someValue"

--- a/live-examples/js-examples/globalprops/globalprops-isfinite.js
+++ b/live-examples/js-examples/globalprops/globalprops-isfinite.js
@@ -6,7 +6,7 @@ function div(x) {
 }
 
 console.log(div(0));
-// Expected output: "Number is Infinity!""
+// Expected output: "Number is Infinity!"
 
 console.log(div(1));
 // Expected output: "Number is NOT Infinity."

--- a/live-examples/js-examples/intl/intl-datetimeformat-prototype-formattoparts.js
+++ b/live-examples/js-examples/intl/intl-datetimeformat-prototype-formattoparts.js
@@ -11,4 +11,4 @@ const parts = dateTimeFormat.formatToParts(date);
 const partValues = parts.map((p) => p.value);
 
 console.log(partValues);
-// Expected output: "["Friday", ", ", "June", " ", "1", ", ", "2012"]"
+// Expected output: Array ["Friday", ", ", "June", " ", "1", ", ", "2012"]

--- a/live-examples/js-examples/intl/intl-getcanonicallocales.js
+++ b/live-examples/js-examples/intl/intl-getcanonicallocales.js
@@ -8,6 +8,6 @@ try {
   Intl.getCanonicalLocales('EN_US');
 } catch (err) {
   console.log(err.toString());
-  // Expected output (Firefox/Safari): RangeError: invalid language tag: "EN_US"
-  // Expected output (Chrome): RangeError: Incorrect locale information provided
+  // Expected output (Firefox/Safari): "RangeError: invalid language tag: "EN_US""
+  // Expected output (Chrome): "RangeError: Incorrect locale information provided"
 }

--- a/live-examples/js-examples/intl/intl-listformat-prototype-formattoparts.js
+++ b/live-examples/js-examples/intl/intl-listformat-prototype-formattoparts.js
@@ -14,6 +14,6 @@ const partValuesEn = formatterEn.formatToParts(vehicles).map((p) => p.value);
 const partValuesFr = formatterFr.formatToParts(vehicles).map((p) => p.value);
 
 console.log(partValuesEn);
-// Expected output: "["Motorcycle", ", ", "Bus", ", and ", "Car"]"
+// Expected output: Array ["Motorcycle", ", ", "Bus", ", and ", "Car"]
 console.log(partValuesFr);
-// Expected output: "["Motorcycle", ", ", "Bus", " et ", "Car"]"
+// Expected output: Array ["Motorcycle", ", ", "Bus", " et ", "Car"]

--- a/live-examples/js-examples/intl/intl-listformat-prototype-resolvedoptions.js
+++ b/live-examples/js-examples/intl/intl-listformat-prototype-resolvedoptions.js
@@ -2,8 +2,7 @@ const deListFormatter1 = new Intl.ListFormat('de-DE', { type: 'disjunction' });
 const options1 = deListFormatter1.resolvedOptions();
 
 console.log(options1.locale);
-// Expected output (Firefox / Safari): "de-DE"
-// Expected output (Chrome): "de"
+// Expected output: "de-DE"
 
 console.log(options1.style);
 // Expected output: "long"

--- a/live-examples/js-examples/intl/intl-numberformat-prototype-format.js
+++ b/live-examples/js-examples/intl/intl-numberformat-prototype-format.js
@@ -4,7 +4,7 @@ const options1 = { style: 'currency', currency: 'RUB' };
 const numberFormat1 = new Intl.NumberFormat('ru-RU', options1);
 
 console.log(numberFormat1.format(amount));
-// Expected output: "654 321,99 ₽"
+// Expected output: "654 321,99 ₽"
 
 const options2 = { style: 'currency', currency: 'USD' };
 const numberFormat2 = new Intl.NumberFormat('en-US', options2);

--- a/live-examples/js-examples/intl/intl-numberformat-prototype-formattoparts.js
+++ b/live-examples/js-examples/intl/intl-numberformat-prototype-formattoparts.js
@@ -6,4 +6,4 @@ const parts = numberFormat.formatToParts(amount);
 const partValues = parts.map((p) => p.value);
 
 console.log(partValues);
-// Expected output: "["$", "654", ",", "321", ".", "99"]"
+// Expected output: Array ["$", "654", ",", "321", ".", "99"]

--- a/live-examples/js-examples/intl/intl-numberformat-prototype-resolvedoptions.js
+++ b/live-examples/js-examples/intl/intl-numberformat-prototype-resolvedoptions.js
@@ -2,8 +2,7 @@ const numberFormat1 = new Intl.NumberFormat('de-DE');
 const options1 = numberFormat1.resolvedOptions();
 
 console.log(options1.locale);
-// Expected output (Firefox / Safari): "de-DE"
-// Expected output (Chrome): "de"
+// Expected output: "de-DE"
 
 console.log(options1.numberingSystem);
 // Expected output: "latn"

--- a/live-examples/js-examples/intl/intl-numberformat.js
+++ b/live-examples/js-examples/intl/intl-numberformat.js
@@ -5,7 +5,7 @@ console.log(
     number,
   ),
 );
-// Expected output: "123.456,79 €"
+// Expected output: "123.456,79 €"
 
 // The Japanese yen doesn't use a minor unit
 console.log(

--- a/live-examples/js-examples/intl/intl-segmenter.js
+++ b/live-examples/js-examples/intl/intl-segmenter.js
@@ -4,7 +4,7 @@ const string1 = 'Que ma joie demeure';
 const iterator1 = segmenterFr.segment(string1)[Symbol.iterator]();
 
 console.log(iterator1.next().value.segment);
-// Expected output: 'Que'
+// Expected output: "Que"
 
 console.log(iterator1.next().value.segment);
-// Expected output: ' '
+// Expected output: " "

--- a/live-examples/js-examples/intl/intl-supportedvaluesof.js
+++ b/live-examples/js-examples/intl/intl-supportedvaluesof.js
@@ -10,5 +10,5 @@ try {
   Intl.supportedValuesOf('someInvalidKey');
 } catch (err) {
   console.log(err.toString());
-  // Expected output: RangeError: invalid key: "someInvalidKey"
+  // Expected output: "RangeError: Invalid key : someInvalidKey"
 }

--- a/live-examples/js-examples/json/json-stringify.js
+++ b/live-examples/js-examples/json/json-stringify.js
@@ -1,13 +1,13 @@
 console.log(JSON.stringify({ x: 5, y: 6 }));
-// Expected output: '{"x":5,"y":6}'
+// Expected output: "{"x":5,"y":6}"
 
 console.log(
   JSON.stringify([new Number(3), new String('false'), new Boolean(false)]),
 );
-// Expected output: '[3,"false",false]'
+// Expected output: "[3,"false",false]"
 
 console.log(JSON.stringify({ x: [10, undefined, function () {}, Symbol('')] }));
-// Expected output: '{"x":[10,null,null,null]}'
+// Expected output: "{"x":[10,null,null,null]}"
 
 console.log(JSON.stringify(new Date(2006, 0, 2, 15, 4, 5)));
-// Expected output: '"2006-01-02T15:04:05.000Z"'
+// Expected output: ""2006-01-02T15:04:05.000Z""

--- a/live-examples/js-examples/number/number-tolocalestring.js
+++ b/live-examples/js-examples/number/number-tolocalestring.js
@@ -9,4 +9,4 @@ console.log(eArabic('123456.789'));
 // Expected output: "123456.789"
 
 console.log(eArabic(NaN));
-// Expected output: "ليس رقم"
+// Expected output: "ليس رقم"

--- a/live-examples/js-examples/proxyhandler/proxyhandler-ownkeys.js
+++ b/live-examples/js-examples/proxyhandler/proxyhandler-ownkeys.js
@@ -14,6 +14,6 @@ const proxy1 = new Proxy(monster1, handler1);
 
 for (const key of Object.keys(proxy1)) {
   console.log(key);
-  // Expected output: "_age"
-  // Expected output: "eyeCount"
 }
+// Expected output: "_age"
+// Expected output: "eyeCount"

--- a/live-examples/js-examples/regexp/regexp-character-classes.js
+++ b/live-examples/js-examples/regexp/regexp-character-classes.js
@@ -1,9 +1,9 @@
 const chessStory = 'He played the King in a8 and she moved her Queen in c2.';
 const regexpCoordinates = /\w\d/g;
 console.log(chessStory.match(regexpCoordinates));
-// Expected output: Array [ 'a8', 'c2']
+// Expected output: Array ["a8", "c2"]
 
 const moods = 'happy 🙂, confused 😕, sad 😢';
 const regexpEmoticons = /[\u{1F600}-\u{1F64F}]/gu;
 console.log(moods.match(regexpEmoticons));
-// Expected output: Array ['🙂', '😕', '😢']
+// Expected output: Array ["🙂", "😕", "😢"]

--- a/live-examples/js-examples/regexp/regexp-prototype-exec.js
+++ b/live-examples/js-examples/regexp/regexp-prototype-exec.js
@@ -4,6 +4,6 @@ let array1;
 
 while ((array1 = regex1.exec(str1)) !== null) {
   console.log(`Found ${array1[0]}. Next starts at ${regex1.lastIndex}.`);
-  // Expected output: "Found foo. Next starts at 9."
-  // Expected output: "Found foo. Next starts at 19."
 }
+// Expected output: "Found foo. Next starts at 9."
+// Expected output: "Found foo. Next starts at 19."

--- a/live-examples/js-examples/set/set-prototype-add.js
+++ b/live-examples/js-examples/set/set-prototype-add.js
@@ -6,6 +6,6 @@ set1.add(13);
 
 for (const item of set1) {
   console.log(item);
-  // Expected output: 42
-  // Expected output: 13
 }
+// Expected output: 42
+// Expected output: 13

--- a/live-examples/js-examples/set/set-prototype-entries.js
+++ b/live-examples/js-examples/set/set-prototype-entries.js
@@ -6,6 +6,6 @@ const iterator1 = set1.entries();
 
 for (const entry of iterator1) {
   console.log(entry);
-  // Expected output: Array [42, 42]
-  // Expected output: Array ["forty two", "forty two"]
 }
+// Expected output: Array [42, 42]
+// Expected output: Array ["forty two", "forty two"]

--- a/live-examples/js-examples/string/string-fromcodepoint.js
+++ b/live-examples/js-examples/string/string-fromcodepoint.js
@@ -1,2 +1,2 @@
 console.log(String.fromCodePoint(9731, 9733, 9842, 0x2f804));
-// Expected output: "☃★♲你"
+// Expected output: "☃★♲你"

--- a/live-examples/js-examples/string/string-lastindexof.js
+++ b/live-examples/js-examples/string/string-lastindexof.js
@@ -3,6 +3,6 @@ const paragraph = "I think Ruth's dog is cuter than your dog!";
 const searchTerm = 'dog';
 
 console.log(
-  `Index of the last ${searchTerm} is ${paragraph.lastIndexOf(searchTerm)}`,
+  `Index of the last "${searchTerm}" is ${paragraph.lastIndexOf(searchTerm)}`,
 );
 // Expected output: "Index of the last "dog" is 38"

--- a/live-examples/js-examples/string/string-tolocalelowercase.js
+++ b/live-examples/js-examples/string/string-tolocalelowercase.js
@@ -1,7 +1,7 @@
 const dotted = 'İstanbul';
 
 console.log(`EN-US: ${dotted.toLocaleLowerCase('en-US')}`);
-// Expected output: "i̇stanbul"
+// Expected output: "EN-US: i̇stanbul"
 
 console.log(`TR: ${dotted.toLocaleLowerCase('tr')}`);
-// Expected output: "istanbul"
+// Expected output: "TR: istanbul"

--- a/live-examples/js-examples/string/string-trimend.js
+++ b/live-examples/js-examples/string/string-trimend.js
@@ -1,7 +1,7 @@
 const greeting = '   Hello world!   ';
 
 console.log(greeting);
-// Expected output: "   Hello world!   ";
+// Expected output: "   Hello world!   "
 
 console.log(greeting.trimEnd());
-// Expected output: "   Hello world!";
+// Expected output: "   Hello world!"

--- a/live-examples/js-examples/string/string-trimstart.js
+++ b/live-examples/js-examples/string/string-trimstart.js
@@ -1,7 +1,7 @@
 const greeting = '   Hello world!   ';
 
 console.log(greeting);
-// Expected output: "   Hello world!   ";
+// Expected output: "   Hello world!   "
 
 console.log(greeting.trimStart());
-// Expected output: "Hello world!   ";
+// Expected output: "Hello world!   "

--- a/live-examples/js-examples/symbol/symbol-prototype-tostring.js
+++ b/live-examples/js-examples/symbol/symbol-prototype-tostring.js
@@ -2,7 +2,7 @@ console.log(Symbol('desc').toString());
 // Expected output: "Symbol(desc)"
 
 console.log(Symbol.iterator.toString());
-// Expected output: "Symbol(Symbol.iterator)
+// Expected output: "Symbol(Symbol.iterator)"
 
 console.log(Symbol.for('foo').toString());
 // Expected output: "Symbol(foo)"

--- a/live-examples/js-examples/typedarray/typedarray-findlast.js
+++ b/live-examples/js-examples/typedarray/typedarray-findlast.js
@@ -4,5 +4,5 @@ function isNegative(element /*, index, array */) {
 
 const int8 = new Int8Array([10, 0, -10, 20, -30, 40, 50]);
 
-console.log(int8.find(isNegative));
+console.log(int8.findLast(isNegative));
 // Expected output: -30


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Fix a few `// Expected output: ...` comments in JS examples. In some cases these comments weren't consistent with what JS engines output, in other cases, the formatting was inconsistent with how the interactive example console formats things.

Note that for currency formatting (e.g. bigint-tolocalestring.js), JS engines produce a non-breaking space U+00A0 instead of an ASCII space U+0032.