### PR TITLE
Update array-copywithin.js

### DIFF
--- a/live-examples/js-examples/array/array-copywithin.js
+++ b/live-examples/js-examples/array/array-copywithin.js
@@ -6,4 +6,4 @@ console.log(array1.copyWithin(0, 3, 4));
 
 // Copy to index 1 all elements from index 3 to the end
 console.log(array1.copyWithin(1, 3));
-// Expected output: Array ["d", "d", "e", "d", "e"]
+// Expected output: Array ["a", "d", "e", "d", "e"]


### PR DESCRIPTION
The index of 0 will not change.

### Description

The expected output is actually `['a', 'd', 'e', 'd', 'e']`, not `['d', 'd', 'e', 'd', 'e']`. The `copyWithin` method copies elements within the same array, starting from index 3 (`'d'` and `'e'`), and pastes them at index 1. It does not overwrite the element at index 0 (`'a'`), which is why the first element remains `'a'`.
