### PR TITLE
fix(css): clip-path should use proper coords

### DIFF
--- a/live-examples/css-examples/masking/clip-path.html
+++ b/live-examples/css-examples/masking/clip-path.html
@@ -28,7 +28,7 @@
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">clip-path: rect(5px 5px 160px 145px round 20%);</code></pre>
+    <pre><code class="language-css">clip-path: rect(5px 145px 160px 5px round 20%);</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>


### PR DESCRIPTION
This is probably not going to be deployed via npm / GitHub release, but the source should be updated before https://github.com/orgs/mdn/discussions/782

See https://bugzilla.mozilla.org/show_bug.cgi?id=1949982#c7