### PR TITLE
chore: Add warning for new PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,19 +1,7 @@
-<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->
+# This repository is not accepting pull requests
 
-### Description
-
-<!-- ✍️ Summarize your changes in one or two sentences -->
-
-### Motivation
-
-<!-- ❓ Why are you making these changes and how do they help? -->
-
-### Additional details
-
-<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->
-
-### Related issues and pull requests
-
-<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
-<!-- 👉 Highlight related pull requests using "Relates to #123" -->
-<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
+> [!WARNING]
+> This repository is in the process of being **archived**!
+>
+> New pull requests will be closed, so do not work on issues or tasks relating to this repository to avoid lost time and work.
+> For more information, see <https://github.com/orgs/mdn/discussions/782>.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # interactive-examples
 
+> [!WARNING]
+> This repository is in the process of being **archived**!
+>
+> New pull requests will be closed, so do not work on issues or tasks relating to this repository to avoid lost time and work.
+> For more information, see <https://github.com/orgs/mdn/discussions/782>.
+
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 
 Home of the [MDN](https://developer.mozilla.org/) interactive code examples.


### PR DESCRIPTION
There is migration work in progress to inline the example code into content. We should put up a warning to avoid that anyone loses time and work due to rejected / closed PRs.