### PR TITLE
fix(workflows): disable cache in privileged workflows

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: npm
 
       - name: Install all npm packages
         run: npm ci

--- a/.github/workflows/stage-deploy.yml
+++ b/.github/workflows/stage-deploy.yml
@@ -35,7 +35,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: npm
 
       - name: Install all npm packages
         run: npm ci


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Disables the cache (used by `actions/setup-node`) in privileged workflows.

#### Test results and supporting details

This limits the impact of less-privileged workflows that may be vulnerable to code injection.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
