### PR TITLE
Change BrE spellings to AmE 

### DIFF
--- a/live-examples/js-examples/globalprops/globalprops-nan.js
+++ b/live-examples/js-examples/globalprops/globalprops-nan.js
@@ -1,12 +1,12 @@
-function sanitise(x) {
+function sanitize(x) {
   if (isNaN(x)) {
     return NaN;
   }
   return x;
 }
 
-console.log(sanitise('1'));
+console.log(sanitize('1'));
 // Expected output: "1"
 
-console.log(sanitise('NotANumber'));
+console.log(sanitize('NotANumber'));
 // Expected output: NaN


### PR DESCRIPTION
#**Fixes #2881: Changed British English to American English in [globalprops-nan.js](live-examples/js-examples/globalprops/globalprops-nan.js)**

Updated British English spellings to American English in the following lines:

- Line 1
- Line 8
- Line 11

File modified: [globalprops-nan.js](live-examples/js-examples/globalprops/globalprops-nan.js)

